### PR TITLE
P64 restore MKRF CT legacy parity

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16367,3 +16367,13 @@
   - updated the existing guide pages so operators now land on those logic docs
     instead of only seeing package anatomy and figure pages, then rebuilt the
     standalone instance Sphinx docs warning-clean.
+## 2026-05-02 - Clarified MKRF treatment docs wording
+- `#173` docs wording follow-up:
+  - rewrote the canonical `CC` and `CT` treatment bullets so the docs explain
+    post-treatment field updates in plain language instead of raw assignment
+    fragments;
+  - replaced the ambiguous prose `retention 20` with an explicit description of
+    the treatment `retain="20"` attribute as a 20-year post-treatment
+    re-entry lock for automated scheduling; and
+  - removed the stale `CT followed by clearcut twenty years later` wording from
+    `model-anatomy.rst`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16377,3 +16377,31 @@
     re-entry lock for automated scheduling; and
   - removed the stale `CT followed by clearcut twenty years later` wording from
     `model-anatomy.rst`.
+## 2026-05-02 - Restored MKRF CT legacy parity in the canonical runtime lane
+- `#180` / `P64` CT legacy-parity follow-up:
+  - opened the new parent feature issue and feature branch for the post-release
+    CT parity repair, then recorded the contract and active edge in
+    `ROADMAP.md` and `planning/mkrf_femic_native_rebuild.md`;
+  - updated the instance and parent MKRF docs so they now state plainly that
+    legacy and PoC CT use a constant proportional split rather than a constant
+    absolute gap:
+    - treatment-year CT harvest/product signal = `0.4 * base curve`
+    - post-thin THN standing signal for later ages = `0.6 * base curve(x)`;
+  - repaired the canonical MKRF runtime generator so CT now:
+    - uses the legacy/PoC select statement
+      `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'thn_')`;
+    - emits `retain="20"` and transitions to `au='thn_'+au`;
+    - drives THN state labels from the thinned AU lane; and
+    - separates CT treatment-year extracted products (`0.4`) from post-CT THN
+      standing yields (`0.6`);
+  - regenerated the canonical runtime package, reran Matrix Builder as
+    `mkrf_ct_parity_matrix_20260502a`, reran the canonical even-flow smoke as
+    `mkrf_ct_parity_smoke_20260502a`, and reran
+    `femic instance mkrf-audit-runtime-sanity` with zero failures;
+  - verified one representative rebuilt CT track directly from the rebuilt
+    runtime outputs:
+    - age 40: `184.1 = 73.64 + 110.46`
+    - age 60: `398.3 = 159.32 + 238.98`
+    - age 100: `764.8 = 305.92 + 458.88`; and
+  - kept focused tests, parent docs, instance docs, and `git diff --check`
+    clean after the repair.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1751,8 +1751,45 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P63.5b Update the existing guide pages so operators land on those new logic docs instead of shallow package-only descriptions.
   - [x] P63.5c Rebuild the standalone instance docs and verify the new treatment/AU/remap explanations render warning-clean.
 
+## Phase 64: Restore MKRF CT Legacy Parity
+
+- [ ] P64.1 Record the CT legacy-parity contract and current divergence (`#180`)
+  - [ ] P64.1a Update the roadmap/planning surfaces so the post-`v0.0.1a1` CT follow-up is governed by `#180`.
+  - [ ] P64.1b Document the exact legacy and PoC CT behavior from source XML, including the `0.4` treatment-year extraction and `0.6` thinned standing lane.
+  - [ ] P64.1c Record the current canonical CT divergence explicitly so the runtime repair is judged against the legacy/PoC contract rather than ad hoc interpretation.
+- [ ] P64.2 Repair canonical MKRF CT runtime logic to match legacy/PoC (`#180`)
+  - [ ] P64.2a Emit the legacy/PoC CT select statement and transition contract in the canonical generator, including `retain="20"` and `au='thn_'+au`.
+  - [ ] P64.2b Drive THN state/yield behavior from the thinned AU lane while preserving canonical CC regeneration behavior back to the treated/post-clearcut lane.
+  - [ ] P64.2c Split CT treatment-year extracted products (`0.4 * base curve`) from post-CT standing THN yields (`0.6 * base curve(x)`).
+- [ ] P64.3 Prove CT parity in tests, rebuilt runtime outputs, and published docs (`#180`)
+  - [ ] P64.3a Add focused regression coverage for CT select/transition semantics and the legacy `0.4`/`0.6` split.
+  - [ ] P64.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical even-flow smoke at `100000` iterations.
+  - [ ] P64.3c Inspect representative rebuilt CT-active outputs, keep parent/instance docs warning-clean, and record the parity result in repo/GitHub surfaces.
+
 ### Detailed Next Steps Notes
 
