### PR TITLE
P66 bucketed MKRF CT redesign for v0.0.2a1

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16456,3 +16456,31 @@
     lanes so extracted and residual CT surfaces remain auditable by bucket; and
   - kept `v0.0.2a1` as the release boundary for this redesign rather than a
     continuation of the earlier `v0.0.1a1` alpha line.
+## 2026-05-03 - Implemented the Phase 66 bucketed MKRF CT redesign
+- `#182` / `P66` implementation:
+  - replaced the single canonical `CT` treatment with bucketed treatments
+    `CT40`, `CT50`, `CT60`, ... across 10-year age windows;
+  - emitted per-bucket thinned AU/state lanes (`thn040_`, `thn050_`, ...)
+    and bucket-anchored extracted/residual CT curve families in the canonical
+    runtime XML;
+  - changed canonical CT extracted-product logic to
+    `0.4 * base_curve(x_ct_bucket)`;
+  - changed canonical post-CT standing logic to
+    `max(0, base_curve(x) - 0.4 * base_curve(x_ct_bucket))`;
+  - fixed non-CT products on thinned lanes so follow-on `CC` harvests the
+    residual standing curve rather than the untreated base curve;
+  - updated the instance/operator/parent MKRF docs so the canonical CT
+    contract now describes the bucketed constant-absolute-gap design and keeps
+    the old `0.4` / `0.6` proportional split as legacy/PoC reference only;
+  - reran focused runtime-package tests successfully;
+  - regenerated the canonical runtime package successfully;
+  - reran Patchworks Matrix Builder successfully as
+    `mkrf_ct_bucket_matrix_20260502b`;
+  - reran the canonical `100000`-iteration smoke successfully as
+    `mkrf_ct_bucket_smoke_20260502b`;
+  - reran the runtime sanity audit successfully with `rows=24 failures=0`;
+  - confirmed representative rebuilt track arithmetic for lower and higher CT
+    buckets:
+    - `CT40`: `73.64 + 691.16 = 764.8`
+    - `CT100`: `305.92 + 589.38 = 895.3`; and
+  - kept the intended release boundary for this redesign at `v0.0.2a1`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16429,3 +16429,18 @@
   - rebuilt the standalone instance docs warning-clean; and
   - pushed the instance docs commit, posted a final closeout comment on
     `femic-mkrf-instance#1`, and closed the issue.
+## 2026-05-03 - Opened the next MKRF CT redesign lane beyond legacy parity
+- `#182` / `P66` kickoff:
+  - opened the new parent feature issue
+    `Feature: redesign MKRF CT response beyond legacy parity`;
+  - created the working branch
+    `feature/issue-182-mkrf-ct-response-redesign`;
+  - updated `ROADMAP.md` so Phase 66 now governs the next MKRF modeling lane;
+  - updated `planning/mkrf_femic_native_rebuild.md` so the redesign contract is
+    explicit:
+    - legacy proportional-gap CT stays benchmark/reference only
+    - the new canonical target is a constant-absolute-gap CT model
+    - the primary decision bar is CT-vs-no-CT full-rotation harvested-volume
+      behavior; and
+  - recorded the intended redesign release boundary as `v0.0.2a1` rather than
+    a continuation of `v0.0.1a1`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16444,3 +16444,15 @@
       behavior; and
   - recorded the intended redesign release boundary as `v0.0.2a1` rather than
     a continuation of `v0.0.1a1`.
+## 2026-05-03 - Locked Phase 66 to a bucketed CT redesign contract
+- `#182` / `P66` planning refinement:
+  - updated `ROADMAP.md` and `planning/mkrf_femic_native_rebuild.md` so the
+    canonical CT redesign is now explicitly a bucketed constant-absolute-gap
+    model rather than a generic continuous-age target;
+  - locked the discretization contract to 10-year midpoint buckets with
+    labels `CT40`, `CT50`, `CT60`, ... and age windows `35-44`, `45-54`,
+    `55-64`, ...;
+  - locked the post-treatment runtime shape to per-bucket thinned AU/state
+    lanes so extracted and residual CT surfaces remain auditable by bucket; and
+  - kept `v0.0.2a1` as the release boundary for this redesign rather than a
+    continuation of the earlier `v0.0.1a1` alpha line.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1783,35 +1783,39 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
 
 ## Phase 66: Redesign MKRF CT Response Beyond Legacy Parity
 
