### PR TITLE
Generate MKRF Patchworks map layer fixes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1928,10 +1928,10 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
 - [x] P70.3 Prove the map-layer fix against generated artifacts and runtime smoke (`UBC-FRESH/femic-mkrf-instance#21`)
   - [x] P70.3a Regenerate the canonical runtime package so ``models/mkrf_patchworks_model/analysis/base.pin`` carries the updated map layers.
   - [x] P70.3b Run targeted pytest, Patchworks preflight, default ``mkrf.base`` smoke, saved-stage sanity audit, and instance docs build.
-- [ ] P70.4 Publish the map-layer bugfix branch and close issue `UBC-FRESH/femic-mkrf-instance#21`
+- [x] P70.4 Publish the map-layer bugfix branch and close issue `UBC-FRESH/femic-mkrf-instance#21`
   - [x] P70.4a Push the instance and parent branches and open PRs.
-  - [ ] P70.4b Merge the instance/runtime PR, then merge the parent generator/submodule-pointer PR.
-  - [ ] P70.4c Close issue `UBC-FRESH/femic-mkrf-instance#21` after PR merge.
+  - [x] P70.4b Merge the instance/runtime PR, then merge the parent generator/submodule-pointer PR.
+  - [x] P70.4c Close issue `UBC-FRESH/femic-mkrf-instance#21` after PR merge.
 
 ### Detailed Next Steps Notes
 
@@ -1948,4 +1948,4 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - `P70.1` complete
   - `P70.2` complete
   - `P70.3` complete
-  - `P70.4` in progress: instance branch publication is done; follow-up color-ramp PR, parent PR update, merge, and issue closeout remain
+  - `P70.4` complete: branch publication, PRs, merge, and issue closeout are handled for `UBC-FRESH/femic-mkrf-instance#21`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1923,13 +1923,13 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P70.1a Open the bug issue for treatment legend labels, forest outline presentation, and age-class layer coverage.
 - [x] P70.2 Update the canonical MKRF ``base.pin`` map-layer generator (`UBC-FRESH/femic-mkrf-instance#21`)
   - [x] P70.2a Replace generic CT legend entries with the active treatment labels ``CT35``, ``CT40``, and ``CT45`` for current/latest treatment layers.
-  - [x] P70.2b Rename/restyle the default block layer as a semi-transparent gray ``Forest Outline`` context layer.
-  - [x] P70.2c Add a hidden-by-default ``Age Class (20-year)`` layer keyed to dynamic mean fragment age via ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)``.
+  - [x] P70.2b Rename/restyle the default block layer as a very light gray ``Forest Outline`` context layer.
+  - [x] P70.2c Add a hidden-by-default ``Age Class (20-year)`` layer keyed to dynamic mean fragment age via ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`` with an explicit yellow-green graduated color ramp.
 - [x] P70.3 Prove the map-layer fix against generated artifacts and runtime smoke (`UBC-FRESH/femic-mkrf-instance#21`)
   - [x] P70.3a Regenerate the canonical runtime package so ``models/mkrf_patchworks_model/analysis/base.pin`` carries the updated map layers.
   - [x] P70.3b Run targeted pytest, Patchworks preflight, default ``mkrf.base`` smoke, saved-stage sanity audit, and instance docs build.
 - [ ] P70.4 Publish the map-layer bugfix branch and close issue `UBC-FRESH/femic-mkrf-instance#21`
-  - [ ] P70.4a Push the instance and parent branches and open PRs.
+  - [x] P70.4a Push the instance and parent branches and open PRs.
   - [ ] P70.4b Merge the instance/runtime PR, then merge the parent generator/submodule-pointer PR.
   - [ ] P70.4c Close issue `UBC-FRESH/femic-mkrf-instance#21` after PR merge.
 
@@ -1948,4 +1948,4 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - `P70.1` complete
   - `P70.2` complete
   - `P70.3` complete
-  - `P70.4` in progress: local fix and QA are done; branch publication, PRs, merge, and issue closeout remain
+  - `P70.4` in progress: instance branch publication is done; follow-up color-ramp PR, parent PR update, merge, and issue closeout remain

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1917,6 +1917,22 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P69.4c Open the follow-up PRs for the instance/runtime package and parent FEMIC pointer/code changes.
   - [x] P69.4d Close the issue set once `UBC-FRESH/femic-mkrf-instance#20` and `UBC-FRESH/femic#193` are reviewed/merged.
 