+- Active MKRF follow-up is now `#180`, not `#173`:
+  - the new post-release target is CT legacy parity for the canonical lane rather than more generic docs/publication cleanup;
+  - the governing behavioral contract comes from
+    `external/femic-mkrf-instance/data/legacy_mkrf/generated_xml/baseMKRF.xml`
+    and the accepted PoC mirror in
+    `external/femic-mkrf-instance/models/mkrf_patchworks_model_poc/XML/baseMKRF.xml`;
+  - both source XML surfaces implement CT as a constant proportional split:
+    - treatment-year CT harvest/product signal = `0.4 * base curve`
+    - post-thin standing THN signal for later ages = `0.6 * base curve(x)`; and
+  - the current canonical generator still diverges because it uses the `0.6`
+    residual logic but does not yet emit the separate `0.4` CT extraction
+    surface correctly.
+- Immediate execution order for `#180`:
+  - first update the instance and parent MKRF docs so they explain the exact
+    legacy/PoC CT contract and the current canonical divergence plainly;
+  - then repair the canonical runtime generator so CT transitions to
+    `thn_` AUs, preserves origin, and restores the legacy `0.4` extracted /
+    `0.6` residual split; and
+  - finish with focused CT regression checks plus a full canonical package
+    rebuild, Matrix Builder rerun, and `100000`-iteration even-flow smoke so
+    the parity claim is based on rebuilt outputs rather than code inspection
+    alone.
 - Phase 62 publication lane is complete:
   - instance PR `UBC-FRESH/femic-mkrf-instance#2` merged and parent PR `#179` merged;
   - `femic-mkrf-instance` release `v0.0.1a1` is published as an alpha pre-release;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1753,43 +1753,44 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
 
 ## Phase 64: Restore MKRF CT Legacy Parity
 
-- [ ] P64.1 Record the CT legacy-parity contract and current divergence (`#180`)
-  - [ ] P64.1a Update the roadmap/planning surfaces so the post-`v0.0.1a1` CT follow-up is governed by `#180`.
-  - [ ] P64.1b Document the exact legacy and PoC CT behavior from source XML, including the `0.4` treatment-year extraction and `0.6` thinned standing lane.
-  - [ ] P64.1c Record the current canonical CT divergence explicitly so the runtime repair is judged against the legacy/PoC contract rather than ad hoc interpretation.
-- [ ] P64.2 Repair canonical MKRF CT runtime logic to match legacy/PoC (`#180`)
-  - [ ] P64.2a Emit the legacy/PoC CT select statement and transition contract in the canonical generator, including `retain="20"` and `au='thn_'+au`.
-  - [ ] P64.2b Drive THN state/yield behavior from the thinned AU lane while preserving canonical CC regeneration behavior back to the treated/post-clearcut lane.
-  - [ ] P64.2c Split CT treatment-year extracted products (`0.4 * base curve`) from post-CT standing THN yields (`0.6 * base curve(x)`).
-- [ ] P64.3 Prove CT parity in tests, rebuilt runtime outputs, and published docs (`#180`)
-  - [ ] P64.3a Add focused regression coverage for CT select/transition semantics and the legacy `0.4`/`0.6` split.
-  - [ ] P64.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical even-flow smoke at `100000` iterations.
-  - [ ] P64.3c Inspect representative rebuilt CT-active outputs, keep parent/instance docs warning-clean, and record the parity result in repo/GitHub surfaces.
+- [x] P64.1 Record the CT legacy-parity contract and current divergence (`#180`)
+  - [x] P64.1a Update the roadmap/planning surfaces so the post-`v0.0.1a1` CT follow-up is governed by `#180`.
+  - [x] P64.1b Document the exact legacy and PoC CT behavior from source XML, including the `0.4` treatment-year extraction and `0.6` thinned standing lane.
+  - [x] P64.1c Record the current canonical CT divergence explicitly so the runtime repair is judged against the legacy/PoC contract rather than ad hoc interpretation.
+- [x] P64.2 Repair canonical MKRF CT runtime logic to match legacy/PoC (`#180`)
+  - [x] P64.2a Emit the legacy/PoC CT select statement and transition contract in the canonical generator, including `retain="20"` and `au='thn_'+au`.
+  - [x] P64.2b Drive THN state/yield behavior from the thinned AU lane while preserving canonical CC regeneration behavior back to the treated/post-clearcut lane.
+  - [x] P64.2c Split CT treatment-year extracted products (`0.4 * base curve`) from post-CT standing THN yields (`0.6 * base curve(x)`).
+- [x] P64.3 Prove CT parity in tests, rebuilt runtime outputs, and published docs (`#180`)
+  - [x] P64.3a Add focused regression coverage for CT select/transition semantics and the legacy `0.4`/`0.6` split.
+  - [x] P64.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical even-flow smoke at `100000` iterations.
+  - [x] P64.3c Inspect representative rebuilt CT-active outputs, keep parent/instance docs warning-clean, and record the parity result in repo/GitHub surfaces.
 
 ### Detailed Next Steps Notes
 