-- [ ] P66.1 Record the redesign contract and release framing (`#182`)
-  - [ ] P66.1a Update roadmap/planning surfaces so the next MKRF modeling lane is governed by `#182`.
-  - [ ] P66.1b Record the legacy proportional-gap CT model as benchmark/reference only and the bucketed constant-absolute-gap CT model as the new canonical target.
-  - [ ] P66.1c Record that the release boundary for this redesign is `v0.0.2a1`, not a continuation of `v0.0.1a1`.
-- [ ] P66.2 Replace canonical MKRF CT with a bucketed constant-absolute-gap standing-yield model (`#182`)
-  - [ ] P66.2a Replace the single schedulable `CT` treatment with 10-year midpoint CT bucket treatments (`CT40`, `CT50`, `CT60`, ...) covering age windows such as `35-44`, `45-54`, and `55-64`.
-  - [ ] P66.2b Emit per-bucket thinned AU/state lanes so each bucket uses a precompiled constant-absolute-gap post-CT standing response anchored to the bucket midpoint age.
-  - [ ] P66.2c Preserve explicit CT treatment-year extraction, thinned-lane semantics, and CC follow-on behavior while keeping the bucketed redesign as the canonical default rather than an experimental sidecar.
-- [ ] P66.3 Prove the redesign against runtime outputs, docs, and release framing (`#182`)
-  - [ ] P66.3a Add focused regression coverage for the bucketed constant-absolute-gap CT behavior and its difference from the legacy proportional-gap rule.
-  - [ ] P66.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical `100000`-iteration even-flow smoke.
-  - [ ] P66.3c Inspect representative lower-bucket and higher-bucket CT outputs, confirm CT-vs-no-CT full-rotation harvested-volume behavior, rebuild parent/instance docs warning-clean, and record the `v0.0.2a1` framing in repo/GitHub surfaces.
+- [x] P66.1 Record the redesign contract and release framing (`#182`)
+  - [x] P66.1a Update roadmap/planning surfaces so the next MKRF modeling lane is governed by `#182`.
+  - [x] P66.1b Record the legacy proportional-gap CT model as benchmark/reference only and the bucketed constant-absolute-gap CT model as the new canonical target.
+  - [x] P66.1c Record that the release boundary for this redesign is `v0.0.2a1`, not a continuation of `v0.0.1a1`.
+- [x] P66.2 Replace canonical MKRF CT with a bucketed constant-absolute-gap standing-yield model (`#182`)
+  - [x] P66.2a Replace the single schedulable `CT` treatment with 10-year midpoint CT bucket treatments (`CT40`, `CT50`, `CT60`, ...) covering age windows such as `35-44`, `45-54`, and `55-64`.
+  - [x] P66.2b Emit per-bucket thinned AU/state lanes so each bucket uses a precompiled constant-absolute-gap post-CT standing response anchored to the bucket midpoint age.
+  - [x] P66.2c Preserve explicit CT treatment-year extraction, thinned-lane semantics, and CC follow-on behavior while keeping the bucketed redesign as the canonical default rather than an experimental sidecar.
+- [x] P66.3 Prove the redesign against runtime outputs, docs, and release framing (`#182`)
+  - [x] P66.3a Add focused regression coverage for the bucketed constant-absolute-gap CT behavior and its difference from the legacy proportional-gap rule.
+  - [x] P66.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical `100000`-iteration even-flow smoke.
+  - [x] P66.3c Inspect representative lower-bucket and higher-bucket CT outputs, confirm CT-vs-no-CT full-rotation harvested-volume behavior, rebuild parent/instance docs warning-clean, and record the `v0.0.2a1` framing in repo/GitHub surfaces.
 
 ### Detailed Next Steps Notes
 
-- Phase 66 CT redesign beyond legacy parity is now the active MKRF edge:
-  - the legacy proportional-gap CT model is now complete and retained only as a
-    benchmark/reference contract;
-  - the next canonical target is a bucketed constant-absolute-gap CT
-    standing-yield response anchored at representative CT midpoint ages;
-  - the locked discretization contract is:
-    - 10-year midpoint treatment buckets;
-    - labels `CT40`, `CT50`, `CT60`, ...;
-    - age windows `35-44`, `45-54`, `55-64`, ...; and
-    - per-bucket thinned AU/state lanes for auditability;
-  - the decision bar is CT-vs-no-CT full-rotation harvested-volume behavior,
-    not legacy-output mimicry; and
-  - this redesign is intended to ship as `v0.0.2a1` so it is not conflated
-    with the earlier `v0.0.1a1` alpha release.
+- Phase 66 bucketed CT redesign is now implemented on `#182`:
+  - the canonical MKRF lane now emits `CT40`, `CT50`, `CT60`, ... bucket
+    treatments with per-bucket `thn040_`, `thn050_`, ... thinned lanes;
+  - treatment-year CT extraction is now bucket-anchored at
+    `0.4 * base_curve(x_ct_bucket)`;
+  - post-CT standing yield now follows the bucketed constant-absolute-gap rule
+    `max(0, base_curve(x) - 0.4 * base_curve(x_ct_bucket))`;
+  - non-CT products from thinned lanes now harvest the residual standing lane
+    rather than the untreated base curve;
+  - canonical validation is complete on the MKRF lane:
+    - focused runtime-package tests passed;
+    - canonical runtime package regeneration passed;
+    - Matrix Builder run `mkrf_ct_bucket_matrix_20260502b` passed;
+    - canonical even-flow smoke `mkrf_ct_bucket_smoke_20260502b` passed;
+    - runtime sanity audit reported `rows=24 failures=0`; and
+    - representative rebuilt track checks confirmed constant-gap arithmetic for
+      lower and higher CT buckets; and
+  - the intended release boundary for this redesign remains `v0.0.2a1`.
 - Phase 65 archival-publication follow-up is complete:
   - `external/femic-mkrf-instance/data/legacy_mkrf/` is now published as a
     first-class repo-local archive/reference lane rather than only a scattered

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1781,8 +1781,32 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P65.3b Push the instance and parent pointer updates required for the published docs/metadata state.
   - [x] P65.3c Close `femic-mkrf-instance#1` once the archival lane is documented and the canonical lane remains the default.
 
+## Phase 66: Redesign MKRF CT Response Beyond Legacy Parity
+
+- [ ] P66.1 Record the redesign contract and release framing (`#182`)
+  - [ ] P66.1a Update roadmap/planning surfaces so the next MKRF modeling lane is governed by `#182`.
+  - [ ] P66.1b Record the legacy proportional-gap CT model as benchmark/reference only and the constant-absolute-gap CT model as the new canonical target.
+  - [ ] P66.1c Record that the release boundary for this redesign is `v0.0.2a1`, not a continuation of `v0.0.1a1`.
+- [ ] P66.2 Replace canonical MKRF CT with a constant-absolute-gap standing-yield model (`#182`)
+  - [ ] P66.2a Rework canonical CT standing-yield logic so post-CT THN standing volume is anchored to CT-age removed volume rather than a constant proportional gap.
+  - [ ] P66.2b Preserve the CT treatment-year extraction signal, thinned AU transition contract, and CC follow-on behavior unless the redesign proves one of those contracts must change.
+  - [ ] P66.2c Keep the redesign as the canonical MKRF default rather than shipping it as an experimental sidecar variant.
+- [ ] P66.3 Prove the redesign against runtime outputs, docs, and release framing (`#182`)
+  - [ ] P66.3a Add focused regression coverage for the constant-absolute-gap CT behavior and its difference from the legacy proportional-gap rule.
+  - [ ] P66.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical `100000`-iteration even-flow smoke.
+  - [ ] P66.3c Inspect representative CT-vs-no-CT full-rotation harvested-volume behavior, rebuild parent/instance docs warning-clean, and record the `v0.0.2a1` framing in repo/GitHub surfaces.
+
 ### Detailed Next Steps Notes
 
