### PR TITLE
P67.3 lock smoothed AU first-growth selector and TSA29 adoption

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17308,3 +17308,15 @@
     `femic-tsa29-instance` lane after the shared/default promotion lands; and
   - updated `ROADMAP.md` so Phase 67 now governs the shared/default promotion
     and TSA29 follow-on sequence.
+## 2026-05-10 - Audited where AU first-growth default-selection actually lives
+- `#187` / `P67.2a` audit checkpoint:
+  - confirmed `src/femic/pipeline/mkrf_first_growth.py` already hard-codes the
+    AU-level direct-fit selection to `smoothed_bin_pchip`;
+  - confirmed `src/femic/workflows/mkrf.py` already publishes that family into
+    MKRF runtime/metadata surfaces as the explicit first-growth curve family;
+  - confirmed `src/femic/pipeline/vdyp_stage.py` is still the older
+    stratum-level NLLS-oriented smoothing/fallback engine rather than a shared
+    AU-level first-growth default-selection seam; and
+  - recorded that the next implementation move must be a real shared/default
+    surface introduction under `P67.2b`, not a cosmetic flag flip in the
+    legacy stratum smoother.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17299,3 +17299,12 @@
     BCDC/pipeline runtime artifacts; and
   - reduced the parent worktree back to the intentional tracked public-data
     pointer update instead of hundreds of untracked TSA29 runtime files.
+## 2026-05-10 - Opened the smoothed AU-level VDYP first-growth promotion lane
+- `#187` / `#188` planning and tracker kickoff:
+  - opened parent feature issue `#187` to promote `smoothed_bin_pchip` as the
+    official default for AU-level first-growth / unmanaged VDYP synthesis,
+    using the accepted MKRF evidence from `#177` / `#173`;
+  - opened TSA29-only child issue `#188` to adopt that promoted default on the
+    `femic-tsa29-instance` lane after the shared/default promotion lands; and
+  - updated `ROADMAP.md` so Phase 67 now governs the shared/default promotion
+    and TSA29 follow-on sequence.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17320,3 +17320,16 @@
   - recorded that the next implementation move must be a real shared/default
     surface introduction under `P67.2b`, not a cosmetic flag flip in the
     legacy stratum smoother.
+## 2026-05-10 - Added a reusable AU-level first-growth default-selection seam
+- `#187` / `P67.2b` shared-surface implementation:
+  - added `src/femic/pipeline/au_first_growth.py` as the reusable AU-level
+    first-growth selector implementing the promoted `smoothed_bin_pchip`
+    default path and explicit `insufficient_source_stands` fallback;
+  - switched `src/femic/pipeline/mkrf_first_growth.py` to consume that shared
+    selector instead of carrying the default-selection logic only as MKRF-local
+    private helpers;
+  - exported the new shared surface through `src/femic/pipeline/__init__.py`;
+  - added focused regression coverage in `tests/test_au_first_growth.py`; and
+  - kept `src/femic/pipeline/vdyp_stage.py` unchanged so the older
+    stratum-level NLLS-oriented smoothing path remains available for legacy
+    callers while the AU-level default-promotion lane moves forward.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17333,3 +17333,12 @@
   - kept `src/femic/pipeline/vdyp_stage.py` unchanged so the older
     stratum-level NLLS-oriented smoothing path remains available for legacy
     callers while the AU-level default-promotion lane moves forward.
+## 2026-05-10 - Updated docs/contracts framing for the promoted AU first-growth default
+- `#187` / `P67.2c` docs/contracts/test update:
+  - corrected the stale MKRF planning contract language that still described
+    AU-level first-growth synthesis as an NLLS-default lane;
+  - updated the diagnostics and pipeline guide surfaces so
+    `smoothed_bin_pchip` is described as the official AU-level first-growth
+    default and NLLS is clearly legacy/fallback; and
+  - added a focused docs-contract test to keep that default-method framing from
+    drifting back.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17342,3 +17342,23 @@
     default and NLLS is clearly legacy/fallback; and
   - added a focused docs-contract test to keep that default-method framing from
     drifting back.
+## 2026-05-10 - Locked the accepted smoothed AU first-growth selector and TSA29 curve library
+- `#187` / `#188` / `P67.3a-P67.3c` selector-and-artifact lock:
+  - switched the TSA29 unmanaged VDYP smoothing lane onto the shared
+    AU-level selector in `src/femic/pipeline/au_first_growth.py` and
+    kept that selector as the promoted shared/default surface in the parent repo;
+  - locked the accepted selector contract at:
+    - minimum trusted source-bin age `60`;
+    - maximum trusted source-bin age `300`;
+    - seven-point / four-pass smoothing;
+    - local early-window left-bin censoring; and
+    - legacy exponential toe splice blended into the smoothed PCHIP body;
+  - regenerated and accepted the TSA29 curve artifact library:
+    - `data/vdyp_curves_smooth-tsa29.feather`;
+    - `plots/vdyp_fitdiag_tsa29-*.png`;
+    - `plots/vdyp_lmh_tsa29-*.png`; and
+    - `evidence/curve_selection_summary-tsa29-p67_3b_tsa29_smoothed_default_20260510g.csv`;
+  - confirmed the accepted selector still chooses `smoothed_bin_pchip` for all
+    `54` TSA29 AU/stratum-SI rows; and
+  - recorded that there are currently no TSA29
+    `insufficient_source_stands` rows under the accepted selector contract.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1855,7 +1855,7 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P67.1b Open the TSA29-only child issue and record the downstream adoption boundary (`#188`).
 - [ ] P67.2 Promote `smoothed_bin_pchip` to the default AU-level first-growth / unmanaged VDYP synthesis method (`#187`)
   - [x] P67.2a Audit where first-growth default-selection currently lives across the MKRF-specific builder and reusable VDYP-stage machinery.
-  - [ ] P67.2b Expose the promoted default without breaking legacy callers that still rely on older NLLS-oriented behavior.
+  - [x] P67.2b Expose the promoted default without breaking legacy callers that still rely on older NLLS-oriented behavior.
   - [ ] P67.2c Update docs/contracts/tests so `smoothed_bin_pchip` is the official default and NLLS is clearly legacy/fallback.
 - [ ] P67.3 Adopt the promoted default on the TSA29 instance lane (`#188`)
   - [ ] P67.3a Switch the TSA29 AU-level first-growth build path to the promoted default and regenerate the relevant instance outputs.
@@ -1881,14 +1881,22 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
       smoothing/fallback engine with NLLS-first selection paths such as
       `primary_nlls`, `reparameterized_nlls`, `censored_refit`,
       `tail_blend`, and `merchantable_floor`; and
-    - therefore the shared/default promotion cannot be implemented as a simple
-      one-line flag flip in `vdyp_stage.py`; `P67.2b` must introduce an
-      explicit reusable AU-level first-growth default-selection surface that
-      generalizes the MKRF builder rather than pretending the old stratum
-      smoother already owns this contract; and
-  - the next bounded move is `P67.2b`: implement that reusable/shared
-    default-selection surface and switch callers onto it without breaking
-    legacy NLLS-oriented paths; and
+    - therefore the shared/default promotion could not be implemented as a
+      simple one-line flag flip in `vdyp_stage.py`; and
+  - `P67.2b` is complete:
+    - added `src/femic/pipeline/au_first_growth.py` as the explicit reusable
+      AU-level first-growth default-selection seam;
+    - moved the generic `smoothed_bin_pchip` selection behavior into that new
+      shared helper instead of leaving it implicit inside the MKRF-only module;
+    - switched `src/femic/pipeline/mkrf_first_growth.py` to consume the shared
+      selector so MKRF now rides the same reusable default-selection surface we
+      intend to promote more broadly; and
+    - kept the older `src/femic/pipeline/vdyp_stage.py` stratum-level
+      NLLS-oriented smoothing engine unchanged, so legacy callers are not
+      broken by this promotion seam extraction; and
+  - the next bounded move is `P67.2c`: update the remaining docs/contracts
+    surfaces so `smoothed_bin_pchip` is described as the official default
+    first-growth method and NLLS is demoted to legacy/fallback framing; and
   - TSA29 adoption work stays parked behind that shared/default promotion and
     should proceed only through child issue `#188`.
 - Phase 66 bucketed CT redesign is now implemented on `#182`:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1853,13 +1853,14 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
 - [x] P67.1 Record the shared/default promotion lane for AU-level first-growth VDYP synthesis (`#187`)
   - [x] P67.1a Open the parent feature issue with the accepted MKRF evidence basis, rationale, and default-method acceptance criteria.
   - [x] P67.1b Open the TSA29-only child issue and record the downstream adoption boundary (`#188`).