-- Active MKRF follow-up is now `#180`, not `#173`:
-  - the new post-release target is CT legacy parity for the canonical lane rather than more generic docs/publication cleanup;
-  - the governing behavioral contract comes from
-    `external/femic-mkrf-instance/data/legacy_mkrf/generated_xml/baseMKRF.xml`
-    and the accepted PoC mirror in
-    `external/femic-mkrf-instance/models/mkrf_patchworks_model_poc/XML/baseMKRF.xml`;
-  - both source XML surfaces implement CT as a constant proportional split:
+- Phase 64 CT legacy-parity follow-up is complete on the implementation branch:
+  - legacy and PoC CT semantics are now documented directly from source XML as
+    a constant proportional split:
     - treatment-year CT harvest/product signal = `0.4 * base curve`
-    - post-thin standing THN signal for later ages = `0.6 * base curve(x)`; and
-  - the current canonical generator still diverges because it uses the `0.6`
-    residual logic but does not yet emit the separate `0.4` CT extraction
-    surface correctly.
-- Immediate execution order for `#180`:
-  - first update the instance and parent MKRF docs so they explain the exact
-    legacy/PoC CT contract and the current canonical divergence plainly;
-  - then repair the canonical runtime generator so CT transitions to
-    `thn_` AUs, preserves origin, and restores the legacy `0.4` extracted /
-    `0.6` residual split; and
-  - finish with focused CT regression checks plus a full canonical package
-    rebuild, Matrix Builder rerun, and `100000`-iteration even-flow smoke so
-    the parity claim is based on rebuilt outputs rather than code inspection
-    alone.
+    - post-thin THN standing signal for later ages = `0.6 * base curve(x)`;
+  - the canonical generator now emits the same CT select/transition contract:
+    - `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'thn_')`
+    - `retain="20"`
+    - `au='thn_'+au`;
+  - rebuilt runtime outputs now prove the intended split on representative CT
+    tracks, including one direct rebuilt example where:
+    - age 40: `184.1 = 73.64 + 110.46`
+    - age 60: `398.3 = 159.32 + 238.98`
+    - age 100: `764.8 = 305.92 + 458.88`; and
+  - the canonical Matrix Builder run, `100000`-iteration even-flow smoke, and
+    runtime sanity audit are all clean after the repair.
+- Out-of-scope future follow-up remains open by design:
+  - do not treat legacy CT parity as an endorsement of the proportional-gap
+    silviculture model as ideal;
+  - a constant absolute gap or post-thin growth-response model is still a valid
+    later enhancement; and
+  - any such redesign should open a new issue/phase rather than mutating the
+    legacy-parity contract under `#180`.
 - Phase 62 publication lane is complete:
   - instance PR `UBC-FRESH/femic-mkrf-instance#2` merged and parent PR `#179` merged;
   - `femic-mkrf-instance` release `v0.0.1a1` is published as an alpha pre-release;

--- a/docs/sample-models/mkrf.rst
+++ b/docs/sample-models/mkrf.rst
@@ -71,6 +71,22 @@ The practical handoff is:
 - use the PoC package only for benchmark/reference comparison; and
 - use Phase 60 / ``#173`` for the remaining closeout/docs claim-boundary work.
 
+Commercial thinning follow-up
+-----------------------------
+
+The post-release CT follow-up is now governed by ``#180`` rather than the
+original rebuild-closeout issue.
+
+That follow-up uses the legacy source XML and accepted PoC XML as the
+behavioral contract for CT:
+
+- treatment-year CT extraction = ``0.4 * base curve``; and
+- post-thin THN standing yield for later ages = ``0.6 * base curve(x)``.
+
+This is a constant proportional gap model, not a constant absolute gap model.
+Use the standalone instance treatment/state page for the exact current
+canonical CT wording and evidence pointers.
+
 Current ``v0`` checkpoint signal
 --------------------------------
 