+- Phase 66 CT redesign beyond legacy parity is now the active MKRF edge:
+  - the legacy proportional-gap CT model is now complete and retained only as a
+    benchmark/reference contract;
+  - the next canonical target is a constant-absolute-gap CT standing-yield
+    response anchored at CT age;
+  - the decision bar is CT-vs-no-CT full-rotation harvested-volume behavior,
+    not legacy-output mimicry; and
+  - this redesign is intended to ship as `v0.0.2a1` so it is not conflated
+    with the earlier `v0.0.1a1` alpha release.
 - Phase 65 archival-publication follow-up is complete:
   - `external/femic-mkrf-instance/data/legacy_mkrf/` is now published as a
     first-class repo-local archive/reference lane rather than only a scattered

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1785,24 +1785,29 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
 
 - [ ] P66.1 Record the redesign contract and release framing (`#182`)
   - [ ] P66.1a Update roadmap/planning surfaces so the next MKRF modeling lane is governed by `#182`.
-  - [ ] P66.1b Record the legacy proportional-gap CT model as benchmark/reference only and the constant-absolute-gap CT model as the new canonical target.
+  - [ ] P66.1b Record the legacy proportional-gap CT model as benchmark/reference only and the bucketed constant-absolute-gap CT model as the new canonical target.
   - [ ] P66.1c Record that the release boundary for this redesign is `v0.0.2a1`, not a continuation of `v0.0.1a1`.
-- [ ] P66.2 Replace canonical MKRF CT with a constant-absolute-gap standing-yield model (`#182`)
-  - [ ] P66.2a Rework canonical CT standing-yield logic so post-CT THN standing volume is anchored to CT-age removed volume rather than a constant proportional gap.
-  - [ ] P66.2b Preserve the CT treatment-year extraction signal, thinned AU transition contract, and CC follow-on behavior unless the redesign proves one of those contracts must change.
-  - [ ] P66.2c Keep the redesign as the canonical MKRF default rather than shipping it as an experimental sidecar variant.
+- [ ] P66.2 Replace canonical MKRF CT with a bucketed constant-absolute-gap standing-yield model (`#182`)
+  - [ ] P66.2a Replace the single schedulable `CT` treatment with 10-year midpoint CT bucket treatments (`CT40`, `CT50`, `CT60`, ...) covering age windows such as `35-44`, `45-54`, and `55-64`.
+  - [ ] P66.2b Emit per-bucket thinned AU/state lanes so each bucket uses a precompiled constant-absolute-gap post-CT standing response anchored to the bucket midpoint age.
+  - [ ] P66.2c Preserve explicit CT treatment-year extraction, thinned-lane semantics, and CC follow-on behavior while keeping the bucketed redesign as the canonical default rather than an experimental sidecar.
 - [ ] P66.3 Prove the redesign against runtime outputs, docs, and release framing (`#182`)
-  - [ ] P66.3a Add focused regression coverage for the constant-absolute-gap CT behavior and its difference from the legacy proportional-gap rule.
+  - [ ] P66.3a Add focused regression coverage for the bucketed constant-absolute-gap CT behavior and its difference from the legacy proportional-gap rule.
   - [ ] P66.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical `100000`-iteration even-flow smoke.
-  - [ ] P66.3c Inspect representative CT-vs-no-CT full-rotation harvested-volume behavior, rebuild parent/instance docs warning-clean, and record the `v0.0.2a1` framing in repo/GitHub surfaces.
+  - [ ] P66.3c Inspect representative lower-bucket and higher-bucket CT outputs, confirm CT-vs-no-CT full-rotation harvested-volume behavior, rebuild parent/instance docs warning-clean, and record the `v0.0.2a1` framing in repo/GitHub surfaces.
 
 ### Detailed Next Steps Notes
 
 - Phase 66 CT redesign beyond legacy parity is now the active MKRF edge:
   - the legacy proportional-gap CT model is now complete and retained only as a
     benchmark/reference contract;
-  - the next canonical target is a constant-absolute-gap CT standing-yield
-    response anchored at CT age;
+  - the next canonical target is a bucketed constant-absolute-gap CT
+    standing-yield response anchored at representative CT midpoint ages;
+  - the locked discretization contract is:
+    - 10-year midpoint treatment buckets;
+    - labels `CT40`, `CT50`, `CT60`, ...;
+    - age windows `35-44`, `45-54`, `55-64`, ...; and
+    - per-bucket thinned AU/state lanes for auditability;
   - the decision bar is CT-vs-no-CT full-rotation harvested-volume behavior,
     not legacy-output mimicry; and
   - this redesign is intended to ship as `v0.0.2a1` so it is not conflated

--- a/docs/sample-models/mkrf.rst
+++ b/docs/sample-models/mkrf.rst
@@ -74,18 +74,24 @@ The practical handoff is:
 Commercial thinning follow-up
 -----------------------------
 
-The post-release CT follow-up is now governed by ``#180`` rather than the
-original rebuild-closeout issue.
+The current post-release CT redesign is governed by ``#182`` rather than the
+earlier legacy-parity follow-up issue.
 