-- [ ] P67.2 Promote `smoothed_bin_pchip` to the default AU-level first-growth / unmanaged VDYP synthesis method (`#187`)
+- [x] P67.2 Promote `smoothed_bin_pchip` to the default AU-level first-growth / unmanaged VDYP synthesis method (`#187`)
   - [x] P67.2a Audit where first-growth default-selection currently lives across the MKRF-specific builder and reusable VDYP-stage machinery.
   - [x] P67.2b Expose the promoted default without breaking legacy callers that still rely on older NLLS-oriented behavior.
   - [x] P67.2c Update docs/contracts/tests so `smoothed_bin_pchip` is the official default and NLLS is clearly legacy/fallback.
-- [ ] P67.3 Adopt the promoted default on the TSA29 instance lane (`#188`)
-  - [ ] P67.3a Switch the TSA29 AU-level first-growth build path to the promoted default and regenerate the relevant instance outputs.
-  - [ ] P67.3b Validate TSA29 residual/shape diagnostics against AU binned medians and record explicit insufficient-support AU treatment.
+- [x] P67.3 Adopt the promoted default on the TSA29 instance lane (`#188`)
+  - [x] P67.3a Switch the TSA29 AU-level first-growth build path to the promoted default and regenerate the relevant instance outputs.
+  - [x] P67.3b Patch the promoted selector to suppress low-age humps, far-right tail bumps, excess wobble, and bad toe shape, then rerun TSA29 diagnostics/outputs.
+  - [x] P67.3c Validate TSA29 residual/shape diagnostics against AU binned medians and record explicit insufficient-support AU treatment.
 
 ### Detailed Next Steps Notes
 
@@ -1902,11 +1903,34 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
       method and NLLS as legacy/fallback; and
     - added a focused docs-contract test so those surfaces must keep the
       promoted default framing in future changes; and
-  - the next bounded move is `P67.3a`: switch the TSA29 AU-level first-growth
-    build path to the promoted default and regenerate the relevant instance
-    outputs; and
-  - TSA29 adoption work stays parked behind that shared/default promotion and
-    should proceed only through child issue `#188`.
+  - `P67.3a` is complete:
+    - TSA29 now routes the legacy unmanaged VDYP smoothing lane through the
+      shared AU-level first-growth selector for TSA 29 only;
+    - the regenerated TSA29 curve-selection summary moved all `54`
+      stratum/SI rows from the older mixed NLLS/fallback family onto
+      `smoothed_bin_pchip`; and
+    - the downstream TSA29 `model_input_bundle` regeneration now runs cleanly
+      from the rebuilt untreated curve table; and
+  - `P67.3b` and `P67.3c` are complete:
+    - the accepted shared selector parameters now use:
+      - minimum trusted source-bin age `60`;
+      - maximum trusted source-bin age `300`;
+      - stronger seven-point / four-pass local smoothing;
+      - a local early-window left-bin censor rather than the rejected global
+        leading-anchor prune; and
+      - the legacy exponential toe splice on the left merged into the smoothed
+        PCHIP body;
+    - the accepted TSA29 instance curve library is the regenerated
+      `data/vdyp_curves_smooth-tsa29.feather` plus the paired fit-diagnostic
+      and L/M/H overlay plots under `plots/`;
+    - the accepted reviewer surface is
+      `evidence/curve_selection_summary-tsa29-p67_3b_tsa29_smoothed_default_20260510g.csv`;
+    - all `54` TSA29 AU/stratum-SI rows still select
+      `smoothed_bin_pchip`; and
+    - there are no current TSA29 `insufficient_source_stands` rows under the
+      accepted selector contract; and
+  - Phase 67 is now at the lock/commit surface for the accepted parent logic
+    and TSA29 artifact library on `#187` / `#188`.
 - Phase 66 bucketed CT redesign is now implemented on `#182`:
   - the canonical MKRF lane now emits `CT40`, `CT50`, `CT60`, ... bucket
     treatments with per-bucket `thn040_`, `thn050_`, ... thinned lanes;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1856,7 +1856,7 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
 - [ ] P67.2 Promote `smoothed_bin_pchip` to the default AU-level first-growth / unmanaged VDYP synthesis method (`#187`)
   - [x] P67.2a Audit where first-growth default-selection currently lives across the MKRF-specific builder and reusable VDYP-stage machinery.
   - [x] P67.2b Expose the promoted default without breaking legacy callers that still rely on older NLLS-oriented behavior.
-  - [ ] P67.2c Update docs/contracts/tests so `smoothed_bin_pchip` is the official default and NLLS is clearly legacy/fallback.
+  - [x] P67.2c Update docs/contracts/tests so `smoothed_bin_pchip` is the official default and NLLS is clearly legacy/fallback.
 - [ ] P67.3 Adopt the promoted default on the TSA29 instance lane (`#188`)
   - [ ] P67.3a Switch the TSA29 AU-level first-growth build path to the promoted default and regenerate the relevant instance outputs.
   - [ ] P67.3b Validate TSA29 residual/shape diagnostics against AU binned medians and record explicit insufficient-support AU treatment.
@@ -1894,9 +1894,17 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
     - kept the older `src/femic/pipeline/vdyp_stage.py` stratum-level
       NLLS-oriented smoothing engine unchanged, so legacy callers are not
       broken by this promotion seam extraction; and
-  - the next bounded move is `P67.2c`: update the remaining docs/contracts
-    surfaces so `smoothed_bin_pchip` is described as the official default
-    first-growth method and NLLS is demoted to legacy/fallback framing; and
+  - `P67.2c` is complete:
+    - corrected the stale MKRF planning contract text that still described
+      AU-level first-growth as an NLLS-default lane;
+    - updated the relevant diagnostics/pipeline guide text so
+      `smoothed_bin_pchip` is described as the official default first-growth
+      method and NLLS as legacy/fallback; and
+    - added a focused docs-contract test so those surfaces must keep the
+      promoted default framing in future changes; and
+  - the next bounded move is `P67.3a`: switch the TSA29 AU-level first-growth
+    build path to the promoted default and regenerate the relevant instance
+    outputs; and
   - TSA29 adoption work stays parked behind that shared/default promotion and
     should proceed only through child issue `#188`.
 - Phase 66 bucketed CT redesign is now implemented on `#182`:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1854,7 +1854,7 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P67.1a Open the parent feature issue with the accepted MKRF evidence basis, rationale, and default-method acceptance criteria.
   - [x] P67.1b Open the TSA29-only child issue and record the downstream adoption boundary (`#188`).
 - [ ] P67.2 Promote `smoothed_bin_pchip` to the default AU-level first-growth / unmanaged VDYP synthesis method (`#187`)
-  - [ ] P67.2a Audit where first-growth default-selection currently lives across the MKRF-specific builder and reusable VDYP-stage machinery.
+  - [x] P67.2a Audit where first-growth default-selection currently lives across the MKRF-specific builder and reusable VDYP-stage machinery.
   - [ ] P67.2b Expose the promoted default without breaking legacy callers that still rely on older NLLS-oriented behavior.
   - [ ] P67.2c Update docs/contracts/tests so `smoothed_bin_pchip` is the official default and NLLS is clearly legacy/fallback.
 - [ ] P67.3 Adopt the promoted default on the TSA29 instance lane (`#188`)
@@ -1870,11 +1870,25 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
     the accepted direct first-growth family;
   - the promotion scope is intentionally limited to AU-level first-growth /
     unmanaged VDYP synthesis, not the managed lane;
-  - the next bounded move is `P67.2a`: audit exactly where first-growth
-    default-selection still lives across `src/femic/pipeline/mkrf_first_growth.py`
-    and `src/femic/pipeline/vdyp_stage.py`, then decide the smallest shared
-    code surface that can carry the promoted default without breaking legacy
-    callers; and
+  - `P67.2a` is complete:
+    - `src/femic/pipeline/mkrf_first_growth.py` already hard-codes the
+      AU-level first-growth direct-fit selection to `smoothed_bin_pchip`;
+    - `src/femic/workflows/mkrf.py` already publishes that family explicitly
+      into the MKRF runtime/metadata surfaces via
+      `firstGrowthCurveFamily = smoothed_bin_pchip`;
+    - `src/femic/pipeline/vdyp_stage.py` is not a shared AU-level
+      first-growth-default seam today; it is still the legacy stratum-level
+      smoothing/fallback engine with NLLS-first selection paths such as
+      `primary_nlls`, `reparameterized_nlls`, `censored_refit`,
+      `tail_blend`, and `merchantable_floor`; and
+    - therefore the shared/default promotion cannot be implemented as a simple
+      one-line flag flip in `vdyp_stage.py`; `P67.2b` must introduce an
+      explicit reusable AU-level first-growth default-selection surface that
+      generalizes the MKRF builder rather than pretending the old stratum
+      smoother already owns this contract; and
+  - the next bounded move is `P67.2b`: implement that reusable/shared
+    default-selection surface and switch callers onto it without breaking
+    legacy NLLS-oriented paths; and
   - TSA29 adoption work stays parked behind that shared/default promotion and
     should proceed only through child issue `#188`.
 - Phase 66 bucketed CT redesign is now implemented on `#182`:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1848,8 +1848,35 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P66.3b Regenerate the canonical runtime package, rerun Matrix Builder, and rerun the canonical `100000`-iteration even-flow smoke.
   - [x] P66.3c Inspect representative lower-bucket and higher-bucket CT outputs, confirm CT-vs-no-CT full-rotation harvested-volume behavior, rebuild parent/instance docs warning-clean, and record the `v0.0.2a1` framing in repo/GitHub surfaces.
 