+## Phase 70: MKRF Patchworks Map-Layer Presentation Fix
+
+- [x] P70.1 Record the Patchworks GUI map-layer bug (`UBC-FRESH/femic-mkrf-instance#21`)
+  - [x] P70.1a Open the bug issue for treatment legend labels, forest outline presentation, and age-class layer coverage.
+- [x] P70.2 Update the canonical MKRF ``base.pin`` map-layer generator (`UBC-FRESH/femic-mkrf-instance#21`)
+  - [x] P70.2a Replace generic CT legend entries with the active treatment labels ``CT35``, ``CT40``, and ``CT45`` for current/latest treatment layers.
+  - [x] P70.2b Rename/restyle the default block layer as a semi-transparent gray ``Forest Outline`` context layer.
+  - [x] P70.2c Add a hidden-by-default ``Age Class (20-year)`` layer keyed to dynamic mean fragment age via ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)``.
+- [x] P70.3 Prove the map-layer fix against generated artifacts and runtime smoke (`UBC-FRESH/femic-mkrf-instance#21`)
+  - [x] P70.3a Regenerate the canonical runtime package so ``models/mkrf_patchworks_model/analysis/base.pin`` carries the updated map layers.
+  - [x] P70.3b Run targeted pytest, Patchworks preflight, default ``mkrf.base`` smoke, saved-stage sanity audit, and instance docs build.
+- [ ] P70.4 Publish the map-layer bugfix branch and close issue `UBC-FRESH/femic-mkrf-instance#21`
+  - [ ] P70.4a Push the instance and parent branches and open PRs.
+  - [ ] P70.4b Merge the instance/runtime PR, then merge the parent generator/submodule-pointer PR.
+  - [ ] P70.4c Close issue `UBC-FRESH/femic-mkrf-instance#21` after PR merge.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -1929,3 +1945,7 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - `P69.2` complete
   - `P69.3` complete
   - `P69.4` complete; follow-up PRs are merged and the issue set is closed
+  - `P70.1` complete
+  - `P70.2` complete
+  - `P70.3` complete
+  - `P70.4` in progress: local fix and QA are done; branch publication, PRs, merge, and issue closeout remain

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -3743,10 +3743,97 @@ def initialize_mkrf_runtime_package(
 
                   DefaultTheme def = new DefaultTheme(
                      blockData,
-                     new PolygonSymbol(new Color(204, 204, 255))
+                     new PolygonSymbol(new Color(128, 128, 128, 128))
                   );
+                  def.setCaption("Forest Outline");
                   Layer defLayer = new GeoRelLayer(blockData, def);
                   layers.add(defLayer);
+
+                  NumericTheme ageClassTheme = new NumericTheme(blockData);
+                  ageClassTheme.setFieldname("0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)");
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_000_019",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 0)
+                     ),
+                     "0 - 19"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_020_039",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 1)
+                     ),
+                     "20 - 39"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_040_059",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 2)
+                     ),
+                     "40 - 59"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_060_079",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 3)
+                     ),
+                     "60 - 79"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_080_099",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 4)
+                     ),
+                     "80 - 99"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_100_119",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 5)
+                     ),
+                     "100 - 119"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_120_139",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 6)
+                     ),
+                     "120 - 139"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_140_159",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 7)
+                     ),
+                     "140 - 159"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_160_179",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 8)
+                     ),
+                     "160 - 179"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_180_199",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 9)
+                     ),
+                     "180 - 199"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_200plus",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 10)
+                     ),
+                     "200 - 99999"
+                  );
+                  ageClassTheme.setCaption("Age Class (20-year)");
+                  ageClassTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+                  blockData.addTheme(ageClassTheme);
+                  GeoRelLayer ageClassLayer = new GeoRelLayer(blockData, ageClassTheme);
+                  ageClassLayer.setVisible(false);
+                  layers.add(ageClassLayer);
 
                   UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
                   currTreatTheme.setFieldname("CURRENTTREATMENT");
@@ -3759,10 +3846,24 @@ def initialize_mkrf_runtime_package(
                   );
                   currTreatTheme.addElement(
                      new ThemeElement(
-                        "CT",
+                        "CT35",
                         PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 1)
                      ),
-                     "CT"
+                     "CT35"
+                  );
+                  currTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT40",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 2)
+                     ),
+                     "CT40"
+                  );
+                  currTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT45",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 3)
+                     ),
+                     "CT45"
                   );
                   currTreatTheme.setCaption("Current Treatments");
                   currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
@@ -3782,10 +3883,24 @@ def initialize_mkrf_runtime_package(
                   );
                   latestTreatTheme.addElement(
                      new ThemeElement(
-                        "CT",
+                        "CT35",
                         PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 1)
                      ),
-                     "CT"
+                     "CT35"
+                  );
+                  latestTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT40",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 2)
+                     ),
+                     "CT40"
+                  );
+                  latestTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT45",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 3)
+                     ),
+                     "CT45"
                   );
                   latestTreatTheme.setCaption("Latest Treatments");
                   latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -3743,7 +3743,7 @@ def initialize_mkrf_runtime_package(
 
                   DefaultTheme def = new DefaultTheme(
                      blockData,
-                     new PolygonSymbol(new Color(128, 128, 128, 128))
+                     new PolygonSymbol(new Color(239, 239, 239))
                   );
                   def.setCaption("Forest Outline");
                   Layer defLayer = new GeoRelLayer(blockData, def);
@@ -3754,77 +3754,77 @@ def initialize_mkrf_runtime_package(
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_000_019",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 0)
+                        new PolygonSymbol(new Color(255, 255, 229))
                      ),
                      "0 - 19"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_020_039",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 1)
+                        new PolygonSymbol(new Color(248, 252, 193))
                      ),
                      "20 - 39"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_040_059",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 2)