-That follow-up uses the legacy source XML and accepted PoC XML as the
-behavioral contract for CT:
+Legacy and PoC CT behavior remains documented as benchmark/reference:
 
 - treatment-year CT extraction = ``0.4 * base curve``; and
 - post-thin THN standing yield for later ages = ``0.6 * base curve(x)``.
 
-This is a constant proportional gap model, not a constant absolute gap model.
+That is a constant proportional gap model, not the current canonical target.
+
+The active canonical redesign now uses bucketed CT treatments
+(``CT40``, ``CT50``, ``CT60``, ...) and bucket-specific thinned lanes so the
+canonical runtime can approximate a constant-absolute-gap response legally in
+ForestModel XML. The intended release boundary for that redesign is
+``v0.0.2a1`` so it is not conflated with the original ``v0.0.1a1`` alpha line.
+
 Use the standalone instance treatment/state page for the exact current
-canonical CT wording and evidence pointers.
+canonical CT wording, bucket layout, and evidence pointers.
 
 Current ``v0`` checkpoint signal
 --------------------------------

--- a/planning/mkrf_femic_native_rebuild.md
+++ b/planning/mkrf_femic_native_rebuild.md
@@ -1970,12 +1970,25 @@ Treat the current legacy/PoC CT behavior as benchmark/reference only:
 - post-thin standing THN yield for later ages:
   `0.6 * base curve(x)`
 
-The next canonical target is instead a constant-absolute-gap model:
+The next canonical target is instead a bucketed constant-absolute-gap model:
 
 - CT treatment-year extraction remains anchored at CT age; and
 - post-CT THN standing volume should follow
   `base curve(x) - 0.4 * base curve(x_ct)` rather than a constant proportional
   gap.
+
+Because canonical ForestModel XML does not expose a clean dynamic "age at
+which CT was applied" state hook for this use case, the redesign will
+discretize CT into precompiled treatment buckets rather than a single
+continuous-age treatment.
+
+Locked bucket contract:
+
+- 10-year midpoint buckets;
+- treatment labels `CT40`, `CT50`, `CT60`, ...;
+- age windows `35-44`, `45-54`, `55-64`, ...; and
+- per-bucket thinned AU/state lanes so extracted and residual curves stay
+  auditable by bucket anchor age.
 
 ### Required runtime boundary
 
@@ -1984,7 +1997,7 @@ runtime contract:
 
 - CT eligibility remains
   `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'thn_')`;
-- CT remains a transition to `au='thn_'+au`;
+- CT remains a transition to bucket-specific `thn_` AU/state lanes;
 - CC remains valid from the thinned lane and returns the stand to the
   treated/post-clearcut pathway; and
 - no new end-user CT knobs are introduced in this phase.
@@ -1999,6 +2012,8 @@ The redesign should be treated as successful only if:
 - CT treatment-year extraction remains explicit and nonzero;
 - post-CT standing volume no longer drifts farther behind untreated curves
   solely because of the old proportional-gap artifact; and
+- representative lower-bucket and higher-bucket CT outputs both remain
+  numerically coherent under the precompiled bucket response contract; and
 - the resulting CT + CC full-rotation harvested-volume behavior is defensible
   relative to the no-CT baseline.
 

--- a/planning/mkrf_femic_native_rebuild.md
+++ b/planning/mkrf_femic_native_rebuild.md
@@ -1996,8 +1996,9 @@ Unless the redesign proves otherwise, preserve the rest of the accepted CT
 runtime contract:
 
 - CT eligibility remains
-  `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'thn_')`;
-- CT remains a transition to bucket-specific `thn_` AU/state lanes;
+  `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'thn')`;
+- CT remains a transition to bucket-specific `thn040_`, `thn050_`, ... AU/state
+  lanes;
 - CC remains valid from the thinned lane and returns the stand to the
   treated/post-clearcut pathway; and
 - no new end-user CT knobs are introduced in this phase.
@@ -2023,3 +2024,36 @@ This redesign is intended to ship as MKRF release `v0.0.2a1`.
 
 That release tag must remain distinct from `v0.0.1a1`, which now refers to the
 legacy-parity CT checkpoint rather than the redesign.
+
+### Implementation result
+
+Phase 66 is now implemented on the active `#182` branch.
+
+The canonical MKRF runtime lane now:
+
+- emits bucketed CT treatments `CT40`, `CT50`, `CT60`, ... with 10-year age
+  windows and per-bucket thinned AU/state lanes;
+- uses bucket-anchored CT extracted-product curves:
+  `0.4 * base_curve(x_ct_bucket)`;
+- uses bucketed constant-absolute-gap post-CT standing curves:
+  `max(0, base_curve(x) - 0.4 * base_curve(x_ct_bucket))`; and
+- harvests the residual standing lane for non-CT products on thinned tracks so
+  follow-on `CC` behavior is numerically coherent.
+
+Representative rebuilt track checks from the canonical runtime package now show
+the intended constant-gap arithmetic:
+
+- `CT40` example:
+  - age `60`: `73.64 + 324.66 = 398.3`
+  - age `100`: `73.64 + 691.16 = 764.8`
+- `CT100` example:
+  - age `100`: `305.92 + 458.88 = 764.8`
+  - age `120`: `305.92 + 589.38 = 895.3`
+
+Validation completed for the MKRF lane:
+
+- focused runtime-package tests passed;
+- canonical runtime package regeneration passed;
+- Matrix Builder run `mkrf_ct_bucket_matrix_20260502b` passed;
+- canonical even-flow smoke `mkrf_ct_bucket_smoke_20260502b` passed; and
+- runtime sanity audit reported `rows=24 failures=0`.

--- a/planning/mkrf_femic_native_rebuild.md
+++ b/planning/mkrf_femic_native_rebuild.md
@@ -23,6 +23,8 @@ Current post-release status:
 - the CT legacy-parity repair under `#180` is complete; and
 - the follow-on archival/reference publication issue
   `UBC-FRESH/femic-mkrf-instance#1` is now also complete.