+## Phase 67: Promote Smoothed AU-Level VDYP First-Growth Curves Beyond MKRF
+
+- [x] P67.1 Record the shared/default promotion lane for AU-level first-growth VDYP synthesis (`#187`)
+  - [x] P67.1a Open the parent feature issue with the accepted MKRF evidence basis, rationale, and default-method acceptance criteria.
+  - [x] P67.1b Open the TSA29-only child issue and record the downstream adoption boundary (`#188`).
+- [ ] P67.2 Promote `smoothed_bin_pchip` to the default AU-level first-growth / unmanaged VDYP synthesis method (`#187`)
+  - [ ] P67.2a Audit where first-growth default-selection currently lives across the MKRF-specific builder and reusable VDYP-stage machinery.
+  - [ ] P67.2b Expose the promoted default without breaking legacy callers that still rely on older NLLS-oriented behavior.
+  - [ ] P67.2c Update docs/contracts/tests so `smoothed_bin_pchip` is the official default and NLLS is clearly legacy/fallback.
+- [ ] P67.3 Adopt the promoted default on the TSA29 instance lane (`#188`)
+  - [ ] P67.3a Switch the TSA29 AU-level first-growth build path to the promoted default and regenerate the relevant instance outputs.
+  - [ ] P67.3b Validate TSA29 residual/shape diagnostics against AU binned medians and record explicit insufficient-support AU treatment.
+
 ### Detailed Next Steps Notes
 
+- Phase 67 smoothed AU-level first-growth promotion is now opened on `#187`
+  with TSA29 child issue `#188`:
+  - the accepted evidence basis is the recent MKRF curve-quality lane under
+    `#177` / `#173`, where AU-local `smoothed_bin_pchip` curves were adopted as
+    the accepted direct first-growth family;
+  - the promotion scope is intentionally limited to AU-level first-growth /
+    unmanaged VDYP synthesis, not the managed lane;
+  - the next bounded move is `P67.2a`: audit exactly where first-growth
+    default-selection still lives across `src/femic/pipeline/mkrf_first_growth.py`
+    and `src/femic/pipeline/vdyp_stage.py`, then decide the smallest shared
+    code surface that can carry the promoted default without breaking legacy
+    callers; and
+  - TSA29 adoption work stays parked behind that shared/default promotion and
+    should proceed only through child issue `#188`.
 - Phase 66 bucketed CT redesign is now implemented on `#182`:
   - the canonical MKRF lane now emits `CT40`, `CT50`, `CT60`, ... bucket
     treatments with per-bucket `thn040_`, `thn050_`, ... thinned lanes;

--- a/docs/guides/diagnostics-playbook.rst
+++ b/docs/guides/diagnostics-playbook.rst
@@ -24,6 +24,8 @@ VDYP Fit Diagnostics (``vdyp_fitdiag_*.png``)
 Healthy signals:
 
 - Smoothed curve tracks binned median trend.
+- For AU-level first-growth synthesis, the default accepted direct-fit family
+  is ``smoothed_bin_pchip`` rather than the older NLLS-first approach.
 - SI levels show coherent ordering when signal exists.
 - Tail handling avoids unrealistic late-age collapse/oscillation.
 
@@ -32,6 +34,8 @@ Red flags:
 - Outlier-driven overfit (for example impossible young-age volumes).
 - Inverted SI dominance where ecological signal should be monotonic.
 - Apparent fit to sparse/noisy bins without fallback/merge behavior.
+- Unexplained reversion to an older NLLS-oriented first-growth fit when the
+  canonical AU-level default should be ``smoothed_bin_pchip``.
 
 TIPSY vs VDYP Overlays (``tipsy_vdyp_*.png``)
 ---------------------------------------------

--- a/docs/guides/pipeline-overview.rst
+++ b/docs/guides/pipeline-overview.rst
@@ -113,6 +113,9 @@ Operator Interpretation Callouts
   before curve fitting is trusted.
 - ``vdyp_fitdiag_*.png`` should track binned medians; large early-age spikes
   or inverted SI ordering are red flags.
+- AU-level first-growth synthesis should default to the smoothed observed-bin
+  PCHIP family (``smoothed_bin_pchip``); treat older NLLS-oriented fits as
+  legacy/fallback behavior rather than the default story.
 - ``tipsy_vdyp_*.png`` should be coherent with intended untreated/treated story;
   if not, tune TIPSY config or use configured managed-curve transform mode.
 

--- a/planning/mkrf_femic_native_rebuild.md
+++ b/planning/mkrf_femic_native_rebuild.md
@@ -1002,15 +1002,17 @@ AU.
 The required curve-consolidation behavior is:
 
 - aggregate stand-level first-growth evidence to the canonical AU level;
-- fit AU-wise unmanaged/first-growth curves using the existing FEMIC NLLS
-  functions and policy style already used for K3Z; and
+- fit AU-wise unmanaged/first-growth curves using the accepted strongly
+  smoothed observed-bin PCHIP family (`smoothed_bin_pchip`) as the canonical
+  default direct-fit method, with the older AU-wise NLLS lane treated as
+  legacy/fallback rather than the default; and
 - publish AU-wise unmanaged/first-growth curves as the runtime-facing surface
   consumed by the canonical XML/track-generation lane.
 
 The legacy one-curve-per-stand first-growth implementation remains valid only
 as benchmark/reference evidence. It is not part of the canonical rebuild
-architecture unless a later benchmark gate proves the AU-wise NLLS approach is
-insufficient.
+architecture unless a later benchmark gate proves the canonical
+`smoothed_bin_pchip` approach is insufficient.
 
 ### Publication and acceptance rule
 
@@ -1019,8 +1021,9 @@ Before `P60.5a` can be considered satisfied, the rebuild lane should publish:
 - an explicit AU table proving the canonical AU key is being used;
 - traceable lineage from stand-level VDYP first-growth evidence into AU-wise
   first-growth surfaces; and
-- curve-fit diagnostics and acceptance checks for the AU-wise NLLS-fitted
-  unmanaged curves.
+- curve-fit diagnostics and acceptance checks for the AU-wise
+  `smoothed_bin_pchip` unmanaged curves, with any surviving NLLS-family use
+  called out explicitly as legacy/fallback behavior.
 
 In other words, `P60.5a` should consume the AU-wise first-growth lane, not
 recreate a stand-wise unmanaged curve contract inside the canonical runtime
@@ -1185,8 +1188,10 @@ The rebuild lane should compile AU-wise unmanaged/first-growth VDYP curves by:
   `P60.5b`;
 - aggregating the unmanaged/first-growth evidence to one AU-wise fitting lane
   per canonical `au_id`;
-- fitting one unmanaged/first-growth curve per canonical AU with the existing
-  FEMIC NLLS functions and policy style already used for K3Z; and
+- fitting one unmanaged/first-growth curve per canonical AU with the accepted
+  strongly smoothed observed-bin PCHIP family (`smoothed_bin_pchip`) as the
+  canonical default, while treating the older NLLS family as legacy/fallback
+  only; and
 - publishing both the AU-wise curve surface and its fit diagnostics as explicit
   canonical model-input artifacts.
 
@@ -1209,7 +1214,9 @@ The AU-wise first-growth lane should leave behind traceable lineage showing:
 - the canonical `au_id` each source record was assigned to;
 - the sample counts contributing to each AU fit;
 - the age/value domain used for fitting; and
-- the exact FEMIC NLLS policy family used for the accepted fit.
+- the exact accepted curve family used for the fit, with
+  `smoothed_bin_pchip` as the canonical default and any NLLS-family use marked
+  explicitly as legacy/fallback.
 
 ### Required diagnostics
 
