### PR TITLE
Adopt GitHub issue Type policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,13 @@ When contributing to this repository as the coding agent:
 11. Treat GitHub issue hygiene as a required part of the development workflow:
    - before starting a new feature, bug, docs push, or other non-trivial task, ensure `gh` is
      available in the active shell and authenticated as the intended active GitHub user;
+   - use GitHub built-in issue `Type` as the canonical work-kind field for FEMIC issues:
+     `Bug`, `Feature`, or `Task`;
+   - do not mirror issue `Type` into duplicate work-kind labels such as `bug`, `enhancement`,
+     `feature`, or `task`;
+   - use labels only for orthogonal metadata that `Type` does not express, such as platform,
+     subsystem, or workflow tags (for example `documentation`, `windows`, `k3z`, `tsa29`,
+     `patchworks`, `data`, `good first issue`, `help wanted`);
    - use GitHub to find an existing relevant open issue first; if none exists, create a new issue
      (`feature`, `bug`, `docs`, or similar as appropriate) before substantial implementation;
    - link the governing GitHub issue in `ROADMAP.md` when the task becomes active so roadmap notes

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6659,3 +6659,46 @@
   clearer intake-policy document for both human developers and the coding
   agent, including queue purpose, usage rules, removal rules, and basic queue
   hygiene expectations.
+
+## 2026-03-26 - Phase 39 GitHub Issue Type Policy Kickoff
+
+- Opened GitHub issue `#28`:
+  - `Adopt GitHub issue Type as FEMIC's canonical work-kind classifier`
+- Created the working branch:
+  - `feature/github-issue-type-policy`
+- Confirmed the live FEMIC GitHub issue-type surface already provides the three
+  built-in work kinds the new policy expects:
+  - `Task`
+  - `Bug`
+  - `Feature`
+- Added Phase 39 rollout tasks to `ROADMAP.md` covering maintainer-doc updates,
+  label normalization, open-issue backfill, and final validation/closeout.
+
+## 2026-03-26 - Phase 39 GitHub Issue Type Policy Rollout
+
+- Updated `AGENTS.md` so FEMIC issue hygiene now explicitly requires:
+  - built-in GitHub issue `Type` as the canonical work-kind field;
+  - no duplicate work-kind labels such as `bug`, `enhancement`, `feature`, or `task`;
+  - labels reserved for orthogonal metadata only.
+- Added the orthogonal FEMIC labels needed for the lightweight taxonomy:
+  - `windows`
+  - `k3z`
+  - `tsa29`
+  - `patchworks`
+  - `data`
+- Backfilled built-in issue `Type` on the open issue set:
+  - `#11 -> Bug`
+  - `#10 -> Task`
+  - `#8 -> Task`
+  - `#27 -> Feature`
+  - `#28 -> Task`
+- Backfilled orthogonal labels on the open issue set:
+  - `#11 -> windows, data`
+  - `#10 -> tsa29`
+  - `#8 -> documentation, windows, patchworks`
+  - `#27 -> k3z, patchworks`
+- Deleted the duplicate work-kind labels `bug` and `enhancement` from the FEMIC
+  repo after confirming the open issue set no longer depended on them.
+- Removed the harvested-stem QMD product-account idea from
+  `planning/incoming_ideas.md` because it has now been promoted into GitHub as
+  issue `#27`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6955,6 +6955,31 @@ run_id=k3z_post_tipsy_true_tipsy_20260321_d, rebuilt external/femic-k3z-instance
       - the regenerated `forestmodel_pct_light.xml`, `forestmodel_pct_moderate.xml`, and `forestmodel_pct_heavy.xml` all carry that attribute;
       - the rebuilt `tracks_pct_light`, `tracks_pct_moderate`, and `tracks_pct_heavy` surfaces now show `PCT ... ADJUST=R`.
 
+## Phase 39: Adopt GitHub Issue Type as FEMIC's Canonical Work-Kind Classifier
+- [x] P39.1 Publish the FEMIC issue metadata policy in repo maintainer docs
+  - [x] P39.1a Record that GitHub built-in `Type` is the canonical work-kind field using `Bug`, `Feature`, and `Task`.
+  - [x] P39.1b Record the small orthogonal label set that remains valid after the transition.
+- [x] P39.2 Normalize the live FEMIC GitHub label surface
+  - [x] P39.2a Add the orthogonal labels needed for current workflow coverage: `windows`, `k3z`, `tsa29`, `patchworks`, and `data`.
+  - [x] P39.2b Retire duplicate work-kind labels from active use, specifically `bug` and `enhancement`, once the open issue set has been backfilled with `Type`.
+- [x] P39.3 Backfill `Type` and orthogonal labels onto the open issue set
+  - [x] P39.3a Set built-in `Type` on the open FEMIC issue set, starting with `#11 -> Bug`, `#10 -> Task`, `#8 -> Task`, `#27 -> Feature`, and the governing rollout tracker `#28 -> Task`.
+  - [x] P39.3b Apply orthogonal labels only where they add domain or platform information, e.g. `windows`, `k3z`, `tsa29`, `patchworks`, `data`, and existing `documentation`.
+- [x] P39.4 Validate the new issue-metadata workflow and close out the tracker
+  - [x] P39.4a Confirm the repo can now answer `type:` and label-based queries cleanly without duplicate work-kind labels.
+  - [x] P39.4b Update `CHANGE_LOG.md` and GitHub issue `#28` with the completed rollout details and closeout rationale.
+  - Notes:
+    - Governing tracker:
+      - GitHub issue #28
+    - Confirmed live issue-type surface:
+      - `Task`
+      - `Bug`
+      - `Feature`
+    - Final rollout result:
+      - the open issue set now uses built-in `Type` for work kind;
+      - orthogonal labels are limited to domain/platform/workflow metadata;
+      - duplicate work-kind labels `bug` and `enhancement` have been deleted from the repo.
+
 
 
 

--- a/planning/incoming_ideas.md
+++ b/planning/incoming_ideas.md
@@ -54,5 +54,3 @@ Good queue hygiene
 - Prefer fewer, clearer entries over long duplicated lists of similar ideas.
 
 ---
-
-[feature] Extend QMD logic in the `ctfert_*` variant family of the K3Z instance to include `product` type Patchworks accounts (i.e., mean diameter of harvested stems, by AU and treatment type). Once that is done, port the QMD logic to all other variants in the K3Z instance.


### PR DESCRIPTION
## Summary
- adopt GitHub built-in issue Type as FEMIC's canonical work-kind classifier
- document the policy in repo maintainer notes and planning files
- record the live rollout that backfilled open issues and removed duplicate kind labels

## Testing
- not run (GitHub-admin and repo-doc policy update only)