+- the next MKRF modeling lane is the post-legacy CT redesign governed by
+  `#182`.
 
 It starts after the legacy archaeology / PoC benchmark program recorded in:
 
@@ -1953,3 +1955,56 @@ The archival-publication issue is now complete:
   lane; and
 - `femic-mkrf-instance#1` is closed after the standalone docs rebuilt
   warning-clean.
+
+## Post-legacy MKRF CT redesign (`#182`)
+
+The next MKRF modeling phase is no longer about legacy parity or publication.
+It is a canonical CT redesign beyond the legacy proportional-gap model.
+
+### Governing redesign contract
+
+Treat the current legacy/PoC CT behavior as benchmark/reference only:
+
+- treatment-year CT extraction:
+  `0.4 * base curve`
+- post-thin standing THN yield for later ages:
+  `0.6 * base curve(x)`
+
+The next canonical target is instead a constant-absolute-gap model:
+
+- CT treatment-year extraction remains anchored at CT age; and
+- post-CT THN standing volume should follow
+  `base curve(x) - 0.4 * base curve(x_ct)` rather than a constant proportional
+  gap.
+
+### Required runtime boundary
+
+Unless the redesign proves otherwise, preserve the rest of the accepted CT
+runtime contract:
+
+- CT eligibility remains
+  `status in managed and oper in operable and ct eq 'Y' and not startswith(au,'thn_')`;
+- CT remains a transition to `au='thn_'+au`;
+- CC remains valid from the thinned lane and returns the stand to the
+  treated/post-clearcut pathway; and
+- no new end-user CT knobs are introduced in this phase.
+
+### Decision bar
+
+Judge the redesign primarily on CT-vs-no-CT full-rotation harvested-volume
+behavior.
+
+The redesign should be treated as successful only if:
+
+- CT treatment-year extraction remains explicit and nonzero;
+- post-CT standing volume no longer drifts farther behind untreated curves
+  solely because of the old proportional-gap artifact; and
+- the resulting CT + CC full-rotation harvested-volume behavior is defensible
+  relative to the no-CT baseline.
+
+### Release framing
+
+This redesign is intended to ship as MKRF release `v0.0.2a1`.
+
+That release tag must remain distinct from `v0.0.1a1`, which now refers to the
+legacy-parity CT checkpoint rather than the redesign.

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -99,10 +99,35 @@ def _normalize_species_bucket(species_code: str) -> str:
 
 
 _SPECIES_BUCKETS = ("Ba", "Cw", "Dec", "Dr", "Fd", "Hw", "Oth", "Yc")
+_MKRF_CT_BUCKET_ANCHORS = tuple(range(40, 151, 10))
+_MKRF_CT_BUCKET_WIDTH = 10
+_MKRF_CT_BUCKET_PREFIX_WIDTH = 3
 
 
 def _build_lookup_expr(keys: list[str], values: list[str], *, key_expr: str) -> str:
     return f"lookupTable({key_expr},'{','.join(keys)}','{','.join(values)}')"