@@ -1738,7 +1745,7 @@ The canonical runtime package must consume:
 That means the canonical XML and track-generation lane may not:
 
 - emit one unmanaged/first-growth curve per stand; or
-- bypass the AU-wise NLLS-fitted first-growth surface while still claiming a
+- bypass the AU-wise canonical first-growth surface while still claiming a
   canonical rebuild runtime package.
 
 ### Acceptance rule for `P60.8a`

--- a/src/femic/pipeline/__init__.py
+++ b/src/femic/pipeline/__init__.py
@@ -23,6 +23,12 @@ from femic.pipeline.io import (
     resolve_effective_run_options,
     resolve_legacy_external_data_paths,
 )
+from femic.pipeline.au_first_growth import (
+    AuFirstGrowthSelectionResult,
+    build_smoothed_bin_pchip_curve,
+    fit_au_first_growth_quality,
+    select_au_first_growth_curve,
+)
 from femic.pipeline.manifest import (
     build_run_manifest_payload,
     collect_runtime_versions,
@@ -386,4 +392,8 @@ __all__ = [
     "compile_strata_fit_results",
     "load_vdyp_input_tables",
     "load_or_build_vdyp_results_tsa",
+    "AuFirstGrowthSelectionResult",
+    "build_smoothed_bin_pchip_curve",
+    "fit_au_first_growth_quality",
+    "select_au_first_growth_curve",
 ]

--- a/src/femic/pipeline/au_first_growth.py
+++ b/src/femic/pipeline/au_first_growth.py
@@ -1,0 +1,158 @@
+"""Reusable AU-level first-growth curve selection helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy.interpolate import PchipInterpolator
+
+from femic.pipeline.vdyp_curves import build_observed_bins_for_fit
+
+
+_TAIL_START_AGE = 150.0
+_CURVE_MAX_AGE = 300
+_SMOOTHING_WEIGHTS = np.asarray([1.0, 2.0, 3.0, 2.0, 1.0], dtype=float)
+_SMOOTHING_WEIGHTS = _SMOOTHING_WEIGHTS / _SMOOTHING_WEIGHTS.sum()
+_SMOOTHING_PASSES = 2
+_DEFAULT_MIN_SOURCE_STANDS = 2
+
+
+@dataclass(frozen=True)
+class AuFirstGrowthSelectionResult:
+    """Selected AU-level first-growth curve and diagnostics."""
+
+    selected_path: str
+    accepted: bool
+    x_curve: np.ndarray
+    y_curve: np.ndarray
+    binned: pd.DataFrame
+    metrics: dict[str, float]
+
+
+def fit_au_first_growth_quality(
+    *,
+    binned: pd.DataFrame,
+    x_curve: np.ndarray,
+    y_curve: np.ndarray,
+    tail_start_age: float = _TAIL_START_AGE,
+) -> dict[str, float]:
+    """Measure fit quality against observed AU-level median bins."""
+    observed_age = np.asarray(binned["age_bin"].values, dtype=float)
+    observed_volume = np.asarray(binned["median_volume"].values, dtype=float)
+    fitted = np.interp(observed_age, x_curve, y_curve)
+    residual = fitted - observed_volume
+    abs_obs = np.maximum(np.abs(observed_volume), 1e-6)
+    rmse = float(np.sqrt(np.mean(np.square(residual))))
+    mape = float(np.mean(np.abs(residual) / abs_obs))
+    tail_mask = observed_age >= float(tail_start_age)
+    tail_rmse = (
+        float(np.sqrt(np.mean(np.square(residual[tail_mask]))))
+        if np.any(tail_mask)
+        else rmse
+    )
+    return {
+        "rmse": rmse,
+        "mape": mape,
+        "tail_rmse": tail_rmse,
+    }
+
+
+def build_smoothed_bin_pchip_curve(
+    *,
+    binned: pd.DataFrame,
+    smoothing_passes: int = _SMOOTHING_PASSES,
+    curve_max_age: int = _CURVE_MAX_AGE,
+    min_anchor_age: float = 30.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a strongly smoothed observed-bin PCHIP curve."""
+    anchors = binned.loc[:, ["age_bin", "median_volume"]].copy()
+    anchors["age_bin"] = pd.to_numeric(anchors["age_bin"], errors="coerce")
+    anchors["median_volume"] = pd.to_numeric(anchors["median_volume"], errors="coerce")
+    anchors = anchors.dropna().sort_values("age_bin", kind="stable")
+    anchors = anchors.loc[anchors["age_bin"] >= float(min_anchor_age)].copy()
+    if anchors.empty:
+        return np.asarray([], dtype=float), np.asarray([], dtype=float)
+
+    smoothed = anchors["median_volume"].to_numpy(dtype=float).copy()
+    if len(smoothed) >= 5:
+        for _ in range(int(smoothing_passes)):
+            updated = smoothed.copy()
+            for idx in range(2, len(smoothed) - 2):
+                updated[idx] = float(np.dot(_SMOOTHING_WEIGHTS, smoothed[idx - 2 : idx + 3]))
+            smoothed = updated
+
+    anchor_ages = np.concatenate([[1.0], anchors["age_bin"].to_numpy(dtype=float)])
+    anchor_volumes = np.concatenate([[1e-6], smoothed])
+    pchip = PchipInterpolator(anchor_ages, anchor_volumes, extrapolate=True)
+    curve_x = np.arange(1, int(curve_max_age), dtype=float)
+    curve_y = np.asarray(pchip(curve_x), dtype=float)
+    curve_y = np.nan_to_num(curve_y, nan=0.0, posinf=0.0, neginf=0.0)
+    curve_y = np.maximum(curve_y, 1e-6)
+    return curve_x, curve_y
+
+
+def select_au_first_growth_curve(
+    *,
+    vdyp_out: dict[int, pd.DataFrame],
+    min_source_stands: int = _DEFAULT_MIN_SOURCE_STANDS,
+    min_age: int = 30,
+    max_age: int = 350,
+    bin_years: int = 5,
+    smoothing_passes: int = _SMOOTHING_PASSES,
+) -> AuFirstGrowthSelectionResult:
+    """Select the default AU-level first-growth curve from stand-level VDYP evidence."""
+    empty_binned = pd.DataFrame(columns=["age_bin", "median_volume"])
+    if len(vdyp_out) < int(min_source_stands):
+        return AuFirstGrowthSelectionResult(
+            selected_path="insufficient_source_stands",
+            accepted=False,
+            x_curve=np.asarray([], dtype=float),
+            y_curve=np.asarray([], dtype=float),
+            binned=empty_binned,
+            metrics={"rmse": np.nan, "mape": np.nan, "tail_rmse": np.nan},
+        )
+
+    binned = build_observed_bins_for_fit(
+        vdyp_out_concat=pd.concat(vdyp_out.values()),
+        volume_flavour="Vdwb",
+        min_age=int(min_age),
+        max_age=int(max_age),
+        bin_years=int(bin_years),
+    )
+    if binned.empty:
+        return AuFirstGrowthSelectionResult(
+            selected_path="insufficient_source_stands",
+            accepted=False,
+            x_curve=np.asarray([], dtype=float),
+            y_curve=np.asarray([], dtype=float),
+            binned=binned,
+            metrics={"rmse": np.nan, "mape": np.nan, "tail_rmse": np.nan},
+        )
+    x_curve, y_curve = build_smoothed_bin_pchip_curve(
+        binned=binned,
+        smoothing_passes=int(smoothing_passes),
+    )
+    if x_curve.size == 0 or y_curve.size == 0:
+        return AuFirstGrowthSelectionResult(
+            selected_path="insufficient_source_stands",
+            accepted=False,
+            x_curve=x_curve,
+            y_curve=y_curve,
+            binned=binned,
+            metrics={"rmse": np.nan, "mape": np.nan, "tail_rmse": np.nan},
+        )
+    metrics = fit_au_first_growth_quality(
+        binned=binned,
+        x_curve=x_curve,
+        y_curve=y_curve,
+    )
+    return AuFirstGrowthSelectionResult(
+        selected_path="smoothed_bin_pchip",
+        accepted=True,
+        x_curve=x_curve,
+        y_curve=y_curve,
+        binned=binned,
+        metrics=metrics,
+    )

--- a/src/femic/pipeline/au_first_growth.py
+++ b/src/femic/pipeline/au_first_growth.py
@@ -7,16 +7,33 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 from scipy.interpolate import PchipInterpolator
+from scipy.optimize import curve_fit
 
-from femic.pipeline.vdyp_curves import build_observed_bins_for_fit
+from femic.pipeline.vdyp_curves import (
+    build_observed_bins_for_fit,
+    legacy_fit_func1,
+    legacy_fit_func1_bounds_func,
+)
 
 
 _TAIL_START_AGE = 150.0
 _CURVE_MAX_AGE = 300
-_SMOOTHING_WEIGHTS = np.asarray([1.0, 2.0, 3.0, 2.0, 1.0], dtype=float)
+_MAX_SOURCE_BIN_AGE = 300
+_MIN_BIN_AGE = 60
+_SMOOTHING_WEIGHTS = np.asarray([1.0, 2.0, 3.0, 4.0, 3.0, 2.0, 1.0], dtype=float)
 _SMOOTHING_WEIGHTS = _SMOOTHING_WEIGHTS / _SMOOTHING_WEIGHTS.sum()
-_SMOOTHING_PASSES = 2
+_SMOOTHING_PASSES = 4
 _DEFAULT_MIN_SOURCE_STANDS = 2
+_EARLY_LOCAL_WINDOW_BINS = 8
+_EARLY_LOCAL_MIN_SEGMENT_BINS = 4
+_EARLY_LOCAL_MAX_PRUNE_BINS = 8
+_EARLY_LOCAL_MAX_START_AGE = 120.0
+_EARLY_LOCAL_MAX_NEGATIVE_STEPS = 1
+_EARLY_LOCAL_NEGATIVE_DROP_TOLERANCE = 2.0
+_TOE_SPLICE_SKIP_BINS = 2
+_TOE_SPLICE_DI = 20
+_TOE_SPLICE_CY = 0.1
+_TOE_SPLICE_BLEND_MIN = 6
 
 
 @dataclass(frozen=True)
@@ -29,6 +46,42 @@ class AuFirstGrowthSelectionResult:
     y_curve: np.ndarray
     binned: pd.DataFrame
     metrics: dict[str, float]
+
+
+def _prune_bad_leading_anchors(anchors: pd.DataFrame) -> pd.DataFrame:
+    """Drop only the locally inconsistent early anchor block.
+
+    This is intentionally local. We never compare early anchors against the full
+    future tail because legitimate senescent decline would otherwise delete the
+    valid body of the curve. Instead, search for the earliest start in the left
+    window whose next few bins are locally close to non-decreasing.
+    """
+    cleaned = anchors.copy()
+    if cleaned.empty:
+        return cleaned
+    window_bins = min(_EARLY_LOCAL_WINDOW_BINS, len(cleaned))
+    min_segment_bins = min(_EARLY_LOCAL_MIN_SEGMENT_BINS, len(cleaned))
+    max_prune = max(0, min(_EARLY_LOCAL_MAX_PRUNE_BINS, len(cleaned) - min_segment_bins))
+    best_start = 0
+    best_score = float("inf")
+    for start_idx in range(max_prune + 1):
+        start_age = float(cleaned.iloc[start_idx]["age_bin"])
+        if start_age > _EARLY_LOCAL_MAX_START_AGE:
+            break
+        segment = cleaned.iloc[start_idx : start_idx + window_bins]["median_volume"].to_numpy(
+            dtype=float
+        )
+        if segment.size < min_segment_bins:
+            continue
+        diffs = np.diff(segment)
+        negative_drops = -diffs[diffs < 0.0]
+        negative_steps = int(negative_drops.size)
+        negative_drop_sum = float(negative_drops.sum()) if negative_steps else 0.0
+        score = negative_steps * 1000.0 + negative_drop_sum + start_idx * 0.5
+        if score < best_score:
+            best_score = score
+            best_start = start_idx
+    return cleaned.iloc[best_start:].reset_index(drop=True)
 
 
 def fit_au_first_growth_quality(
@@ -59,12 +112,63 @@ def fit_au_first_growth_quality(
     }
 
 
+def _splice_exponential_toe(
+    *,
+    x_curve: np.ndarray,
+    y_curve: np.ndarray,
+    first_anchor_age: float,
+    skip_bins: int = _TOE_SPLICE_SKIP_BINS,
+    di: int = _TOE_SPLICE_DI,
+    cy: float = _TOE_SPLICE_CY,
+) -> np.ndarray:
+    """Replace the left edge with the legacy exponential toe splice."""
+    x_ = np.asarray(x_curve, dtype=float).copy()
+    y_ = np.asarray(y_curve, dtype=float).copy()
+    anchor_idx = int(np.searchsorted(x_, float(first_anchor_age), side="left"))
+    if anchor_idx <= 0 or anchor_idx >= y_.size:
+        return y_
+    join_idx = int(min(max(anchor_idx + int(skip_bins), 1), max(y_.size - 1, 1)))
+    fit_end = int(min(join_idx + int(di), y_.size))
+    if fit_end - join_idx < 4:
+        return y_
+    x_fit = np.concatenate(([1.0, 2.0, 3.0], x_[join_idx:fit_end]))
+    y_fit = np.concatenate(([1.0 * cy, 2.0 * cy, 3.0 * cy], y_[join_idx:fit_end]))
+    try:
+        bounds = legacy_fit_func1_bounds_func(x_fit)
+        popt, _ = curve_fit(
+            legacy_fit_func1,
+            x_fit,
+            y_fit,
+            maxfev=10000,
+            bounds=bounds,
+        )
+    except Exception:
+        return y_
+    x_left = np.asarray(x_[:join_idx], dtype=float)
+    body_left = np.asarray(y_[:join_idx], dtype=float)
+    y_left = legacy_fit_func1(x_left, *popt)
+    y_left = np.nan_to_num(np.asarray(y_left, dtype=float), nan=0.0, posinf=0.0, neginf=0.0)
+    if y_left.size == 0:
+        return y_
+    join_value = float(y_[join_idx])
+    y_left = np.clip(y_left, 0.0, max(join_value, 0.0))
+    y_left = np.maximum.accumulate(y_left)
+    blend_width = min(int(y_left.size), max(_TOE_SPLICE_BLEND_MIN, int(skip_bins) + 4))
+    if blend_width > 1:
+        blend_start = int(y_left.size - blend_width)
+        w = np.linspace(0.0, 1.0, blend_width)
+        y_left[blend_start:] = (1.0 - w) * y_left[blend_start:] + w * body_left[blend_start:]
+    y_out = y_.copy()
+    y_out[:join_idx] = y_left
+    return y_out
+
+
 def build_smoothed_bin_pchip_curve(
     *,
     binned: pd.DataFrame,
     smoothing_passes: int = _SMOOTHING_PASSES,
     curve_max_age: int = _CURVE_MAX_AGE,
-    min_anchor_age: float = 30.0,
+    min_anchor_age: float = _MIN_BIN_AGE,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Build a strongly smoothed observed-bin PCHIP curve."""
     anchors = binned.loc[:, ["age_bin", "median_volume"]].copy()
@@ -72,22 +176,35 @@ def build_smoothed_bin_pchip_curve(
     anchors["median_volume"] = pd.to_numeric(anchors["median_volume"], errors="coerce")
     anchors = anchors.dropna().sort_values("age_bin", kind="stable")
     anchors = anchors.loc[anchors["age_bin"] >= float(min_anchor_age)].copy()
+    anchors = _prune_bad_leading_anchors(anchors)
     if anchors.empty:
         return np.asarray([], dtype=float), np.asarray([], dtype=float)
 
     smoothed = anchors["median_volume"].to_numpy(dtype=float).copy()
-    if len(smoothed) >= 5:
+    half_window = len(_SMOOTHING_WEIGHTS) // 2
+    if len(smoothed) >= len(_SMOOTHING_WEIGHTS):
         for _ in range(int(smoothing_passes)):
             updated = smoothed.copy()
-            for idx in range(2, len(smoothed) - 2):
-                updated[idx] = float(np.dot(_SMOOTHING_WEIGHTS, smoothed[idx - 2 : idx + 3]))
+            for idx in range(half_window, len(smoothed) - half_window):
+                updated[idx] = float(
+                    np.dot(
+                        _SMOOTHING_WEIGHTS,
+                        smoothed[idx - half_window : idx + half_window + 1],
+                    )
+                )
             smoothed = updated
 
     anchor_ages = np.concatenate([[1.0], anchors["age_bin"].to_numpy(dtype=float)])
     anchor_volumes = np.concatenate([[1e-6], smoothed])
-    pchip = PchipInterpolator(anchor_ages, anchor_volumes, extrapolate=True)
+    pchip = PchipInterpolator(anchor_ages, anchor_volumes, extrapolate=False)
     curve_x = np.arange(1, int(curve_max_age), dtype=float)
-    curve_y = np.asarray(pchip(curve_x), dtype=float)
+    clamped_x = np.minimum(curve_x, float(anchor_ages[-1]))
+    curve_y = np.asarray(pchip(clamped_x), dtype=float)
+    curve_y = _splice_exponential_toe(
+        x_curve=curve_x,
+        y_curve=curve_y,
+        first_anchor_age=float(anchors["age_bin"].iloc[0]),
+    )
     curve_y = np.nan_to_num(curve_y, nan=0.0, posinf=0.0, neginf=0.0)
     curve_y = np.maximum(curve_y, 1e-6)
     return curve_x, curve_y
@@ -97,8 +214,8 @@ def select_au_first_growth_curve(
     *,
     vdyp_out: dict[int, pd.DataFrame],
     min_source_stands: int = _DEFAULT_MIN_SOURCE_STANDS,
-    min_age: int = 30,
-    max_age: int = 350,
+    min_age: int = _MIN_BIN_AGE,
+    max_age: int = _MAX_SOURCE_BIN_AGE,
     bin_years: int = 5,
     smoothing_passes: int = _SMOOTHING_PASSES,
 ) -> AuFirstGrowthSelectionResult:

--- a/src/femic/pipeline/mkrf_first_growth.py
+++ b/src/femic/pipeline/mkrf_first_growth.py
@@ -9,20 +9,15 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from scipy.interpolate import PchipInterpolator
 
+from femic.pipeline.au_first_growth import select_au_first_growth_curve
 from femic.pipeline.mkrf_au import build_mkrf_assignment_rows
 from femic.pipeline.tsa import build_stratum_lexmatch_alias_map
-from femic.pipeline.vdyp_curves import build_observed_bins_for_fit, process_vdyp_out
+from femic.pipeline.vdyp_curves import process_vdyp_out
 
 
-_TAIL_START_AGE = 150.0
 _MIN_FIRST_GROWTH_AGE = 80.0
 _MIN_FIRST_GROWTH_SOURCE_STANDS = 2
-_CURVE_MAX_AGE = 300
-_SMOOTHING_WEIGHTS = np.asarray([1.0, 2.0, 3.0, 2.0, 1.0], dtype=float)
-_SMOOTHING_WEIGHTS = _SMOOTHING_WEIGHTS / _SMOOTHING_WEIGHTS.sum()
-_SMOOTHING_PASSES = 2
 
 
 @dataclass(frozen=True)
@@ -124,63 +119,6 @@ def _build_feature_tables(vdyp_yields: pd.DataFrame) -> dict[int, pd.DataFrame]:
             .copy()
         )
     return feature_tables
-
-
-def _fit_quality(
-    *,
-    binned: pd.DataFrame,
-    x_curve: np.ndarray,
-    y_curve: np.ndarray,
-) -> dict[str, float]:
-    observed_age = np.asarray(binned["age_bin"].values, dtype=float)
-    observed_volume = np.asarray(binned["median_volume"].values, dtype=float)
-    fitted = np.interp(observed_age, x_curve, y_curve)
-    residual = fitted - observed_volume
-    abs_obs = np.maximum(np.abs(observed_volume), 1e-6)
-    rmse = float(np.sqrt(np.mean(np.square(residual))))
-    mape = float(np.mean(np.abs(residual) / abs_obs))
-    tail_mask = observed_age >= _TAIL_START_AGE
-    if np.any(tail_mask):
-        tail_rmse = float(np.sqrt(np.mean(np.square(residual[tail_mask]))))
-    else:
-        tail_rmse = rmse
-    return {
-        "rmse": rmse,
-        "mape": mape,
-        "tail_rmse": tail_rmse,
-    }
-
-
-def _build_smoothed_bin_pchip_curve(
-    *,
-    binned: pd.DataFrame,
-    smoothing_passes: int = _SMOOTHING_PASSES,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Build a strongly smoothed observed-bin PCHIP curve."""
-    anchors = binned.loc[:, ["age_bin", "median_volume"]].copy()
-    anchors["age_bin"] = pd.to_numeric(anchors["age_bin"], errors="coerce")
-    anchors["median_volume"] = pd.to_numeric(anchors["median_volume"], errors="coerce")
-    anchors = anchors.dropna().sort_values("age_bin", kind="stable")
-    anchors = anchors.loc[anchors["age_bin"] >= 30.0].copy()
-    if anchors.empty:
-        return np.asarray([], dtype=float), np.asarray([], dtype=float)
-
-    smoothed = anchors["median_volume"].to_numpy(dtype=float).copy()
-    if len(smoothed) >= 5:
-        for _ in range(int(smoothing_passes)):
-            updated = smoothed.copy()
-            for idx in range(2, len(smoothed) - 2):
-                updated[idx] = float(np.dot(_SMOOTHING_WEIGHTS, smoothed[idx - 2 : idx + 3]))
-            smoothed = updated
-
-    anchor_ages = np.concatenate([[1.0], anchors["age_bin"].to_numpy(dtype=float)])
-    anchor_volumes = np.concatenate([[1e-6], smoothed])
-    pchip = PchipInterpolator(anchor_ages, anchor_volumes, extrapolate=True)
-    curve_x = np.arange(1, _CURVE_MAX_AGE, dtype=float)
-    curve_y = np.asarray(pchip(curve_x), dtype=float)
-    curve_y = np.nan_to_num(curve_y, nan=0.0, posinf=0.0, neginf=0.0)
-    curve_y = np.maximum(curve_y, 1e-6)
-    return curve_x, curve_y
 
 
 def _build_au_lexmatch_alias_map(
@@ -377,26 +315,17 @@ def build_mkrf_first_growth_curves(
         lexmatch_count = int(assignment_status.eq("lexmatch_assigned").sum())
         lexmatch_alias_count = int(lexmatch_used.astype(bool).sum())
         sparse_warning = len(feature_ids) < 5
-        binned = pd.DataFrame(columns=["age_bin", "median_volume"])
-        if len(feature_ids) < min_source_stands:
-            x_curve = np.asarray([], dtype=float)
-            y_curve = np.asarray([], dtype=float)
-            metrics = {"rmse": np.nan, "mape": np.nan, "tail_rmse": np.nan}
-            selected_path = "insufficient_source_stands"
-            accepted = False
-        else:
-            vdyp_out = {feature_id: feature_tables[feature_id] for feature_id in feature_ids}
-            binned = build_observed_bins_for_fit(
-                vdyp_out_concat=pd.concat(vdyp_out.values()),
-                volume_flavour="Vdwb",
-                min_age=30,
-                max_age=350,
-                bin_years=5,
-            )
-            x_curve, y_curve = _build_smoothed_bin_pchip_curve(binned=binned)
-            metrics = _fit_quality(binned=binned, x_curve=x_curve, y_curve=y_curve)
-            selected_path = "smoothed_bin_pchip"
-            accepted = True
+        vdyp_out = {feature_id: feature_tables[feature_id] for feature_id in feature_ids}
+        selection = select_au_first_growth_curve(
+            vdyp_out=vdyp_out,
+            min_source_stands=min_source_stands,
+        )
+        binned = selection.binned
+        x_curve = selection.x_curve
+        y_curve = selection.y_curve
+        metrics = selection.metrics
+        selected_path = selection.selected_path
+        accepted = selection.accepted
 
         for age, volume in zip(np.asarray(x_curve, dtype=float), np.asarray(y_curve, dtype=float)):
             if not math.isfinite(float(volume)) or float(volume) <= 0.0:

--- a/src/femic/pipeline/vdyp_stage.py
+++ b/src/femic/pipeline/vdyp_stage.py
@@ -20,6 +20,7 @@ from typing import Any, cast
 
 import numpy as np
 
+from femic.pipeline.au_first_growth import select_au_first_growth_curve
 from femic.pipeline.diagnostics import (
     build_contextual_error_message,
     build_timestamped_event,
@@ -2314,6 +2315,7 @@ def execute_curve_smoothing_runs(
     body_fit_func_bounds_func: Callable[..., Any],
     toe_fit_func: Callable[..., Any],
     toe_fit_func_bounds_func: Callable[..., Any],
+    use_au_first_growth_selector: bool = False,
     message_fn: Callable[..., Any] = print,
 ) -> list[SmoothedCurveResult]:
     """Build smoothed VDYP curves for each stratum/SI combination."""
@@ -3125,6 +3127,67 @@ def execute_curve_smoothing_runs(
                         reason="missing_vdyp_output",
                         context=curve_context,
                     ),
+                )
+                continue
+            if use_au_first_growth_selector:
+                selection = select_au_first_growth_curve(vdyp_out=vdyp_out)
+                plot_binned = selection.binned.copy()
+                for column_name in ("p25", "p75", "n"):
+                    if column_name not in plot_binned.columns:
+                        if column_name == "n":
+                            plot_binned[column_name] = 1
+                        else:
+                            plot_binned[column_name] = plot_binned["median_volume"]
+                append_jsonl_fn(
+                    vdyp_curve_events_path,
+                    build_timestamped_event(
+                        event="vdyp_curve_fit",
+                        status="info",
+                        stage="fallback_policy",
+                        reason="curve_selected",
+                        context=curve_context,
+                        selected_path=selection.selected_path,
+                        available_candidates=[],
+                        selected_metrics=dict(selection.metrics),
+                        selected_gate_fail_reasons=[],
+                    ),
+                )
+                if (
+                    not selection.accepted
+                    or selection.x_curve.size == 0
+                    or selection.y_curve.size == 0
+                ):
+                    message_fn(
+                        "  insufficient AU first-growth support for",
+                        sc,
+                        si_level,
+                    )
+                    continue
+                _emit_fit_diagnostic_plot(
+                    tsa_code=tsa,
+                    stratumi=int(stratumi),
+                    stratum_code=sc,
+                    si_level=si_level,
+                    vdyp_out=vdyp_out,
+                    binned=plot_binned,
+                    x_fit=selection.x_curve,
+                    y_fit=selection.y_curve,
+                    selected_x=selection.x_curve,
+                    selected_y=selection.y_curve,
+                    selected_path=selection.selected_path,
+                    tail_blend_meta=None,
+                    candidate_curves={},
+                    fit_metrics={selection.selected_path: dict(selection.metrics)},
+                )
+                smoothed_runs.append(
+                    SmoothedCurveResult(
+                        stratumi=int(stratumi),
+                        stratum_code=sc,
+                        si_level=si_level,
+                        x=selection.x_curve,
+                        y=selection.y_curve,
+                        vdyp_out=vdyp_out,
+                    )
                 )
                 continue
             x, y = process_vdyp_out_fn(

--- a/src/femic/resources/legacy/01a_run-tsa.py
+++ b/src/femic/resources/legacy/01a_run-tsa.py
@@ -557,6 +557,7 @@ def run_tsa(
         or bool(runtime_config.vdyp_two_pass_rebin)
     )
     if should_rebuild_smooth_curves:
+        use_au_first_growth_selector = str(tsa).strip().zfill(2) == "29"
         smooth_plot_cfg = build_curve_smoothing_plot_config(sns_module=sns)
         smoothed_runs = execute_curve_smoothing_runs(
             tsa=tsa,
@@ -573,6 +574,7 @@ def run_tsa(
             body_fit_func_bounds_func=body_fit_func_bounds_func,
             toe_fit_func=toe_fit_func,
             toe_fit_func_bounds_func=toe_fit_func_bounds_func,
+            use_au_first_growth_selector=use_au_first_growth_selector,
             message_fn=print,
         )
         plot_curve_overlays(

--- a/tests/test_au_first_growth.py
+++ b/tests/test_au_first_growth.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 
 from femic.pipeline.au_first_growth import (
+    _prune_bad_leading_anchors,
+    _splice_exponential_toe,
     build_smoothed_bin_pchip_curve,
     select_au_first_growth_curve,
 )
@@ -57,7 +59,7 @@ def test_select_au_first_growth_curve_uses_smoothed_bin_pchip_default() -> None:
 def test_build_smoothed_bin_pchip_curve_keeps_positive_monotone_curve() -> None:
     binned = pd.DataFrame(
         {
-            "age_bin": [30.0, 80.0, 150.0, 300.0],
+            "age_bin": [50.0, 80.0, 150.0, 300.0],
             "median_volume": [40.0, 280.0, 360.0, 320.0],
         }
     )
@@ -67,3 +69,94 @@ def test_build_smoothed_bin_pchip_curve_keeps_positive_monotone_curve() -> None:
     assert x_curve.size == y_curve.size
     assert x_curve[0] == 1.0
     assert np.all(y_curve > 0.0)
+
+
+def test_build_smoothed_bin_pchip_curve_ignores_bins_below_60() -> None:
+    binned = pd.DataFrame(
+        {
+            "age_bin": [30.0, 50.0, 60.0, 80.0, 150.0, 200.0],
+            "median_volume": [400.0, 180.0, 45.0, 220.0, 310.0, 300.0],
+        }
+    )
+
+    x_curve, y_curve = build_smoothed_bin_pchip_curve(binned=binned)
+
+    age_30_idx = int(np.where(x_curve == 30.0)[0][0])
+    age_60_idx = int(np.where(x_curve == 60.0)[0][0])
+    assert y_curve[age_30_idx] < 150.0
+    assert y_curve[age_30_idx] < y_curve[age_60_idx]
+
+
+def test_build_smoothed_bin_pchip_curve_flattens_after_last_anchor() -> None:
+    binned = pd.DataFrame(
+        {
+            "age_bin": [50.0, 80.0, 120.0, 180.0, 200.0],
+            "median_volume": [30.0, 180.0, 260.0, 290.0, 285.0],
+        }
+    )
+
+    x_curve, y_curve = build_smoothed_bin_pchip_curve(binned=binned)
+
+    tail = y_curve[x_curve >= 200.0]
+    assert tail.size > 0
+    assert np.allclose(tail, tail[0])
+
+
+def test_prune_bad_leading_anchors_removes_early_high_outliers() -> None:
+    anchors = pd.DataFrame(
+        {
+            "age_bin": [60.0, 65.0, 70.0, 75.0, 80.0],
+            "median_volume": [30.0, 12.0, 14.0, 18.0, 24.0],
+        }
+    )
+
+    cleaned = _prune_bad_leading_anchors(anchors)
+
+    assert cleaned["age_bin"].tolist() == [65.0, 70.0, 75.0, 80.0]
+    assert cleaned["median_volume"].tolist() == [12.0, 14.0, 18.0, 24.0]
+
+
+def test_prune_bad_leading_anchors_ignores_late_tail_outliers() -> None:
+    anchors = pd.DataFrame(
+        {
+            "age_bin": [60.0, 65.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0, 300.0],
+            "median_volume": [36.2, 42.85, 45.65, 51.55, 61.4, 69.2, 75.6, 82.6, 89.05, 20.0],
+        }
+    )
+
+    cleaned = _prune_bad_leading_anchors(anchors)
+
+    assert cleaned.iloc[0]["age_bin"] == 60.0
+    assert len(cleaned) == len(anchors)
+
+
+def test_prune_bad_leading_anchors_can_drop_local_ugly_left_block() -> None:
+    anchors = pd.DataFrame(
+        {
+            "age_bin": [60.0, 65.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0, 105.0, 110.0],
+            "median_volume": [1.9, 1.9, 30.5, 34.6, 31.75, 34.25, 22.5, 26.0, 24.7, 28.4, 31.3],
+        }
+    )
+
+    cleaned = _prune_bad_leading_anchors(anchors)
+
+    assert cleaned.iloc[0]["age_bin"] >= 90.0
+
+
+def test_splice_exponential_toe_overwrites_left_edge_with_monotone_toe() -> None:
+    x_curve = np.arange(1.0, 300.0, dtype=float)
+    y_curve = np.interp(
+        x_curve,
+        np.asarray([1.0, 100.0, 120.0, 160.0, 200.0], dtype=float),
+        np.asarray([1e-6, 24.7, 38.35, 57.5, 62.5], dtype=float),
+    )
+
+    y_toe = _splice_exponential_toe(
+        x_curve=x_curve,
+        y_curve=y_curve,
+        first_anchor_age=100.0,
+    )
+
+    assert not np.allclose(y_toe[:110], y_curve[:110])
+    assert np.all(np.diff(y_toe[:110]) >= -1e-6)
+    assert float(y_toe[99]) <= float(y_curve[99]) + 0.1

--- a/tests/test_au_first_growth.py
+++ b/tests/test_au_first_growth.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from femic.pipeline.au_first_growth import (
+    build_smoothed_bin_pchip_curve,
+    select_au_first_growth_curve,
+)
+
+
+def test_select_au_first_growth_curve_returns_insufficient_support_for_small_input() -> None:
+    vdyp_out = {
+        10: pd.DataFrame(
+            {
+                "Vdwb": [40.0, 280.0, 360.0],
+            },
+            index=pd.Index([30, 80, 150], name="Age"),
+        )
+    }
+
+    result = select_au_first_growth_curve(vdyp_out=vdyp_out, min_source_stands=2)
+
+    assert result.selected_path == "insufficient_source_stands"
+    assert result.accepted is False
+    assert result.x_curve.size == 0
+    assert result.y_curve.size == 0
+    assert result.binned.empty
+
+
+def test_select_au_first_growth_curve_uses_smoothed_bin_pchip_default() -> None:
+    vdyp_out = {
+        10: pd.DataFrame(
+            {
+                "Vdwb": [40.0, 280.0, 360.0, 320.0],
+            },
+            index=pd.Index([30, 80, 150, 300], name="Age"),
+        ),
+        11: pd.DataFrame(
+            {
+                "Vdwb": [50.0, 300.0, 380.0, 340.0],
+            },
+            index=pd.Index([30, 80, 150, 300], name="Age"),
+        ),
+    }
+
+    result = select_au_first_growth_curve(vdyp_out=vdyp_out, min_source_stands=2)
+
+    assert result.selected_path == "smoothed_bin_pchip"
+    assert result.accepted is True
+    assert result.x_curve.size > 0
+    assert result.y_curve.size > 0
+    assert len(result.binned) > 0
+    assert result.metrics["rmse"] >= 0.0
+
+
+def test_build_smoothed_bin_pchip_curve_keeps_positive_monotone_curve() -> None:
+    binned = pd.DataFrame(
+        {
+            "age_bin": [30.0, 80.0, 150.0, 300.0],
+            "median_volume": [40.0, 280.0, 360.0, 320.0],
+        }
+    )
+
+    x_curve, y_curve = build_smoothed_bin_pchip_curve(binned=binned)
+
+    assert x_curve.size == y_curve.size
+    assert x_curve[0] == 1.0
+    assert np.all(y_curve > 0.0)

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -139,6 +139,23 @@ def test_guides_pages_are_in_docs_tree() -> None:
         assert slug in guides_index, f"missing toctree entry for {slug}"
 
 
+def test_smoothed_bin_pchip_is_documented_as_default_au_first_growth_method() -> None:
+    planning_text = Path("planning/mkrf_femic_native_rebuild.md").read_text(
+        encoding="utf-8"
+    )
+    diagnostics_text = (GUIDES_ROOT / "diagnostics-playbook.rst").read_text(
+        encoding="utf-8"
+    )
+    pipeline_text = (GUIDES_ROOT / "pipeline-overview.rst").read_text(
+        encoding="utf-8"
+    )
+
+    assert "smoothed_bin_pchip" in planning_text
+    assert "legacy/fallback" in planning_text
+    assert "smoothed_bin_pchip" in diagnostics_text
+    assert "smoothed_bin_pchip" in pipeline_text
+
+
 def test_release_runbook_and_workflows_exist() -> None:
     runbook = GUIDES_ROOT / "pypi-release-runbook.rst"
     assert runbook.exists()

--- a/tests/test_vdyp_stage.py
+++ b/tests/test_vdyp_stage.py
@@ -1907,6 +1907,119 @@ def test_execute_curve_smoothing_runs_builds_output_and_logs_missing(
     assert len(fallback_events) == 1
 
 
+def test_execute_curve_smoothing_runs_can_use_smoothed_bin_pchip_selector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    events: list[dict[str, object]] = []
+
+    def append_event(_path: str | Path, payload: object) -> None:
+        assert isinstance(payload, dict)
+        events.append(payload)
+
+    def failing_process(
+        _vdyp_out: object, **_kwargs: object
+    ) -> tuple[list[float], list[float]]:
+        raise AssertionError("legacy NLLS smoother should not run in selector mode")
+
+    stand_a = pd.DataFrame(
+        {
+            "Vdwb": [15.0, 18.0, 22.0, 26.0, 210.0, 220.0, 225.0, 230.0],
+        },
+        index=pd.Index([30, 35, 40, 45, 150, 155, 160, 165], name="Age"),
+    )
+    stand_b = pd.DataFrame(
+        {
+            "Vdwb": [14.0, 17.0, 21.0, 25.0, 205.0, 215.0, 220.0, 226.0],
+        },
+        index=pd.Index([30, 35, 40, 45, 150, 155, 160, 165], name="Age"),
+    )
+
+    smoothed_runs = execute_curve_smoothing_runs(
+        tsa="29",
+        run_id="run-au-selector",
+        results_for_tsa=[(1, "MS_PLI", {})],
+        si_levels=["L"],
+        vdyp_results_for_tsa={1: {"L": {101: stand_a, 102: stand_b}}},
+        kwarg_overrides_for_tsa={},
+        process_vdyp_out_fn=failing_process,
+        append_jsonl_fn=append_event,
+        vdyp_curve_events_path="curve.jsonl",
+        curve_fit_fn=lambda *_a, **_k: None,
+        body_fit_func=lambda *_a, **_k: None,
+        body_fit_func_bounds_func=lambda *_a, **_k: None,
+        toe_fit_func=lambda *_a, **_k: None,
+        toe_fit_func_bounds_func=lambda *_a, **_k: None,
+        use_au_first_growth_selector=True,
+        message_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert len(smoothed_runs) == 1
+    assert smoothed_runs[0].stratum_code == "MS_PLI"
+    assert smoothed_runs[0].si_level == "L"
+    assert np.all(np.diff(np.asarray(smoothed_runs[0].x, dtype=float)) > 0)
+    assert np.all(np.asarray(smoothed_runs[0].y, dtype=float) >= 1e-6)
+    selection_events = [
+        event
+        for event in events
+        if event.get("stage") == "fallback_policy"
+        and event.get("reason") == "curve_selected"
+    ]
+    assert selection_events
+    assert selection_events[-1].get("selected_path") == "smoothed_bin_pchip"
+
+
+def test_execute_curve_smoothing_runs_logs_insufficient_support_in_selector_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    events: list[dict[str, object]] = []
+
+    def append_event(_path: str | Path, payload: object) -> None:
+        assert isinstance(payload, dict)
+        events.append(payload)
+
+    single_stand = pd.DataFrame(
+        {
+            "Vdwb": [15.0, 18.0, 22.0, 26.0, 210.0, 220.0, 225.0, 230.0],
+        },
+        index=pd.Index([30, 35, 40, 45, 150, 155, 160, 165], name="Age"),
+    )
+
+    smoothed_runs = execute_curve_smoothing_runs(
+        tsa="29",
+        run_id="run-au-selector-insufficient",
+        results_for_tsa=[(1, "MS_PLI", {})],
+        si_levels=["L"],
+        vdyp_results_for_tsa={1: {"L": {101: single_stand}}},
+        kwarg_overrides_for_tsa={},
+        process_vdyp_out_fn=lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("legacy NLLS smoother should not run in selector mode")
+        ),
+        append_jsonl_fn=append_event,
+        vdyp_curve_events_path="curve.jsonl",
+        curve_fit_fn=lambda *_a, **_k: None,
+        body_fit_func=lambda *_a, **_k: None,
+        body_fit_func_bounds_func=lambda *_a, **_k: None,
+        toe_fit_func=lambda *_a, **_k: None,
+        toe_fit_func_bounds_func=lambda *_a, **_k: None,
+        use_au_first_growth_selector=True,
+        message_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert smoothed_runs == []
+    selection_events = [
+        event
+        for event in events
+        if event.get("stage") == "fallback_policy"
+        and event.get("reason") == "curve_selected"
+    ]
+    assert selection_events
+    assert selection_events[-1].get("selected_path") == "insufficient_source_stands"
+
+
 def test_execute_curve_smoothing_runs_prefers_tail_blend_for_k3z_output(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- lock the shared AU first-growth selector as the promoted default AU-level unmanaged VDYP synthesis surface
- route TSA29 unmanaged smoothing through the accepted selector contract
- update roadmap and changelog to record the accepted default and TSA29 adoption lock

## Included changes
- `src/femic/pipeline/au_first_growth.py`
- `src/femic/pipeline/vdyp_stage.py`
- `src/femic/resources/legacy/01a_run-tsa.py`
- `tests/test_au_first_growth.py`
- `tests/test_vdyp_stage.py`
- `ROADMAP.md`
- `CHANGE_LOG.md`
- submodule update to the locked TSA29 instance curve-library commit

## Accepted selector contract
- minimum trusted source-bin age `60`
- maximum trusted source-bin age `300`
- seven-point / four-pass smoothing
- local early-window left-bin censoring
- legacy exponential toe splice blended into the smoothed PCHIP body

## Validation
- `python -m pytest tests/test_au_first_growth.py tests/test_vdyp_stage.py -k "au_first_growth or smoothed_bin_pchip_selector or selector_mode" -q`
- `python -m ruff check src/femic/pipeline/au_first_growth.py src/femic/pipeline/vdyp_stage.py src/femic/resources/legacy/01a_run-tsa.py tests/test_au_first_growth.py tests/test_vdyp_stage.py`
- TSA29 accepted selection summary rows: `54`
- selected path counts: `{'smoothed_bin_pchip': 54}`
- `insufficient_source_stands` rows: `0`

## Dependency
- depends on the matching TSA29 instance PR for the locked curve library artifacts