+                        new PolygonSymbol(new Color(229, 244, 171))
                      ),
                      "40 - 59"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_060_079",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 3)
+                        new PolygonSymbol(new Color(199, 232, 154))
                      ),
                      "60 - 79"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_080_099",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 4)
+                        new PolygonSymbol(new Color(162, 216, 137))
                      ),
                      "80 - 99"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_100_119",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 5)
+                        new PolygonSymbol(new Color(120, 198, 121))
                      ),
                      "100 - 119"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_120_139",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 6)
+                        new PolygonSymbol(new Color(76, 176, 98))
                      ),
                      "120 - 139"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_140_159",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 7)
+                        new PolygonSymbol(new Color(47, 147, 77))
                      ),
                      "140 - 159"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_160_179",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 8)
+                        new PolygonSymbol(new Color(20, 120, 62))
                      ),
                      "160 - 179"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_180_199",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 9)
+                        new PolygonSymbol(new Color(0, 97, 52))
                      ),
                      "180 - 199"
                   );
                   ageClassTheme.addElement(
                      new ThemeElement(
                         "age_200plus",
-                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 10)
+                        new PolygonSymbol(new Color(0, 69, 41))
                      ),
                      "200 - 99999"
                   );

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -386,7 +386,7 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert 'block_shape = "../spatial/fragments.shp";' in analysis_pin_text
     assert "setupYieldFlowTargets(control, periods, tracks_path_prefix);" in analysis_pin_text
     assert 'def.setCaption("Forest Outline");' in analysis_pin_text
-    assert "new PolygonSymbol(new Color(128, 128, 128, 128))" in analysis_pin_text
+    assert "new PolygonSymbol(new Color(239, 239, 239))" in analysis_pin_text
     assert (
         'ageClassTheme.setFieldname("0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)");'
         in analysis_pin_text
@@ -394,6 +394,8 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert 'ageClassTheme.setCaption("Age Class (20-year)");' in analysis_pin_text
     assert '"age_000_019"' in analysis_pin_text
     assert '"age_200plus"' in analysis_pin_text
+    assert "new PolygonSymbol(new Color(255, 255, 229))" in analysis_pin_text
+    assert "new PolygonSymbol(new Color(0, 69, 41))" in analysis_pin_text
     assert 'currTreatTheme.setFieldname("CURRENTTREATMENT");' in analysis_pin_text
     assert 'latestTreatTheme.setFieldname("LASTTREATMENT");' in analysis_pin_text
     assert '"CT35"' in analysis_pin_text

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -385,8 +385,21 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert 'sourceRelative("../scripts/targets/flowtargets.bsh");' in analysis_pin_text
     assert 'block_shape = "../spatial/fragments.shp";' in analysis_pin_text
     assert "setupYieldFlowTargets(control, periods, tracks_path_prefix);" in analysis_pin_text
+    assert 'def.setCaption("Forest Outline");' in analysis_pin_text
+    assert "new PolygonSymbol(new Color(128, 128, 128, 128))" in analysis_pin_text
+    assert (
+        'ageClassTheme.setFieldname("0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)");'
+        in analysis_pin_text
+    )
+    assert 'ageClassTheme.setCaption("Age Class (20-year)");' in analysis_pin_text
+    assert '"age_000_019"' in analysis_pin_text
+    assert '"age_200plus"' in analysis_pin_text
     assert 'currTreatTheme.setFieldname("CURRENTTREATMENT");' in analysis_pin_text
     assert 'latestTreatTheme.setFieldname("LASTTREATMENT");' in analysis_pin_text
+    assert '"CT35"' in analysis_pin_text
+    assert '"CT40"' in analysis_pin_text
+    assert '"CT45"' in analysis_pin_text
+    assert '"CT",' not in analysis_pin_text
     assert 'patch0Theme.setFieldname("product.area.managed.treat.CC.size");' in analysis_pin_text
     assert 'patch1Theme.setFieldname("feature.area.managed.seral.le10.size");' in analysis_pin_text
     assert "femicQueueHeadlessStage();" in analysis_pin_text


### PR DESCRIPTION
## Summary
- update the MKRF runtime package generator so `base.pin` emits the corrected GUI map layers
- replace the forest outline alpha symbol with solid very-light-gray paint (`239,239,239`) for Patchworks renderer compatibility
- add regression coverage for the forest outline, dynamic 20-year age-class layer, explicit YlGn-style ramp endpoints, and explicit CT treatment legend labels
- advance the MKRF instance submodule through UBC-FRESH/femic-mkrf-instance#23
- record Phase 70 roadmap status for issue UBC-FRESH/femic-mkrf-instance#21

## QA
- runtime package regenerated from the updated generator
- targeted pytest: `tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py tests/test_tipsy_config.py` -> `45 passed`
- Patchworks preflight passed
- Patchworks smoke run `mkrf_map_layers_ramp_outline_smoke_20260606` passed with return code `0`
- saved-stage sanity audit: `24` rows, `0` failures
- instance docs build passed

Refs UBC-FRESH/femic-mkrf-instance#21
Depends on UBC-FRESH/femic-mkrf-instance#23