--- a/planning/mkrf_femic_native_rebuild.md
+++ b/planning/mkrf_femic_native_rebuild.md
@@ -1802,3 +1802,72 @@ all of the following are true:
 - validating only XML presence without a Matrix Builder run; or
 - validating only Matrix Builder completion without any runtime-assembly or
   launch evidence tied to the canonical package.
+
+## Post-`v0.0.1a1` CT legacy-parity follow-up (`#180`)
+
+The next MKRF follow-up after the canonical `v0.0.1a1` alpha release is not a
+new silviculture redesign. It is a legacy-parity repair for commercial
+thinning (`CT`) semantics in the canonical lane.
+
+### Governing behavioral contract
+
+Use the source XML as the contract surface, not compiled runtime outputs as the
+primary source of truth:
+
+- legacy source XML:
+  `external/femic-mkrf-instance/data/legacy_mkrf/generated_xml/baseMKRF.xml`
+- PoC benchmark XML:
+  `external/femic-mkrf-instance/models/mkrf_patchworks_model_poc/XML/baseMKRF.xml`
+
+Both surfaces implement the same CT approximation:
+
+- CT eligibility:
+  `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'t')`
+- treatment contract:
+  `label="CT"`, `minage="40"`, `maxage="150"`, `retain="20"`
+- transition:
+  `treatment='CT'` and `au='thn_'+au`
+- treatment-year extracted harvest/product signal:
+  `0.4 * base curve`
+- post-thin standing THN signal for later ages:
+  `0.6 * base curve(x)`
+
+This is a constant proportional gap model. It is not the constant absolute gap
+formulation `f(x) - 0.4 * f(x_ct)`.
+
+### Current canonical divergence
+
+The current canonical generator still diverges from the legacy/PoC contract in
+the place that matters most for CT economics:
+
+- it already carries the `0.6` residual/thinned standing logic; but
+- it does not yet emit a distinct `0.4` CT treatment-year extraction surface;
+- and it currently uses the simplified `au=auf` + `statecode='THN'` treatment
+  contract instead of the legacy/PoC `au='thn_'+au` transition.
+
+That means CT is still modeled as an obviously degraded option in the canonical
+lane because the removed commercial volume is not being represented correctly.
+
+### Required repair sequence
+
+The CT parity follow-up should proceed in this order:
+
+1. update instance and parent docs so they explain the exact legacy/PoC CT
+   contract and the current canonical divergence clearly;
+2. repair the canonical runtime generator so CT matches the legacy/PoC select,
+   transition, and `0.4`/`0.6` split exactly; and
+3. regenerate the canonical runtime package, rerun Matrix Builder, rerun the
+   `100000`-iteration even-flow smoke, and inspect representative CT-active
+   outputs before claiming parity.
+
+### Out-of-scope improvement work
+
+Do not redesign CT response curves in this follow-up. In particular, do not
+replace the legacy proportional-gap model with:
+
+- a constant absolute gap model;
+- a post-thin growth boost / rebound model; or
+- any new end-user CT calibration knobs.
+
+Those are valid later enhancements, but they are not part of the legacy-parity
+repair governed by `#180`.

--- a/planning/mkrf_femic_native_rebuild.md
+++ b/planning/mkrf_femic_native_rebuild.md
@@ -1871,3 +1871,19 @@ replace the legacy proportional-gap model with:
 
 Those are valid later enhancements, but they are not part of the legacy-parity
 repair governed by `#180`.
