### PR TITLE
Clean up GLB scratch boundary export warnings

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14360,3 +14360,24 @@
     - official AFLB/LHLB restart checkpoints;
     - dashboard rebuild from the locked chain; and
     - restart-boundary polygon normalization.
+- Started `#147` on branch `feature/issue-147-glb-boundary-warning-cleanup`.
+  - Goal:
+    - remove the remaining scratch boundary export warnings in `prep glb-build` without changing the GLB clip result or the current FileGDB boundary staging contract.
+  - Planned implementation:
+    - slim the staged TSA boundary export in `src/femic/glb.py` to a minimal one-row schema with only geometry plus typed TSA identifier/name fields;
+    - explicitly stop carrying the noisy integer source fields (`FEATURE_CLASS_SKEY`, `OBJECT_VERSION_SKEY`, `OBJECTID`) into the scratch FileGDB layer;
+    - keep the current ArcGIS clip backend and scratch `.gdb` boundary container unchanged.
+  - Planned validation:
+    - strengthen `tests/test_glb.py` to assert the staged boundary export is intentionally slim;
+    - run a real `femic prep glb-build --tsa 29` acceptance check and confirm the GLB area/count are unchanged and the integer-widening warnings are gone.
+- Completed `#147` by slimming the staged GLB boundary export schema.
+  - `src/femic/glb.py` now publishes a minimal one-row scratch boundary layer with only:
+    - `TSA_NUMBER` as string;
+    - `TSA_NAME` as string; and
+    - polygon geometry.
+  - The scratch FileGDB export no longer carries the noisy integer source fields (`FEATURE_CLASS_SKEY`, `OBJECT_VERSION_SKEY`, `OBJECTID`) that triggered `pyogrio` widening warnings.
+  - `tests/test_glb.py` now asserts the staged boundary feature class contains only the slim schema while preserving the same `.gdb` layer path contract for the ArcGIS clip runner.
+  - Acceptance:
+    - `femic prep glb-build --instance-root external/femic-tsa29-instance --tsa 29 --force-rebuild-glb --no-stash-public-data-glb`
+    - still produced `317,735` features and `4,933,664.212 ha` clipped area against `4,933,664.215 ha` boundary area (`-0.003 ha` delta);
+    - emitted no scratch-boundary integer-widening warnings.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16609,3 +16609,24 @@ run_id=k3z_post_tipsy_true_tipsy_20260321_d, rebuilt external/femic-k3z-instance
     - official AFLB/LHLB restart checkpoints;
     - dashboard rebuild from the locked chain; and
     - restart-boundary polygon normalization.
+- 2026-04-17: Started `#147` on branch `feature/issue-147-glb-boundary-warning-cleanup`.
+  - Goal:
+    - remove the remaining scratch boundary export warnings in `prep glb-build` without changing the GLB clip result or the current FileGDB boundary staging contract.
+  - Planned implementation:
+    - slim the staged TSA boundary export in `src/femic/glb.py` to a minimal one-row schema with only geometry plus typed TSA identifier/name fields;
+    - explicitly stop carrying the noisy integer source fields (`FEATURE_CLASS_SKEY`, `OBJECT_VERSION_SKEY`, `OBJECTID`) into the scratch FileGDB layer;
+    - keep the current ArcGIS clip backend and scratch `.gdb` boundary container unchanged.
+  - Planned validation:
+    - strengthen `tests/test_glb.py` to assert the staged boundary export is intentionally slim;
+    - run a real `femic prep glb-build --tsa 29` acceptance check and confirm the GLB area/count are unchanged and the integer-widening warnings are gone.
+- 2026-04-17: Completed `#147` by slimming the staged GLB boundary export schema.
+  - `src/femic/glb.py` now publishes a minimal one-row scratch boundary layer with only:
+    - `TSA_NUMBER` as string;
+    - `TSA_NAME` as string; and
+    - polygon geometry.
+  - The scratch FileGDB export no longer carries the noisy integer source fields (`FEATURE_CLASS_SKEY`, `OBJECT_VERSION_SKEY`, `OBJECTID`) that triggered `pyogrio` widening warnings.
+  - `tests/test_glb.py` now asserts the staged boundary feature class contains only the slim schema while preserving the same `.gdb` layer path contract for the ArcGIS clip runner.
+  - Acceptance:
+    - `femic prep glb-build --instance-root external/femic-tsa29-instance --tsa 29 --force-rebuild-glb --no-stash-public-data-glb`
+    - still produced `317,735` features and `4,933,664.212 ha` clipped area against `4,933,664.215 ha` boundary area (`-0.003 ha` delta);
+    - emitted no scratch-boundary integer-widening warnings.

