### PR TITLE
fix: rejoin source-layer tokens split across PDF table-cell line wraps

### DIFF
--- a/src/femic/tsr_catalog/extract.py
+++ b/src/femic/tsr_catalog/extract.py
@@ -19,6 +19,7 @@ from femic.tsr_catalog.cache import (
 )
 
 
+_INCOMPLETE_TOKEN_TAIL_RE = re.compile(r"[A-Z][A-Z0-9_]*_(?:[A-Z0-9_]*)?$")
 _SOURCE_LAYER_OBJECT_RE = re.compile(r"\b[A-Z][A-Z0-9_]+(?:\.[A-Z0-9_]+)+\b")
 _SOURCE_LAYER_TOKEN_RE = re.compile(
     r"\b(?:SITE_PROD_BC|CONSOLIDATED_CUTBLOCKS(?:_\d{4})?|[A-Z][A-Z0-9]+(?:_[A-Z0-9]+){2,})\b"
@@ -245,6 +246,26 @@ def _looks_like_source_layer_token(token: str) -> bool:
     return "." in token
 
 
+def _rewrap_split_tokens(lines: list[str]) -> list[str]:
+    """Join consecutive lines where a source-layer token is split across the wrap."""
+    if not lines:
+        return lines
+    result: list[str] = [lines[0]]
+    for line in lines[1:]:
+        prev = result[-1]
+        prev_tail = prev.rstrip()
+        line_head = line.lstrip()
+        should_join = False
+        # Previous line ends with trailing underscore suffix (e.g. "L_MULE_DEER_")
+        if prev_tail and prev_tail[-1] == "_" and _INCOMPLETE_TOKEN_TAIL_RE.search(prev_tail):
+            should_join = True
+        if should_join:
+            result[-1] = f"{prev_tail}{line}"
+        else:
+            result.append(line)
+    return result
+
+
 def _iter_source_layer_facts(
     document: TsrInventoryDocument,
     *,
@@ -254,7 +275,7 @@ def _iter_source_layer_facts(
 ) -> tuple[TsrCandidateFact, ...]:
     facts: list[TsrCandidateFact] = []
     seen: set[str] = set()
-    for raw_line in page_text.splitlines():
+    for raw_line in _rewrap_split_tokens(page_text.splitlines()):
         line = _trim_snippet(raw_line)
         if not line:
             continue

--- a/tests/test_tsr_extract.py
+++ b/tests/test_tsr_extract.py
@@ -130,3 +130,49 @@ def test_extract_tsr_candidate_facts_reports_missing_cached_pdfs(
     assert len(result.facts) == 0
     assert len(result.failures) == 1
     assert result.failures[0].error == "cached_pdf_missing"
+
+
+def test_wrapped_source_layer_tokens_are_rejoined(tmp_path: Path) -> None:
+    inventory_path = _write_inventory(tmp_path)
+    corpus_root = tmp_path / ".femic" / "tsr" / "corpus"
+    cached_pdf = (
+        corpus_root
+        / "tsa"
+        / "tsa_29"
+        / "TSR_2024"
+        / "Data_Package_2024"
+        / "29ts_dpkg_2024.pdf"
+    )
+    cached_pdf.parent.mkdir(parents=True, exist_ok=True)
+    cached_pdf.write_bytes(b"fake-pdf")
+    output_path = tmp_path / "metadata" / "tsr" / "tsa_candidate_facts.json"
+
+    def _fake_extract_pages(path: Path) -> tuple[str, ...]:
+        return (
+            "\n".join(
+                [
+                    "Data sources used:",
+                    "REG_LAND_AND_NATURAL_RESOURCE.L_MULE_DEER_",
+                    "WR_CAR_POLY",
+                    "WHSE_WILDLIFE_MANAGEMENT.WCP_UNGULATE_",
+                    "WINTER_RAN",
+                    "WHSE_FOREST_VEGETATION.F_OWN 2024",
+                ]
+            ),
+        )
+
+    result = tsr_catalog.extract_tsr_candidate_facts(
+        documents_path=inventory_path,
+        corpus_root=corpus_root,
+        output_path=output_path,
+        tsa_filters=("29",),
+        source_root=tmp_path,
+        extract_pdf_pages_fn=_fake_extract_pages,
+    )
+
+    values = {fact.value for fact in result.facts}
+    assert "REG_LAND_AND_NATURAL_RESOURCE.L_MULE_DEER_WR_CAR_POLY" in values
+    assert "WHSE_WILDLIFE_MANAGEMENT.WCP_UNGULATE_WINTER_RAN" in values
+    # Truncated fragments should NOT appear
+    assert "REG_LAND_AND_NATURAL_RESOURCE.L_MULE_DEER_" not in values
+    assert "WHSE_WILDLIFE_MANAGEMENT.WCP_UNGULATE_" not in values


### PR DESCRIPTION
Closes #117.

When TSR PDF table cells wrap BCGW object names across lines, the extractor emits truncated tokens like `REG_LAND_AND_NATURAL_RESOURCE.L_MULE_DEER_` instead of the full `REG_LAND_AND_NATURAL_RESOURCE.L_MULE_DEER_WR_CAR_POLY`.

`_rewrap_split_tokens()` detects lines ending with an incomplete uppercase underscored suffix and concatenates them with the next line before regex extraction runs. Conservative: only joins when the previous line tail matches a source-layer token pattern ending in `_`.

Test covers both examples from the issue (MULE_DEER and UNGULATE_WINTER_RAN).