+
+### Implementation closeout
+
+The CT legacy-parity implementation branch now matches that contract:
+
+- the canonical generator emits the legacy/PoC CT select statement plus
+  `retain="20"` and `au='thn_'+au`;
+- the canonical yield/product logic now separates:
+  - treatment-year CT extraction = `0.4 * base curve`; and
+  - post-thin THN standing yield = `0.6 * base curve(x)`;
+- the canonical runtime package has been regenerated from that repaired
+  generator;
+- Matrix Builder completed cleanly on the rebuilt canonical package;
+- the canonical `100000`-iteration even-flow smoke completed cleanly; and
+- representative rebuilt CT-active runtime outputs now prove the expected
+  `0.4` / `0.6` split directly.

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -2022,8 +2022,8 @@ def initialize_mkrf_runtime_package(
     first_growth_curve_lookup_rows = [row for row in curve_ref_rows if row["first_growth_curve_id"]]
     first_growth_curve_au_ids = [str(row["au_id"]) for row in first_growth_curve_lookup_rows]
     first_growth_curve_ids = [str(row["first_growth_curve_id"]) for row in first_growth_curve_lookup_rows]
-    runtime_base_au_expr = "au"
-    runtime_state_expr = "statecode"
+    runtime_base_au_expr = "if(startswith(au,'thn_'),substring(au,4),au)"
+    runtime_state_expr = "if(startswith(au,'thn_'),'THN',statecode)"
     managed_curve_lookup_expr = _build_lookup_expr(
         managed_curve_au_ids,
         managed_curve_ids,
@@ -2133,7 +2133,8 @@ def initialize_mkrf_runtime_package(
         f"curveId({first_growth_curve_lookup_expr}),"
         f"curveId({managed_curve_lookup_expr}))"
     )
-    thinning_factor_expr = "if(treatment eq 'CT' or statecode eq 'THN',0.6,1)"
+    standing_thinning_factor_expr = "if(startswith(au,'thn_'),0.6,1)"
+    ct_extraction_factor_expr = "if(treatment eq 'CT',0.4,1)"
     for obsolete_path in (
         tracks_dir / "au_runtime_status.csv",
         tracks_dir / "au_curve_refs.csv",
@@ -2431,7 +2432,12 @@ def initialize_mkrf_runtime_package(
     ct_select = et.SubElement(
         forestmodel_root,
         "select",
-        {"statement": "status in managed and oper in operable and ct eq 'Y' and statecode ne 'THN'"},
+        {
+            "statement": (
+                "status in managed and oper in operable and ct eq 'Y' "
+                "and not startswith(au,'thn_')"
+            )
+        },
     )
     ct_track = et.SubElement(ct_select, "track")
     ct_treatment = et.SubElement(
@@ -2449,12 +2455,7 @@ def initialize_mkrf_runtime_package(
     et.SubElement(
         ct_transition,
         "assign",
-        {"field": "au", "value": "auf"},
-    )
-    et.SubElement(
-        ct_transition,
-        "assign",
-        {"field": "statecode", "value": "'THN'"},
+        {"field": "au", "value": "'thn_'+au"},
     )
     area_features_select = et.SubElement(forestmodel_root, "select")
     area_features = et.SubElement(area_features_select, "features")
@@ -2497,7 +2498,7 @@ def initialize_mkrf_runtime_package(
         managed_yield_total,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2511,7 +2512,7 @@ def initialize_mkrf_runtime_package(
         managed_yield_state,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2553,7 +2554,7 @@ def initialize_mkrf_runtime_package(
             "expression",
             {
                 "statement": (
-                    f"{origin_curve_lookup_expr}*{thinning_factor_expr}"
+                    f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}"
                     f"*({origin_share_lookup_exprs[share_column]})"
                 ),
                 "by": "1",
@@ -2575,7 +2576,7 @@ def initialize_mkrf_runtime_package(
         unmanaged_yield_total,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2589,7 +2590,7 @@ def initialize_mkrf_runtime_package(
         unmanaged_yield_state,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2605,7 +2606,7 @@ def initialize_mkrf_runtime_package(
             "expression",
             {
                 "statement": (
-                    f"{origin_curve_lookup_expr}*{thinning_factor_expr}"
+                    f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}"
                     f"*({origin_share_lookup_exprs[share_column]})"
                 ),
                 "by": "1",
@@ -2645,7 +2646,7 @@ def initialize_mkrf_runtime_package(
         product_yield_total,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2659,7 +2660,7 @@ def initialize_mkrf_runtime_package(
         product_yield_state,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2675,7 +2676,7 @@ def initialize_mkrf_runtime_package(
             "expression",
             {
                 "statement": (
-                    f"{origin_curve_lookup_expr}*{thinning_factor_expr}"
+                    f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}"
                     f"*({origin_share_lookup_exprs[share_column]})"
                 ),
                 "by": "1",
@@ -2691,7 +2692,7 @@ def initialize_mkrf_runtime_package(
         product_yield_treat,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{thinning_factor_expr}",
+            "statement": f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}",
             "by": "1",
             "ignoreMissingAttributes": "false",
         },

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -384,9 +384,15 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert '<attribute label="feature.area.retention.total">' in forestmodel_text
     assert '<attribute label="%f.area.%m.total">' in forestmodel_text
     assert '<attribute label="%f.area.%m.seral.le10">' in forestmodel_text
-    assert "<attribute label=\"'%f.area.%m.state.'+statecode\"" in forestmodel_text
+    assert (
+        "<attribute label=\"'%f.area.%m.state.'+if(startswith(au,'thn_'),'THN',statecode)\""
+        in forestmodel_text
+    )
     assert '<attribute label="%f.yield.%m.total">' in forestmodel_text
-    assert "<attribute label=\"'%f.yield.%m.state.'+statecode\"" in forestmodel_text
+    assert (
+        "<attribute label=\"'%f.yield.%m.state.'+if(startswith(au,'thn_'),'THN',statecode)\""
+        in forestmodel_text
+    )
     assert '<attribute label="%f.yield.%m.merch.total">' in forestmodel_text
     assert '<attribute label="%f.yield.%m.indsp.Ba">' in forestmodel_text
     assert '<attribute label="%f.yield.%m.indsp.Cw">' in forestmodel_text
@@ -395,7 +401,8 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert 'select statement="status in unmanaged"' in forestmodel_text
     assert "hasfg eq" not in forestmodel_text
     assert "startswith(au,'em_')" not in forestmodel_text
-    assert "startswith(au,'thn_')" not in forestmodel_text
+    assert "startswith(au,'thn_')" in forestmodel_text
+    assert "substring(au,4)" in forestmodel_text
     assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Ba">') == 2
     assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Cw">') == 2
     assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Dr">') == 2
@@ -408,13 +415,20 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert '<attribute label="product.yield.managed.indsp.Ba">' in forestmodel_text
     assert '<attribute label="\'product.yield.managed.treat.\'+treatment">' in forestmodel_text
     assert "if(origin eq 'natural' and hasnatcurve eq 'Y'," in forestmodel_text
-    assert "curveId(lookupTable(au,'cwh_vm_1_dr_hw,cwh_vm_1_hw_cw'," in forestmodel_text
-    assert "if(treatment eq 'CT' or statecode eq 'THN',0.6,1)" in forestmodel_text
+    assert (
+        "curveId(lookupTable(if(startswith(au,'thn_'),substring(au,4),au),"
+        "'cwh_vm_1_dr_hw,cwh_vm_1_hw_cw',"
+        in forestmodel_text
+    )
+    assert "if(startswith(au,'thn_'),0.6,1)" in forestmodel_text
+    assert "if(treatment eq 'CT',0.4,1)" in forestmodel_text
     assert '<curve idref="unity"' in forestmodel_text
     assert '<curve idref="le10"' in forestmodel_text
     assert 'select statement="status in managed and oper in operable"' in forestmodel_text
     assert 'select statement="status in managed"' in forestmodel_text
-    assert "statecode ne 'THN'" in forestmodel_text
+    assert "not startswith(au,'thn_')" in forestmodel_text
+    assert "'thn_'+au" in forestmodel_text
+    assert 'field="statecode" value="\'THN\'"' not in forestmodel_text
     assert "<track>" in forestmodel_text
     assert 'treatment label="CC"' in forestmodel_text
     assert 'treatment label="CT"' in forestmodel_text


### PR DESCRIPTION
## Summary
- restore canonical MKRF CT runtime semantics to match legacy/PoC 40/60 behavior
- document the exact CT treatment contract and current canonical behavior
- regenerate and validate the canonical runtime package, Matrix Builder outputs, and smoke run

## Validation
- python -m pytest tests/test_mkrf_runtime_package.py tests/test_docs_contract.py::test_roadmap_is_a_compact_ordered_control_surface -q
- python -m ruff check src/femic/workflows/mkrf.py tests/test_mkrf_runtime_package.py
- sphinx-build -b html docs _build/html -W
- sphinx-build -b html external/femic-mkrf-instance/docs external/femic-mkrf-instance/docs/_build/html -W
- python -m femic instance mkrf-init-runtime-package --instance-root external/femic-mkrf-instance
- python -m femic patchworks matrix-build --config external/femic-mkrf-instance/config/patchworks.runtime.mkrf_rebuild.windows.yaml --run-id mkrf_ct_parity_matrix_20260502a
- python -m femic patchworks run-default-scenario mkrf.base --run-id mkrf_ct_parity_smoke_20260502a
- python -m femic instance mkrf-audit-runtime-sanity --instance-root external/femic-mkrf-instance --stage-dir runtime/logs/headless_stage/mkrf_ct_parity_smoke_20260502a
