### PR TITLE
Add MKRF cedar-pole CT generation support

### DIFF
--- a/src/femic/pipeline/mkrf_managed.py
+++ b/src/femic/pipeline/mkrf_managed.py
@@ -57,7 +57,16 @@ class MkrfManagedRule:
 class MkrfManagedRuleConfig:
     path: Path
     fire_origin_min_age: float
+    hw_ingrowth_overlay: HwIngrowthOverlayConfig
     rules: tuple[MkrfManagedRule, ...]
+
+
+@dataclass(frozen=True)
+class HwIngrowthOverlayConfig:
+    enabled: bool
+    landscape_default_pct: float
+    au_overrides_pct: Mapping[str, float]
+    stand_overrides_pct: Mapping[str, float]
 
 
 def build_mkrf_legacy_managed_au_table(
@@ -92,6 +101,10 @@ def load_mkrf_managed_rule_config(path: Path) -> MkrfManagedRuleConfig:
     payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     origin_rules = payload.get("origin_rules", {}) or {}
     managed_defaults = payload.get("managed_defaults", {}) or {}
+    hw_ingrowth_overlay = _load_hw_ingrowth_overlay_config(
+        payload.get("hw_ingrowth_overlay", {}) or {},
+        path=path,
+    )
     raw_rules = payload.get(_DEFAULT_MANAGED_RULE_KEY, {}) or {}
     if not isinstance(raw_rules, Mapping) or not raw_rules:
         raise ValueError(f"Managed rule config has no families: {path}")
@@ -159,6 +172,7 @@ def load_mkrf_managed_rule_config(path: Path) -> MkrfManagedRuleConfig:
     return MkrfManagedRuleConfig(
         path=path,
         fire_origin_min_age=fire_origin_min_age,
+        hw_ingrowth_overlay=hw_ingrowth_overlay,
         rules=tuple(rules),
     )
 
@@ -338,7 +352,15 @@ def build_mkrf_managed_au_bootstrap_table(
                     "ct_eligible": False,
                     "ct_target_age": np.nan,
                     "ct_on_fire_origin": False,
+                    "hw_ingrowth_pct": 0.0,
+                    "hw_ingrowth_source": "unmatched",
                     "managed_rule_notes": "",
+                    **_managed_species_payload_dict(
+                        ManagedSpeciesPayload("", "", "", "", "", 0, 0, 0, 0, 0),
+                        prefix="base_managed",
+                    ),
+                    "managed_species_overflow_to_hw_pct": 0.0,
+                    "managed_species_overflow_to_hw_codes": "",
                     **_managed_species_payload_dict(
                         ManagedSpeciesPayload("", "", "", "", "", 0, 0, 0, 0, 0)
                     ),
@@ -346,6 +368,17 @@ def build_mkrf_managed_au_bootstrap_table(
             )
             continue
 
+        hw_ingrowth_pct, hw_ingrowth_source = resolve_hw_ingrowth_pct(
+            rule_config=rule_config,
+            au_id=au_id,
+        )
+        adjusted_species_mix = apply_hw_ingrowth_overlay(
+            species_mix=rule.species_mix,
+            hw_ingrowth_pct=hw_ingrowth_pct,
+        )
+        managed_payload, overflow_pct, overflow_codes = (
+            _managed_species_payload_from_mix_with_hw_overflow(adjusted_species_mix)
+        )
         included = not pd.isna(managed_si)
         rows.append(
             {
@@ -366,10 +399,16 @@ def build_mkrf_managed_au_bootstrap_table(
                 "ct_eligible": bool(rule.ct_eligible),
                 "ct_target_age": int(rule.ct_target_age),
                 "ct_on_fire_origin": bool(rule.ct_on_fire_origin),
+                "hw_ingrowth_pct": float(hw_ingrowth_pct),
+                "hw_ingrowth_source": hw_ingrowth_source,
                 "managed_rule_notes": rule.notes,
                 **_managed_species_payload_dict(
-                    _managed_species_payload_from_mix(rule.species_mix)
+                    _managed_species_payload_from_mix(rule.species_mix),
+                    prefix="base_managed",
                 ),
+                "managed_species_overflow_to_hw_pct": overflow_pct,
+                "managed_species_overflow_to_hw_codes": overflow_codes,
+                **_managed_species_payload_dict(managed_payload),
             }
         )
 
@@ -489,18 +528,71 @@ def _match_managed_rule(
     return None
 
 
-def _managed_species_payload_dict(payload: ManagedSpeciesPayload) -> dict[str, Any]:
+def resolve_hw_ingrowth_pct(
+    *,
+    rule_config: MkrfManagedRuleConfig,
+    au_id: str,
+    stand_id: str | int | None = None,
+) -> tuple[float, str]:
+    overlay = rule_config.hw_ingrowth_overlay
+    if not overlay.enabled:
+        return 0.0, "disabled"
+
+    if stand_id is not None and str(stand_id).strip():
+        stand_key = str(stand_id).strip()
+        if stand_key in overlay.stand_overrides_pct:
+            return float(overlay.stand_overrides_pct[stand_key]), "stand_override"
+
+    au_key = str(au_id).strip().lower()
+    if au_key in overlay.au_overrides_pct:
+        return float(overlay.au_overrides_pct[au_key]), "au_override"
+
+    return float(overlay.landscape_default_pct), "landscape_default"
+
+
+def apply_hw_ingrowth_overlay(
+    *,
+    species_mix: Mapping[str, float],
+    hw_ingrowth_pct: float,
+) -> dict[str, float]:
+    pct = _validate_percent(
+        hw_ingrowth_pct,
+        context="hw_ingrowth_pct",
+    )
+    fraction = pct / 100.0
+    adjusted: dict[str, float] = {}
+    hw_ingrowth_share = 0.0
+    for species, share_value in species_mix.items():
+        code = str(species).strip().upper()
+        share = float(share_value)
+        if code == "HW":
+            adjusted[code] = adjusted.get(code, 0.0) + share
+            continue
+        retained_share = share * (1.0 - fraction)
+        if retained_share > 0.0:
+            adjusted[code] = adjusted.get(code, 0.0) + retained_share
+        hw_ingrowth_share += share * fraction
+    if hw_ingrowth_share > 0.0:
+        adjusted["HW"] = adjusted.get("HW", 0.0) + hw_ingrowth_share
+    return adjusted
+
+
+def _managed_species_payload_dict(
+    payload: ManagedSpeciesPayload,
+    *,
+    prefix: str = "managed",
+) -> dict[str, Any]:
     return {
-        "managed_species_1": payload.species_1,
-        "managed_species_2": payload.species_2,
-        "managed_species_3": payload.species_3,
-        "managed_species_4": payload.species_4,
-        "managed_species_5": payload.species_5,
-        "managed_pct_1": payload.pct_1,
-        "managed_pct_2": payload.pct_2,
-        "managed_pct_3": payload.pct_3,
-        "managed_pct_4": payload.pct_4,
-        "managed_pct_5": payload.pct_5,
+        f"{prefix}_species_1": payload.species_1,
+        f"{prefix}_species_2": payload.species_2,
+        f"{prefix}_species_3": payload.species_3,
+        f"{prefix}_species_4": payload.species_4,
+        f"{prefix}_species_5": payload.species_5,
+        f"{prefix}_pct_1": payload.pct_1,
+        f"{prefix}_pct_2": payload.pct_2,
+        f"{prefix}_pct_3": payload.pct_3,
+        f"{prefix}_pct_4": payload.pct_4,
+        f"{prefix}_pct_5": payload.pct_5,
     }
 
 
@@ -527,6 +619,86 @@ def _managed_species_payload_from_mix(species_mix: Mapping[str, float]) -> Manag
         pct_4=ranked[3][1],
         pct_5=ranked[4][1],
     )
+
+
+def _managed_species_payload_from_mix_with_hw_overflow(
+    species_mix: Mapping[str, float],
+) -> tuple[ManagedSpeciesPayload, float, str]:
+    positive = {
+        str(species).strip().upper(): float(share)
+        for species, share in species_mix.items()
+        if float(share) > 0.0
+    }
+    if len(positive) <= 5 or "HW" not in positive:
+        return _managed_species_payload_from_mix(positive), 0.0, ""
+
+    non_hw_ranked = sorted(
+        ((species, share) for species, share in positive.items() if species != "HW"),
+        key=lambda item: (-item[1], item[0]),
+    )
+    kept = dict(non_hw_ranked[:4])
+    dropped = non_hw_ranked[4:]
+    overflow_pct = float(sum(share for _, share in dropped))
+    if overflow_pct > 0.0:
+        kept["HW"] = positive["HW"] + overflow_pct
+    else:
+        kept["HW"] = positive["HW"]
+    overflow_codes = ",".join(species for species, _ in dropped)
+    return _managed_species_payload_from_mix(kept), overflow_pct, overflow_codes
+
+
+def _load_hw_ingrowth_overlay_config(
+    raw_overlay: Mapping[str, Any],
+    *,
+    path: Path,
+) -> HwIngrowthOverlayConfig:
+    if not isinstance(raw_overlay, Mapping):
+        raise ValueError(f"hw_ingrowth_overlay must be a mapping in {path}")
+    enabled = bool(raw_overlay.get("enabled", False))
+    landscape_default_pct = _validate_percent(
+        raw_overlay.get("landscape_default_pct", 0.0),
+        context="hw_ingrowth_overlay.landscape_default_pct",
+    )
+    return HwIngrowthOverlayConfig(
+        enabled=enabled,
+        landscape_default_pct=landscape_default_pct,
+        au_overrides_pct=_parse_percent_mapping(
+            raw_overlay.get("au_overrides_pct", {}) or {},
+            context="hw_ingrowth_overlay.au_overrides_pct",
+            lowercase_keys=True,
+        ),
+        stand_overrides_pct=_parse_percent_mapping(
+            raw_overlay.get("stand_overrides_pct", {}) or {},
+            context="hw_ingrowth_overlay.stand_overrides_pct",
+            lowercase_keys=False,
+        ),
+    )
+
+
+def _parse_percent_mapping(
+    raw_mapping: Mapping[str, Any],
+    *,
+    context: str,
+    lowercase_keys: bool,
+) -> dict[str, float]:
+    if not isinstance(raw_mapping, Mapping):
+        raise ValueError(f"{context} must be a mapping")
+    parsed: dict[str, float] = {}
+    for raw_key, raw_value in raw_mapping.items():
+        key = str(raw_key).strip()
+        if not key:
+            raise ValueError(f"{context} contains an empty key")
+        if lowercase_keys:
+            key = key.lower()
+        parsed[key] = _validate_percent(raw_value, context=f"{context}.{key}")
+    return parsed
+
+
+def _validate_percent(value: Any, *, context: str) -> float:
+    pct = float(value)
+    if not np.isfinite(pct) or pct < 0.0 or pct > 100.0:
+        raise ValueError(f"{context} must be between 0 and 100, got {value!r}")
+    return pct
 
 
 def _tipsy_species_pair(row: pd.Series) -> tuple[str, str]:

--- a/src/femic/pipeline/tipsy.py
+++ b/src/femic/pipeline/tipsy.py
@@ -3023,6 +3023,44 @@ def _btc_apply_species_payload(
         row[site_column] = _btc_numeric_or_blank(source_record.get("SI")) or 0
 
 
+def _btc_rebalance_species_densities(
+    *,
+    row: dict[str, Any],
+    source_record: Mapping[str, Any],
+    density_prefix: str,
+) -> None:
+    total = _btc_numeric_or_blank(source_record.get("Density"))
+    if total == "":
+        return
+    total_int = int(round(float(total)))
+    density_keys = [
+        f"{density_prefix}{index}"
+        for index in range(1, 6)
+        if row.get(f"{density_prefix}{index}") != ""
+    ]
+    if not density_keys:
+        return
+
+    exact: list[tuple[str, float]] = []
+    for index, density_key in enumerate(density_keys, start=1):
+        pct = _btc_numeric_or_blank(source_record.get(f"PCT_{index}"))
+        if pct == "":
+            return
+        exact_density = float(total) * (float(pct) / 100.0)
+        exact.append((density_key, exact_density))
+
+    floored = {density_key: int(np.floor(value)) for density_key, value in exact}
+    remainder = total_int - sum(floored.values())
+    ranked = sorted(
+        exact,
+        key=lambda item: (-(item[1] - np.floor(item[1])), item[0]),
+    )
+    for density_key, _ in ranked[: max(0, remainder)]:
+        floored[density_key] += 1
+    for density_key, density in floored.items():
+        row[density_key] = density
+
+
 def build_btc_msyt_input_table(
     *,
     tipsy_table: Any,
@@ -3067,6 +3105,11 @@ def build_btc_msyt_input_table(
             species_prefix="planted_species",
             density_prefix="planted_density",
             include_genetic_worth=True,
+        )
+        _btc_rebalance_species_densities(
+            row=row,
+            source_record=record,
+            density_prefix="planted_density",
         )
 
         planted_percent = row["planted_percent"]

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -99,9 +99,11 @@ def _normalize_species_bucket(species_code: str) -> str:
 
 
 _SPECIES_BUCKETS = ("Ba", "Cw", "Dec", "Dr", "Fd", "Hw", "Oth", "Yc")
-_MKRF_CT_BUCKET_ANCHORS = tuple(range(40, 151, 10))
-_MKRF_CT_BUCKET_WIDTH = 10
+_MKRF_CT_BUCKET_ANCHORS = (35, 40, 45)
+_MKRF_CT_BUCKET_WIDTH = 5
 _MKRF_CT_BUCKET_PREFIX_WIDTH = 3
+_MKRF_CT_TARGET_BA_REMOVAL_FRACTION = 0.45
+_MKRF_CT_MIN_CW_SHARE_PCT = 15.0
 
 
 def _build_lookup_expr(keys: list[str], values: list[str], *, key_expr: str) -> str:
@@ -117,29 +119,55 @@ def _mkrf_ct_bucket_prefix(anchor_age: int) -> str:
 
 
 def _mkrf_ct_bucket_specs() -> tuple[dict[str, int | str], ...]:
-    half_width = _MKRF_CT_BUCKET_WIDTH // 2
     return tuple(
         {
             "anchor_age": int(anchor_age),
             "label": _mkrf_ct_bucket_label(anchor_age),
             "prefix": _mkrf_ct_bucket_prefix(anchor_age),
-            "min_age": int(anchor_age) - half_width,
-            "max_age": int(anchor_age) + half_width - 1,
+            "min_age": int(anchor_age),
+            "max_age": int(anchor_age) + _MKRF_CT_BUCKET_WIDTH - 1,
         }
         for anchor_age in _MKRF_CT_BUCKET_ANCHORS
     )
 
 
+def _ct_product_species_fraction_expr(
+    share_column: str,
+    origin_share_lookup_exprs: dict[str, str],
+) -> str:
+    target = str(_MKRF_CT_TARGET_BA_REMOVAL_FRACTION)
+    hw_share = origin_share_lookup_exprs["share_hw"]
+    fd_share = origin_share_lookup_exprs["share_fd"]
+    if share_column == "share_cw":
+        return "0"
+    if share_column == "share_hw":
+        return f"if(({hw_share}) gt {target},1,({hw_share})/{target})"
+    if share_column == "share_fd":
+        return (
+            f"if(({hw_share}) gt {target},0,"
+            f"if(({hw_share})+({fd_share}) gt {target},"
+            f"({target}-({hw_share}))/{target},({fd_share})/{target}))"
+        )
+    if share_column == "share_oth":
+        return (
+            f"if(({hw_share})+({fd_share}) gt {target},0,"
+            f"({target}-({hw_share})-({fd_share}))/{target})"
+        )
+    return "0"
+
+
 def _build_managed_species_share_table(
     managed_bootstrap_table: pd.DataFrame,
+    *,
+    species_prefix: str = "managed",
 ) -> pd.DataFrame:
     rows: list[dict[str, object]] = []
     for row in managed_bootstrap_table.itertuples(index=False):
         shares = {bucket: 0.0 for bucket in _SPECIES_BUCKETS}
         for index in range(1, 6):
-            species_code = getattr(row, f"managed_species_{index}", "")
+            species_code = getattr(row, f"{species_prefix}_species_{index}", "")
             pct_value = pd.to_numeric(
-                getattr(row, f"managed_pct_{index}", 0.0), errors="coerce"
+                getattr(row, f"{species_prefix}_pct_{index}", 0.0), errors="coerce"
             )
             if pd.isna(pct_value) or float(pct_value) <= 0:
                 continue
@@ -2087,6 +2115,17 @@ def initialize_mkrf_runtime_package(
     managed_species_shares = managed_species_shares.assign(
         au_id=lambda df: df["au_id"].astype(str)
     ).sort_values("au_id", kind="stable")
+    ct_eligibility_species_shares = _build_managed_species_share_table(
+        managed_bootstrap,
+        species_prefix=(
+            "base_managed"
+            if "base_managed_species_1" in managed_bootstrap.columns
+            else "managed"
+        ),
+    )
+    ct_eligibility_species_shares = ct_eligibility_species_shares.assign(
+        au_id=lambda df: df["au_id"].astype(str)
+    ).sort_values("au_id", kind="stable")
     unmanaged_share_assignment = stand_au_assignment.merge(
         normalized_assignment[["forest_cover_id", "au_id"]]
         .drop_duplicates(subset=["forest_cover_id"], keep="first")
@@ -2131,6 +2170,19 @@ def initialize_mkrf_runtime_package(
             key_expr=runtime_base_au_expr,
         )
         managed_share_lookup_exprs[share_column] = f"Number({lookup_expr})/100"
+    ct_eligibility_cw_values = [
+        str(float(value))
+        for value in ct_eligibility_species_shares["share_cw"].fillna(0.0).tolist()
+    ]
+    ct_eligibility_cw_lookup_expr = (
+        "Number("
+        + _build_lookup_expr(
+            ct_eligibility_species_shares["au_id"].tolist(),
+            ct_eligibility_cw_values,
+            key_expr=runtime_base_au_expr,
+        )
+        + ")/100"
+    )
     unmanaged_share_lookup_exprs: dict[str, str] = {}
     unmanaged_share_keys = unmanaged_species_shares["au_id"].tolist()
     for share_column in managed_share_label_map:
@@ -2189,8 +2241,16 @@ def initialize_mkrf_runtime_package(
             anchor_age = int(bucket_spec["anchor_age"])
             bucket_prefix = str(bucket_spec["prefix"])
             bucket_label = str(bucket_spec["label"])
-            natural_gap = round(_curve_group_value_at_age(natural_group, anchor_age) * 0.4, 6)
-            treated_gap = round(_curve_group_value_at_age(managed_group, anchor_age) * 0.4, 6)
+            natural_gap = round(
+                _curve_group_value_at_age(natural_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
+            treated_gap = round(
+                _curve_group_value_at_age(managed_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
             natural_residual_curve_id = f"THN{anchor_age:03d}_FG_{au_token}"
             treated_residual_curve_id = f"THN{anchor_age:03d}_MG_{au_token}"
             natural_extraction_curve_id = f"CT{anchor_age:03d}_FG_{au_token}"
@@ -2398,8 +2458,16 @@ def initialize_mkrf_runtime_package(
         natural_group = first_growth_by_au.get(str(row.au_id), managed_group)
         for bucket_spec in ct_bucket_specs:
             anchor_age = int(bucket_spec["anchor_age"])
-            natural_gap = round(_curve_group_value_at_age(natural_group, anchor_age) * 0.4, 6)
-            treated_gap = round(_curve_group_value_at_age(managed_group, anchor_age) * 0.4, 6)
+            natural_gap = round(
+                _curve_group_value_at_age(natural_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
+            treated_gap = round(
+                _curve_group_value_at_age(managed_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
             natural_residual_curve = et.SubElement(
                 forestmodel_root,
                 "curve",
@@ -2606,7 +2674,9 @@ def initialize_mkrf_runtime_package(
         {
             "statement": (
                 "status in managed and oper in operable and ct eq 'Y' "
-                "and not startswith(au,'thn')"
+                "and not startswith(au,'thn') "
+                f"and {ct_eligibility_cw_lookup_expr} gt "
+                f"{_MKRF_CT_MIN_CW_SHARE_PCT / 100.0}"
             )
         },
     )
@@ -2846,12 +2916,19 @@ def initialize_mkrf_runtime_package(
             "attribute",
             {"label": f"product.yield.managed.indsp.{species_label}"},
         )
+        ct_product_species_fraction_expr = _ct_product_species_fraction_expr(
+            share_column,
+            origin_share_lookup_exprs,
+        )
         et.SubElement(
             product_indsp_attr,
             "expression",
             {
                 "statement": (
-                    f"{product_curve_expr}*({origin_share_lookup_exprs[share_column]})"
+                    f"{product_curve_expr}*("
+                    f"if(startswith(treatment,'CT'),"
+                    f"{ct_product_species_fraction_expr},"
+                    f"{origin_share_lookup_exprs[share_column]}))"
                 ),
                 "by": "1",
                 "ignoreMissingAttributes": "false",

--- a/tests/test_mkrf_managed.py
+++ b/tests/test_mkrf_managed.py
@@ -6,12 +6,14 @@ from pathlib import Path
 import pandas as pd
 
 from femic.pipeline.mkrf_managed import (
+    apply_hw_ingrowth_overlay,
     build_mkrf_managed_au_bootstrap_table,
     build_mkrf_managed_au_msyt_table,
     build_mkrf_stand_origin_assignment,
     classify_mkrf_origin,
     load_mkrf_managed_rule_config,
     parse_mkrf_managed_au_curves,
+    resolve_hw_ingrowth_pct,
 )
 from femic.workflows.mkrf import build_mkrf_managed_au_curves
 
@@ -116,6 +118,133 @@ def test_build_mkrf_stand_origin_assignment_publishes_origin_classes() -> None:
     assert out["forest_cover_id"].tolist() == [101, 102]
     assert out["origin_class"].tolist() == ["logging_origin", "fire_origin"]
     assert out["site_index"].tolist() == [24.0, 30.0]
+
+
+def test_hw_ingrowth_overlay_resolves_and_transfers_species_mix(tmp_path: Path) -> None:
+    rules_yaml = tmp_path / "tsamkrf.yaml"
+    rules_yaml.write_text(
+        """
+schema_version: 1
+case_code: "mkrf"
+hw_ingrowth_overlay:
+  enabled: true
+  landscape_default_pct: 10
+  au_overrides_pct:
+    cwh_vm_2_cw_hw: 20
+  stand_overrides_pct:
+    "202": 30
+families:
+  cwh_vm_1:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "1"
+    species_mix:
+      FD: 45
+      CW: 45
+      PW: 10
+  cwh_vm_2:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "2"
+    species_mix:
+      CW: 70
+      FD: 15
+      PW: 5
+      BA: 5
+      SS: 5
+""".strip(),
+        encoding="utf-8",
+    )
+    rule_config = load_mkrf_managed_rule_config(rules_yaml)
+
+    assert resolve_hw_ingrowth_pct(
+        rule_config=rule_config,
+        au_id="cwh_vm_1_cw_fdc",
+    ) == (10.0, "landscape_default")
+    assert resolve_hw_ingrowth_pct(
+        rule_config=rule_config,
+        au_id="cwh_vm_2_cw_hw",
+    ) == (20.0, "au_override")
+    assert resolve_hw_ingrowth_pct(
+        rule_config=rule_config,
+        au_id="cwh_vm_2_cw_hw",
+        stand_id=202,
+    ) == (30.0, "stand_override")
+
+    assert apply_hw_ingrowth_overlay(
+        species_mix={"CW": 80, "FD": 20},
+        hw_ingrowth_pct=10,
+    ) == {"CW": 72.0, "FD": 18.0, "HW": 10.0}
+
+
+def test_build_mkrf_managed_au_bootstrap_table_applies_hw_ingrowth_overlay(
+    tmp_path: Path,
+) -> None:
+    rules_yaml = tmp_path / "tsamkrf.yaml"
+    rules_yaml.write_text(
+        """
+schema_version: 1
+case_code: "mkrf"
+hw_ingrowth_overlay:
+  enabled: true
+  landscape_default_pct: 50
+families:
+  cwh_vm_2:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "2"
+    species_mix:
+      CW: 70
+      FD: 15
+      PW: 5
+      BA: 5
+      SS: 5
+""".strip(),
+        encoding="utf-8",
+    )
+    rule_config = load_mkrf_managed_rule_config(rules_yaml)
+    selected_au_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_2_cw_hw",
+                "selected_rank": 1,
+                "covered_area_ha": 100.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "cw",
+                "leading_species_2": "hw",
+            },
+        ]
+    )
+    stand_origin_assignment = pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 201,
+                "au_id": "cwh_vm_2_cw_hw",
+                "origin_class": "logging_origin",
+                "site_index": 24.0,
+            },
+        ]
+    )
+
+    out = build_mkrf_managed_au_bootstrap_table(
+        selected_au_table=selected_au_table,
+        stand_origin_assignment=stand_origin_assignment,
+        rule_config=rule_config,
+    )
+
+    row = out.iloc[0]
+    assert row["base_managed_species_1"] == "CW"
+    assert row["base_managed_pct_1"] == 70.0
+    assert row["hw_ingrowth_pct"] == 50.0
+    assert row["hw_ingrowth_source"] == "landscape_default"
+    assert row["managed_species_1"] == "HW"
+    assert row["managed_pct_1"] == 52.5
+    assert row["managed_species_2"] == "CW"
+    assert row["managed_pct_2"] == 35.0
+    assert row["managed_species_overflow_to_hw_pct"] == 2.5
+    assert row["managed_species_overflow_to_hw_codes"] == "SS"
 
 
 def test_build_mkrf_managed_au_bootstrap_table_uses_expert_rules_and_si_fallback(
@@ -267,6 +396,44 @@ def test_build_mkrf_managed_au_msyt_table_supports_pw_ss_species() -> None:
     assert row["pw_si"] == 24.0
     assert row["ss_si"] == 24.0
     assert row["planted_density1"] == 1050
+
+
+def test_build_mkrf_managed_au_msyt_table_rebalances_fractional_density_rounding() -> None:
+    bootstrap_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_cw_hw",
+                "selected_rank": 1,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "1",
+                "managed_curve_id": 60001,
+                "included_in_msyt": True,
+                "managed_si": 24.0,
+                "regen_delay": 1,
+                "density_total": 1500,
+                "oaf1": 1.0,
+                "oaf2": 0.95,
+                "managed_species_1": "HW",
+                "managed_species_2": "CW",
+                "managed_species_3": "FD",
+                "managed_species_4": "PW",
+                "managed_species_5": "",
+                "managed_pct_1": 50.0,
+                "managed_pct_2": 22.5,
+                "managed_pct_3": 22.5,
+                "managed_pct_4": 5.0,
+                "managed_pct_5": 0.0,
+            }
+        ]
+    )
+
+    out = build_mkrf_managed_au_msyt_table(bootstrap_table=bootstrap_table)
+
+    row = out.iloc[0].to_dict()
+    densities = [row[f"planted_density{index}"] or 0 for index in range(1, 6)]
+    assert sum(densities) == 1500
+    assert densities[:4] == [750, 338, 337, 75]
 
 
 def test_parse_mkrf_managed_au_curves_maps_back_to_au_id(tmp_path: Path) -> None:

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -152,6 +152,16 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
                 "managed_pct_3": 20.0,
                 "managed_pct_4": 0.0,
                 "managed_pct_5": 0.0,
+                "base_managed_species_1": "CW",
+                "base_managed_species_2": "FD",
+                "base_managed_species_3": "BA",
+                "base_managed_species_4": "",
+                "base_managed_species_5": "",
+                "base_managed_pct_1": 50.0,
+                "base_managed_pct_2": 30.0,
+                "base_managed_pct_3": 20.0,
+                "base_managed_pct_4": 0.0,
+                "base_managed_pct_5": 0.0,
             },
             {
                 "au_id": "cwh_vm_1_dr_hw",
@@ -165,6 +175,16 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
                 "managed_pct_3": 0.0,
                 "managed_pct_4": 0.0,
                 "managed_pct_5": 0.0,
+                "base_managed_species_1": "CW",
+                "base_managed_species_2": "FD",
+                "base_managed_species_3": "PW",
+                "base_managed_species_4": "",
+                "base_managed_species_5": "",
+                "base_managed_pct_1": 45.0,
+                "base_managed_pct_2": 45.0,
+                "base_managed_pct_3": 10.0,
+                "base_managed_pct_4": 0.0,
+                "base_managed_pct_5": 0.0,
             },
         ]
     ).to_csv(managed_bootstrap_csv, index=False)
@@ -414,9 +434,14 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert '<attribute label="product.yield.managed.total">' in forestmodel_text
     assert '<attribute label="product.yield.managed.indsp.Ba">' in forestmodel_text
     assert '<attribute label="\'product.yield.managed.treat.\'+treatment">' in forestmodel_text
+    assert "if(startswith(treatment,'CT'),0," in forestmodel_text
+    assert "/0.45" in forestmodel_text
+    assert "if(startswith(treatment,'CT'),if((" in forestmodel_text
     assert "if(origin eq 'natural' and hasnatcurve eq 'Y'," in forestmodel_text
     assert "lookupTable(treatment+'|'+if(startswith(au,'thn'),substring(au,7),au)," in forestmodel_text
-    assert "'CT40|cwh_vm_1_dr_hw,CT50|cwh_vm_1_dr_hw" in forestmodel_text
+    assert "'CT35|cwh_vm_1_dr_hw,CT40|cwh_vm_1_dr_hw,CT45|cwh_vm_1_dr_hw" in forestmodel_text
+    assert "CT50|" not in forestmodel_text
+    assert "CT150|" not in forestmodel_text
     assert "startswith(treatment,'CT')" in forestmodel_text
     assert "if(startswith(au,'thn'),curveId(" in forestmodel_text
     assert "),if(startswith(au,'thn'),curveId(" in forestmodel_text
@@ -427,14 +452,22 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert 'select statement="status in managed and oper in operable"' in forestmodel_text
     assert 'select statement="status in managed"' in forestmodel_text
     assert "not startswith(au,'thn')" in forestmodel_text
+    assert "share_cw" not in forestmodel_text
+    assert " gt 0.15" in forestmodel_text
+    assert "'cwh_vm_1_dr_hw,cwh_vm_1_hw_cw','45.0,50.0'" in forestmodel_text
+    assert "treatment label=\"CT35\" minage=\"35\" maxage=\"39\"" in forestmodel_text
+    assert "treatment label=\"CT40\" minage=\"40\" maxage=\"44\"" in forestmodel_text
+    assert "treatment label=\"CT45\" minage=\"45\" maxage=\"49\"" in forestmodel_text
     assert "'thn040_'+au" in forestmodel_text
-    assert "'thn150_'+au" in forestmodel_text
+    assert "'thn035_'+au" in forestmodel_text
+    assert "'thn045_'+au" in forestmodel_text
+    assert "'thn050_'+au" not in forestmodel_text
+    assert "'thn150_'+au" not in forestmodel_text
     assert 'field="statecode" value="\'THN\'"' not in forestmodel_text
     assert "<track>" in forestmodel_text
     assert 'treatment label="CC"' in forestmodel_text
     assert 'treatment label="CT"' not in forestmodel_text
-    assert 'treatment label="CT40" minage="35" maxage="44" retain="20"' in forestmodel_text
-    assert 'treatment label="CT150" minage="145" maxage="154" retain="20"' in forestmodel_text
+    assert 'treatment label="CT40" minage="40" maxage="44" retain="20"' in forestmodel_text
 
 
 def test_audit_mkrf_runtime_sanity_flags_zero_signal_with_nonzero_source_share(


### PR DESCRIPTION
## Summary
- adds FEMIC generator support for the MKRF cedar-pole CT runtime
- adds the planted Hw ingrowth overlay in managed BTC inputs
- adds target-bounded Hw-first CT product allocation and 35-49 CT bucket generation
- updates tests and the `external/femic-mkrf-instance` submodule pointer

## Dependency
- Depends on UBC-FRESH/femic-mkrf-instance#14, which publishes the regenerated MKRF runtime package and Matrix Builder tracks.

## QA
- `python -m pytest tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py -q` passed: 12 tests
- `python -m pytest tests/test_tipsy_config.py -q` passed: 33 tests
- Downstream Patchworks gate passed in the submodule: Matrix Builder, `mkrf.base` smoke, and saved-stage sanity audit with 0 failures.

Refs UBC-FRESH/femic-mkrf-instance#8.