--- a/src/femic/glb.py
+++ b/src/femic/glb.py
@@ -55,6 +55,24 @@ class TsaBoundarySelection:
     source_path: Path
 
 
+def _build_scratch_boundary_export_frame(
+    *,
+    selected_boundary: gpd.GeoDataFrame,
+    tsa_number: str,
+    tsa_name: str,
+) -> gpd.GeoDataFrame:
+    """Return a minimal typed boundary layer for scratch FileGDB export."""
+    export_frame = gpd.GeoDataFrame(
+        {
+            "TSA_NUMBER": [str(tsa_number)],
+            "TSA_NAME": [str(tsa_name)],
+        },
+        geometry=selected_boundary.geometry.reset_index(drop=True),
+        crs=selected_boundary.crs,
+    )
+    return export_frame
+
+
 @dataclass(frozen=True)
 class GlbBuildResult:
     """Summary of a raw-source GLB build."""
@@ -358,13 +376,22 @@ def _load_active_tsa_boundary(
         or selected.iloc[0].get("TSA_NUMBER_DESCRIPTION")
         or f"TSA {tsa_number}"
     )
+    staged_boundary = _build_scratch_boundary_export_frame(
+        selected_boundary=selected,
+        tsa_number=tsa_number,
+        tsa_name=tsa_name,
+    )
     boundary_layer_root = scratch_dir / "tsa_boundary"
     if boundary_layer_root.exists():
         shutil.rmtree(boundary_layer_root)
     boundary_layer_root.mkdir(parents=True, exist_ok=True)
     boundary_gdb_path = boundary_layer_root / "tsa_boundary.gdb"
     boundary_layer_name = f"tsa_{tsa_number}_boundary"
-    selected.to_file(boundary_gdb_path, layer=boundary_layer_name, driver="OpenFileGDB")
+    staged_boundary.to_file(
+        boundary_gdb_path,
+        layer=boundary_layer_name,
+        driver="OpenFileGDB",
+    )
     boundary_layer_path = boundary_gdb_path / boundary_layer_name
     return TsaBoundarySelection(
         selector=tsa_selector,

--- a/tests/test_glb.py
+++ b/tests/test_glb.py
@@ -26,6 +26,9 @@ def _write_boundary_layer(path: Path) -> None:
             "TSA_NUMBER": [29],
             "TSA_NAME": ["Williams Lake TSA"],
             "TSB_NUMBER": [None],
+            "FEATURE_CLASS_SKEY": [123456],
+            "OBJECT_VERSION_SKEY": [7890],
+            "OBJECTID": [42],
             "geometry": [Polygon([(0, 0), (0, 1000), (1000, 1000), (1000, 0)])],
         },
         crs="EPSG:3005",
@@ -106,6 +109,13 @@ def test_build_tsa_raw_glb_writes_summary_with_mocked_arcgis(tmp_path: Path) -> 
         assert boundary_layer_path.parent.suffix == ".gdb"
         assert boundary_layer_path.parent.exists()
         assert boundary_layer_path.name == "tsa_29_boundary"
+        staged_boundary = gpd.read_file(
+            boundary_layer_path.parent,
+            layer=boundary_layer_path.name,
+        )
+        assert list(staged_boundary.columns) == ["TSA_NUMBER", "TSA_NAME", "geometry"]
+        assert staged_boundary.iloc[0]["TSA_NUMBER"] == "29"
+        assert staged_boundary.iloc[0]["TSA_NAME"] == "Williams Lake TSA"
         output_gdb_path.mkdir(parents=True, exist_ok=True)
         summary_json_path.write_text(
             json.dumps(


### PR DESCRIPTION
## Summary
Fix the remaining `prep glb-build` scratch boundary export warnings without changing the GLB clip result or the current FileGDB staging contract.

## What changed
- scratch FileGDB boundary export now uses a minimal typed one-row boundary schema
- keeps the same ArcGIS clip backend and scratch `.gdb` container
- drops the unnecessary integer source fields that were triggering `pyogrio` widening warnings

## Acceptance
- `317,735` features
- `4,933,664.212 ha` clipped area
- `-0.003 ha` delta vs boundary
- no scratch-boundary integer-widening warnings