+
+
+def _mkrf_ct_bucket_label(anchor_age: int) -> str:
+    return f"CT{int(anchor_age)}"
+
+
+def _mkrf_ct_bucket_prefix(anchor_age: int) -> str:
+    return f"thn{int(anchor_age):0{_MKRF_CT_BUCKET_PREFIX_WIDTH}d}_"
+
+
+def _mkrf_ct_bucket_specs() -> tuple[dict[str, int | str], ...]:
+    half_width = _MKRF_CT_BUCKET_WIDTH // 2
+    return tuple(
+        {
+            "anchor_age": int(anchor_age),
+            "label": _mkrf_ct_bucket_label(anchor_age),
+            "prefix": _mkrf_ct_bucket_prefix(anchor_age),
+            "min_age": int(anchor_age) - half_width,
+            "max_age": int(anchor_age) + half_width - 1,
+        }
+        for anchor_age in _MKRF_CT_BUCKET_ANCHORS
+    )
 
 
 def _build_managed_species_share_table(
@@ -2022,8 +2047,11 @@ def initialize_mkrf_runtime_package(
     first_growth_curve_lookup_rows = [row for row in curve_ref_rows if row["first_growth_curve_id"]]
     first_growth_curve_au_ids = [str(row["au_id"]) for row in first_growth_curve_lookup_rows]
     first_growth_curve_ids = [str(row["first_growth_curve_id"]) for row in first_growth_curve_lookup_rows]
-    runtime_base_au_expr = "if(startswith(au,'thn_'),substring(au,4),au)"
-    runtime_state_expr = "if(startswith(au,'thn_'),'THN',statecode)"
+    ct_bucket_specs = _mkrf_ct_bucket_specs()
+    runtime_base_au_expr = (
+        f"if(startswith(au,'thn'),substring(au,{len(_mkrf_ct_bucket_prefix(40))}),au)"
+    )
+    runtime_state_expr = "if(startswith(au,'thn'),'THN',statecode)"
     managed_curve_lookup_expr = _build_lookup_expr(
         managed_curve_au_ids,
         managed_curve_ids,
@@ -2128,13 +2156,93 @@ def initialize_mkrf_runtime_package(
         )
         for share_column in managed_share_label_map
     }
+    first_growth_by_au = {
+        str(au_id): group.sort_values("age", kind="stable")
+        for au_id, group in first_growth_curves.groupby("au_id", sort=True)
+    }
+    managed_by_au = {
+        str(au_id): group.sort_values("age", kind="stable")
+        for au_id, group in managed_curves.groupby("au_id", sort=True)
+    }
+
+    def _curve_group_value_at_age(curve_group: pd.DataFrame, age: int) -> float:
+        if curve_group.empty:
+            return 0.0
+        x_vals = curve_group["age"].astype(float).to_numpy()
+        y_vals = curve_group["volume"].astype(float).to_numpy()
+        return float(np.interp(float(age), x_vals, y_vals))
+
+    bucketed_thn_keys: list[str] = []
+    natural_bucketed_thn_curve_ids: list[str] = []
+    treated_bucketed_thn_curve_ids: list[str] = []
+    ct_product_keys: list[str] = []
+    natural_ct_product_curve_ids: list[str] = []
+    treated_ct_product_curve_ids: list[str] = []
+    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(index=False):
+        au_id = str(row.au_id)
+        managed_group = managed_by_au.get(au_id)
+        if managed_group is None or managed_group.empty:
+            continue
+        natural_group = first_growth_by_au.get(au_id, managed_group)
+        au_token = au_id.upper().replace("-", "_")
+        for bucket_spec in ct_bucket_specs:
+            anchor_age = int(bucket_spec["anchor_age"])
+            bucket_prefix = str(bucket_spec["prefix"])
+            bucket_label = str(bucket_spec["label"])
+            natural_gap = round(_curve_group_value_at_age(natural_group, anchor_age) * 0.4, 6)
+            treated_gap = round(_curve_group_value_at_age(managed_group, anchor_age) * 0.4, 6)
+            natural_residual_curve_id = f"THN{anchor_age:03d}_FG_{au_token}"
+            treated_residual_curve_id = f"THN{anchor_age:03d}_MG_{au_token}"
+            natural_extraction_curve_id = f"CT{anchor_age:03d}_FG_{au_token}"
+            treated_extraction_curve_id = f"CT{anchor_age:03d}_MG_{au_token}"
+            bucketed_thn_keys.append(f"{bucket_prefix}{au_id}")
+            natural_bucketed_thn_curve_ids.append(natural_residual_curve_id)
+            treated_bucketed_thn_curve_ids.append(treated_residual_curve_id)
+            ct_product_keys.append(f"{bucket_label}|{au_id}")
+            natural_ct_product_curve_ids.append(natural_extraction_curve_id)
+            treated_ct_product_curve_ids.append(treated_extraction_curve_id)
     origin_curve_lookup_expr = (
         "if(origin eq 'natural' and hasnatcurve eq 'Y',"
         f"curveId({first_growth_curve_lookup_expr}),"
         f"curveId({managed_curve_lookup_expr}))"
     )
-    standing_thinning_factor_expr = "if(startswith(au,'thn_'),0.6,1)"
-    ct_extraction_factor_expr = "if(treatment eq 'CT',0.4,1)"
+    natural_bucketed_thn_curve_lookup_expr = _build_lookup_expr(
+        bucketed_thn_keys,
+        natural_bucketed_thn_curve_ids,
+        key_expr="au",
+    )
+    treated_bucketed_thn_curve_lookup_expr = _build_lookup_expr(
+        bucketed_thn_keys,
+        treated_bucketed_thn_curve_ids,
+        key_expr="au",
+    )
+    ct_product_key_expr = f"treatment+'|'+{runtime_base_au_expr}"
+    natural_ct_product_curve_lookup_expr = _build_lookup_expr(
+        ct_product_keys,
+        natural_ct_product_curve_ids,
+        key_expr=ct_product_key_expr,
+    )
+    treated_ct_product_curve_lookup_expr = _build_lookup_expr(
+        ct_product_keys,
+        treated_ct_product_curve_ids,
+        key_expr=ct_product_key_expr,
+    )
+    standing_curve_expr = (
+        f"if(startswith(au,'thn'),"
+        "curveId("
+        f"if(origin eq 'natural',{natural_bucketed_thn_curve_lookup_expr},"
+        f"{treated_bucketed_thn_curve_lookup_expr})"
+        "),"
+        f"{origin_curve_lookup_expr})"
+    )
+    product_curve_expr = (
+        "if(startswith(treatment,'CT'),"
+        "curveId("
+        f"if(origin eq 'natural',{natural_ct_product_curve_lookup_expr},"
+        f"{treated_ct_product_curve_lookup_expr})"
+        "),"
+        f"{standing_curve_expr})"
+    )
     for obsolete_path in (
         tracks_dir / "au_runtime_status.csv",
         tracks_dir / "au_curve_refs.csv",
@@ -2196,14 +2304,6 @@ def initialize_mkrf_runtime_package(
             au_node.set("note", str(row.runtime_curve_note))
     et.ElementTree(root).write(xml_contract_path, encoding="utf-8", xml_declaration=True)
 
-    first_growth_by_au = {
-        str(au_id): group.sort_values("age", kind="stable")
-        for au_id, group in first_growth_curves.groupby("au_id", sort=True)
-    }
-    managed_by_au = {
-        str(au_id): group.sort_values("age", kind="stable")
-        for au_id, group in managed_curves.groupby("au_id", sort=True)
-    }
     curve_bank_root = et.Element(
         "mkrfRuntimeCurveBank",
         {
@@ -2292,6 +2392,77 @@ def initialize_mkrf_runtime_package(
                         "point",
                         {"x": str(float(curve_row.age)), "y": str(float(curve_row.volume))},
                     )
+        managed_group = managed_by_au.get(str(row.au_id))
+        if managed_group is None or managed_group.empty:
+            continue
+        natural_group = first_growth_by_au.get(str(row.au_id), managed_group)
+        for bucket_spec in ct_bucket_specs:
+            anchor_age = int(bucket_spec["anchor_age"])
+            natural_gap = round(_curve_group_value_at_age(natural_group, anchor_age) * 0.4, 6)
+            treated_gap = round(_curve_group_value_at_age(managed_group, anchor_age) * 0.4, 6)
+            natural_residual_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"THN{anchor_age:03d}_FG_{au_token}"},
+            )
+            treated_residual_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"THN{anchor_age:03d}_MG_{au_token}"},
+            )
+            natural_extraction_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"CT{anchor_age:03d}_FG_{au_token}"},
+            )
+            treated_extraction_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"CT{anchor_age:03d}_MG_{au_token}"},
+            )
+            age_values = sorted(
+                {
+                    float(point.age)
+                    for point in natural_group.itertuples(index=False)
+                    if np.isfinite(float(point.age))
+                }
+                | {
+                    float(point.age)
+                    for point in managed_group.itertuples(index=False)
+                    if np.isfinite(float(point.age))
+                }
+            )
+            if not age_values:
+                age_values = [0.0, 100.0]
+            for age_value in age_values:
+                natural_volume = _curve_group_value_at_age(natural_group, int(age_value))
+                treated_volume = _curve_group_value_at_age(managed_group, int(age_value))
+                et.SubElement(
+                    natural_residual_curve,
+                    "point",
+                    {
+                        "x": str(float(age_value)),
+                        "y": str(max(0.0, natural_volume - natural_gap)),
+                    },
+                )
+                et.SubElement(
+                    treated_residual_curve,
+                    "point",
+                    {
+                        "x": str(float(age_value)),
+                        "y": str(max(0.0, treated_volume - treated_gap)),
+                    },
+                )
+                et.SubElement(
+                    natural_extraction_curve,
+                    "point",
+                    {"x": str(float(age_value)), "y": str(max(0.0, natural_gap))},
+                )
+                et.SubElement(
+                    treated_extraction_curve,
+                    "point",
+                    {"x": str(float(age_value)), "y": str(max(0.0, treated_gap))},
+                )
     define_specs = (
         {"field": "status", "column": "CONTCLAS"},
         {"field": "origin", "column": origin_lookup_expr},
@@ -2435,28 +2606,34 @@ def initialize_mkrf_runtime_package(
         {
             "statement": (
                 "status in managed and oper in operable and ct eq 'Y' "
-                "and not startswith(au,'thn_')"
+                "and not startswith(au,'thn')"
             )
         },
     )
     ct_track = et.SubElement(ct_select, "track")
-    ct_treatment = et.SubElement(
-        ct_track,
-        "treatment",
-        {"label": "CT", "minage": "40", "maxage": "150", "retain": "20"},
-    )
-    ct_produce = et.SubElement(ct_treatment, "produce")
-    et.SubElement(
-        ct_produce,
-        "assign",
-        {"field": "treatment", "value": "'CT'"},
-    )
-    ct_transition = et.SubElement(ct_treatment, "transition")
-    et.SubElement(
-        ct_transition,
-        "assign",
-        {"field": "au", "value": "'thn_'+au"},
-    )
+    for bucket_spec in ct_bucket_specs:
+        ct_treatment = et.SubElement(
+            ct_track,
+            "treatment",
+            {
+                "label": str(bucket_spec["label"]),
+                "minage": str(int(bucket_spec["min_age"])),
+                "maxage": str(int(bucket_spec["max_age"])),
+                "retain": "20",
+            },
+        )
+        ct_produce = et.SubElement(ct_treatment, "produce")
+        et.SubElement(
+            ct_produce,
+            "assign",
+            {"field": "treatment", "value": f"'{str(bucket_spec['label'])}'"},
+        )
+        ct_transition = et.SubElement(ct_treatment, "transition")
+        et.SubElement(
+            ct_transition,
+            "assign",
+            {"field": "au", "value": f"'{str(bucket_spec['prefix'])}'+au"},
+        )
     area_features_select = et.SubElement(forestmodel_root, "select")
     area_features = et.SubElement(area_features_select, "features")
     area_total_attr = et.SubElement(
@@ -2498,7 +2675,7 @@ def initialize_mkrf_runtime_package(
         managed_yield_total,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
+            "statement": standing_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2512,7 +2689,7 @@ def initialize_mkrf_runtime_package(
         managed_yield_state,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
+            "statement": standing_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2554,8 +2731,7 @@ def initialize_mkrf_runtime_package(
             "expression",
             {
                 "statement": (
-                    f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}"
-                    f"*({origin_share_lookup_exprs[share_column]})"
+                    f"{standing_curve_expr}*({origin_share_lookup_exprs[share_column]})"
                 ),
                 "by": "1",
                 "ignoreMissingAttributes": "false",
@@ -2576,7 +2752,7 @@ def initialize_mkrf_runtime_package(
         unmanaged_yield_total,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
+            "statement": standing_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2590,7 +2766,7 @@ def initialize_mkrf_runtime_package(
         unmanaged_yield_state,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}",
+            "statement": standing_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2606,8 +2782,7 @@ def initialize_mkrf_runtime_package(
             "expression",
             {
                 "statement": (
-                    f"{origin_curve_lookup_expr}*{standing_thinning_factor_expr}"
-                    f"*({origin_share_lookup_exprs[share_column]})"
+                    f"{standing_curve_expr}*({origin_share_lookup_exprs[share_column]})"
                 ),
                 "by": "1",
                 "ignoreMissingAttributes": "false",
@@ -2646,7 +2821,7 @@ def initialize_mkrf_runtime_package(
         product_yield_total,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}",
+            "statement": product_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2660,7 +2835,7 @@ def initialize_mkrf_runtime_package(
         product_yield_state,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}",
+            "statement": product_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },
@@ -2676,8 +2851,7 @@ def initialize_mkrf_runtime_package(
             "expression",
             {
                 "statement": (
-                    f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}"
-                    f"*({origin_share_lookup_exprs[share_column]})"
+                    f"{product_curve_expr}*({origin_share_lookup_exprs[share_column]})"
                 ),
                 "by": "1",
                 "ignoreMissingAttributes": "false",
@@ -2692,7 +2866,7 @@ def initialize_mkrf_runtime_package(
         product_yield_treat,
         "expression",
         {
-            "statement": f"{origin_curve_lookup_expr}*{ct_extraction_factor_expr}",
+            "statement": product_curve_expr,
             "by": "1",
             "ignoreMissingAttributes": "false",
         },

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -385,12 +385,12 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert '<attribute label="%f.area.%m.total">' in forestmodel_text
     assert '<attribute label="%f.area.%m.seral.le10">' in forestmodel_text
     assert (
-        "<attribute label=\"'%f.area.%m.state.'+if(startswith(au,'thn_'),'THN',statecode)\""
+        "<attribute label=\"'%f.area.%m.state.'+if(startswith(au,'thn'),'THN',statecode)\""
         in forestmodel_text
     )
     assert '<attribute label="%f.yield.%m.total">' in forestmodel_text
     assert (
-        "<attribute label=\"'%f.yield.%m.state.'+if(startswith(au,'thn_'),'THN',statecode)\""
+        "<attribute label=\"'%f.yield.%m.state.'+if(startswith(au,'thn'),'THN',statecode)\""
         in forestmodel_text
     )
     assert '<attribute label="%f.yield.%m.merch.total">' in forestmodel_text
@@ -401,8 +401,8 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert 'select statement="status in unmanaged"' in forestmodel_text
     assert "hasfg eq" not in forestmodel_text
     assert "startswith(au,'em_')" not in forestmodel_text
-    assert "startswith(au,'thn_')" in forestmodel_text
-    assert "substring(au,4)" in forestmodel_text
+    assert "startswith(au,'thn')" in forestmodel_text
+    assert "substring(au,7)" in forestmodel_text
     assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Ba">') == 2
     assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Cw">') == 2
     assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Dr">') == 2
@@ -415,23 +415,26 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert '<attribute label="product.yield.managed.indsp.Ba">' in forestmodel_text
     assert '<attribute label="\'product.yield.managed.treat.\'+treatment">' in forestmodel_text
     assert "if(origin eq 'natural' and hasnatcurve eq 'Y'," in forestmodel_text
-    assert (
-        "curveId(lookupTable(if(startswith(au,'thn_'),substring(au,4),au),"
-        "'cwh_vm_1_dr_hw,cwh_vm_1_hw_cw',"
-        in forestmodel_text
-    )
-    assert "if(startswith(au,'thn_'),0.6,1)" in forestmodel_text
-    assert "if(treatment eq 'CT',0.4,1)" in forestmodel_text
+    assert "lookupTable(treatment+'|'+if(startswith(au,'thn'),substring(au,7),au)," in forestmodel_text
+    assert "'CT40|cwh_vm_1_dr_hw,CT50|cwh_vm_1_dr_hw" in forestmodel_text
+    assert "startswith(treatment,'CT')" in forestmodel_text
+    assert "if(startswith(au,'thn'),curveId(" in forestmodel_text
+    assert "),if(startswith(au,'thn'),curveId(" in forestmodel_text
+    assert "if(startswith(au,'thn_'),0.6,1)" not in forestmodel_text
+    assert "if(treatment eq 'CT',0.4,1)" not in forestmodel_text
     assert '<curve idref="unity"' in forestmodel_text
     assert '<curve idref="le10"' in forestmodel_text
     assert 'select statement="status in managed and oper in operable"' in forestmodel_text
     assert 'select statement="status in managed"' in forestmodel_text
-    assert "not startswith(au,'thn_')" in forestmodel_text
-    assert "'thn_'+au" in forestmodel_text
+    assert "not startswith(au,'thn')" in forestmodel_text
+    assert "'thn040_'+au" in forestmodel_text
+    assert "'thn150_'+au" in forestmodel_text
     assert 'field="statecode" value="\'THN\'"' not in forestmodel_text
     assert "<track>" in forestmodel_text
     assert 'treatment label="CC"' in forestmodel_text
-    assert 'treatment label="CT"' in forestmodel_text
+    assert 'treatment label="CT"' not in forestmodel_text
+    assert 'treatment label="CT40" minage="35" maxage="44" retain="20"' in forestmodel_text
+    assert 'treatment label="CT150" minage="145" maxage="154" retain="20"' in forestmodel_text
 
 
 def test_audit_mkrf_runtime_sanity_flags_zero_signal_with_nonzero_source_share(


### PR DESCRIPTION
﻿## Summary
- replace canonical MKRF CT with bucketed constant-absolute-gap treatments (`CT40`, `CT50`, `CT60`, ...)
- regenerate the canonical MKRF runtime package and update instance/operator docs
- record Phase 66 completion and `v0.0.2a1` release framing

## Validation
- `python -m pytest tests/test_mkrf_runtime_package.py -q`
- `python -m ruff check src/femic/workflows/mkrf.py tests/test_mkrf_runtime_package.py`
- `python -m femic instance mkrf-init-runtime-package --instance-root external/femic-mkrf-instance`
- `python -m femic patchworks matrix-build --instance-root external/femic-mkrf-instance --config config/patchworks.runtime.mkrf_rebuild.windows.yaml --run-id mkrf_ct_bucket_matrix_20260502b`
- `python -m femic patchworks run-default-scenario mkrf.base --run-id mkrf_ct_bucket_smoke_20260502b`
- `python -m femic instance mkrf-audit-runtime-sanity --instance-root external/femic-mkrf-instance --stage-dir runtime/logs/headless_stage/mkrf_ct_bucket_smoke_20260502b`
- `python -m sphinx -b html docs _build/html -W`
- `python -m sphinx -b html external/femic-mkrf-instance/docs external/femic-mkrf-instance/docs/_build/html -W`
- `python -m pytest tests/test_docs_contract.py::test_roadmap_is_a_compact_ordered_control_surface -q`
- `python -m pre_commit run --all-files`

## Notes
- repo-wide `mypy src` still fails on pre-existing stub/type issues outside this change set
- repo-wide `pytest` still has unrelated baseline failures outside the MKRF scope touched here
