### PR TITLE
Aggregate minor MKRF strata

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1974,6 +1974,27 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P72.2c Create the `v1.0.0-alpha1` tag and GitHub pre-release in `UBC-FRESH/femic-tsa29-instance`.
   - [x] P72.2d Record the release in the parent changelog/planning surfaces and publish the matching closeout comments.
 
+## Phase 73: MKRF Stand Stratification Revisions
+
+- [x] P73.1 Record the MKRF stand-stratification revision issue set (`UBC-FRESH/femic-mkrf-instance#25`)
+  - [x] P73.1a Open separate child issues for minor-strata aggregation and major-strata site-series splitting (`UBC-FRESH/femic-mkrf-instance#26`, `#27`).
+  - [x] P73.1b Record the BEC field-guide reference and Anna's note that the major-stratum split logic remains TBD for the site-series child.
+- [x] P73.2 Implement the reviewed minor-strata aggregation pass (`UBC-FRESH/femic-mkrf-instance#26`)
+  - [x] P73.2a Add explicit raw-to-canonical AU aggregation before selected-AU publication for:
+    - `cwh_vm_2_ba_hw` -> `cwh_vm_2_hw_ba`
+    - `cwh_dm_x_dr_mb` -> `cwh_dm_x_dr_act`
+    - `cwh_dm_x_cw_dr` -> `cwh_dm_x_dr_cw`
+    - `cwh_vm_1_ba_hw` -> `cwh_vm_1_hw_ba`
+    - `cwh_vm_1_fdc_hw` -> `cwh_vm_1_fdc_x`
+  - [x] P73.2b Preserve raw AU lineage in `stand_au_assignment.csv` and add `au_aggregation_audit.csv` so the aggregation is reviewable.
+  - [x] P73.2c Regenerate AU inputs, selected AU table, managed inputs, managed curves, runtime package, Matrix Builder tracks, and the default `mkrf.base` smoke.
+  - [x] P73.2d Fix runtime first-growth summary counts so manifests/XML report the selected runtime AU surface after aggregation.
+  - [x] P73.2e Update MKRF docs/runbook surfaces for the AU aggregation audit and validation lane.
+- [ ] P73.3 Publish the aggregation branch bundle and close child issue `UBC-FRESH/femic-mkrf-instance#26`
+  - [ ] P73.3a Commit and push the instance and parent branches with the regenerated runtime artifacts and submodule pointer update.
+  - [ ] P73.3b Post QA commands, run IDs, and audit summary back to `#26`.
+  - [ ] P73.3c Open the instance and parent PRs for review.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2000,3 +2021,5 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - `P72.2c` complete: `UBC-FRESH/femic-tsa29-instance` pre-release `v1.0.0-alpha1` is published from merged `main` commit `45af95c`
   - `P72.2d` complete: release closeout is recorded in the parent planning surfaces and governing TSA29 release issue `#8`
   - `P72` complete
+  - `P73.1` complete
+  - `P73.2` complete locally for `UBC-FRESH/femic-mkrf-instance#26`; publication and issue closeout remain next

--- a/src/femic/pipeline/mkrf_au.py
+++ b/src/femic/pipeline/mkrf_au.py
@@ -6,10 +6,18 @@ from dataclasses import dataclass
 import math
 from typing import Any
 
+import numpy as np
 import pandas as pd
 
 
 _SPECIES_SLOT_COUNT = 6
+_MKRF_AU_AGGREGATION_TARGETS: dict[str, str] = {
+    "cwh_vm_2_ba_hw": "cwh_vm_2_hw_ba",
+    "cwh_dm_x_dr_mb": "cwh_dm_x_dr_act",
+    "cwh_dm_x_cw_dr": "cwh_dm_x_dr_cw",
+    "cwh_vm_1_ba_hw": "cwh_vm_1_hw_ba",
+    "cwh_vm_1_fdc_hw": "cwh_vm_1_fdc_x",
+}
 
 
 def parse_mkrf_bec(value: object) -> tuple[str, str, str]:
@@ -120,6 +128,12 @@ def annotate_mkrf_au_keys(source_table: pd.DataFrame) -> pd.DataFrame:
         + "_"
         + table["leading_species_2"].astype(str)
     )
+    table["raw_au_id"] = table["au_id"]
+    table["au_id"] = table["raw_au_id"].map(
+        lambda value: _MKRF_AU_AGGREGATION_TARGETS.get(str(value), str(value))
+    )
+    table["au_aggregation_target"] = table["au_id"]
+    table["au_aggregation_applied"] = table["raw_au_id"] != table["au_id"]
     return table
 
 
@@ -150,7 +164,10 @@ def build_mkrf_assignment_rows(source_table: pd.DataFrame) -> pd.DataFrame:
             "shape_area_ha": (
                 pd.to_numeric(shape_area, errors="coerce").fillna(0.0) / 10000.0
             ),
+            "raw_au_id": table["raw_au_id"],
             "au_id": table["au_id"],
+            "au_aggregation_applied": table["au_aggregation_applied"].astype(bool),
+            "au_aggregation_target": table["au_aggregation_target"],
             "assignment_status": "assigned",
         }
     ).sort_values(["au_id", "res_key"], kind="stable")
@@ -166,15 +183,22 @@ def build_mkrf_au_tables(
         table = table.loc[table["CONTCLAS"] != "X"].copy()
 
     assignment = build_mkrf_assignment_rows(table)
+    canonical_parts = assignment["au_id"].astype(str).str.split("_", expand=True)
+    if canonical_parts.shape[1] != 5:
+        raise ValueError("MKRF AU aggregation produced non-canonical AU identifiers.")
+    assignment = assignment.copy()
+    assignment[["au_bec_zone", "au_bec_subzone", "au_bec_variant", "au_species_1", "au_species_2"]] = (
+        canonical_parts
+    )
     au_table = (
         assignment.groupby(
             [
                 "au_id",
-                "bec_zone",
-                "bec_subzone",
-                "bec_variant",
-                "leading_species_1",
-                "leading_species_2",
+                "au_bec_zone",
+                "au_bec_subzone",
+                "au_bec_variant",
+                "au_species_1",
+                "au_species_2",
             ],
             as_index=False,
             sort=True,
@@ -184,11 +208,76 @@ def build_mkrf_au_tables(
             tie_break_record_count=("tie_break_used", "sum"),
         )
         .sort_values("au_id", kind="stable")
+        .rename(
+            columns={
+                "au_bec_zone": "bec_zone",
+                "au_bec_subzone": "bec_subzone",
+                "au_bec_variant": "bec_variant",
+                "au_species_1": "leading_species_1",
+                "au_species_2": "leading_species_2",
+            }
+        )
     )
 
     au_table["tie_break_record_count"] = au_table["tie_break_record_count"].astype(int)
     au_table["stand_count"] = au_table["stand_count"].astype(int)
     return au_table.reset_index(drop=True), assignment
+
+
+def build_mkrf_au_aggregation_audit(assignment: pd.DataFrame) -> pd.DataFrame:
+    """Summarize raw-to-canonical AU aggregation decisions."""
+    required = {"raw_au_id", "au_id", "shape_area_ha", "forest_cover_id", "res_key"}
+    missing = sorted(required - set(assignment.columns))
+    if missing:
+        raise ValueError(
+            "MKRF assignment table missing aggregation audit columns: "
+            + ", ".join(missing)
+        )
+    audit = (
+        assignment.assign(
+            raw_au_id=lambda df: df["raw_au_id"].astype(str),
+            au_id=lambda df: df["au_id"].astype(str),
+            shape_area_ha=lambda df: pd.to_numeric(
+                df["shape_area_ha"], errors="coerce"
+            ).fillna(0.0),
+            forest_cover_id=lambda df: pd.to_numeric(
+                df["forest_cover_id"], errors="coerce"
+            ),
+        )
+        .groupby(["raw_au_id", "au_id"], as_index=False, dropna=False)
+        .agg(
+            source_fragment_count=("res_key", "count"),
+            forest_cover_id_count=("forest_cover_id", "nunique"),
+            covered_area_ha=("shape_area_ha", "sum"),
+        )
+        .sort_values(["au_id", "raw_au_id"], kind="stable")
+        .reset_index(drop=True)
+    )
+    audit["was_aggregated"] = audit["raw_au_id"] != audit["au_id"]
+    total_area = float(audit["covered_area_ha"].sum())
+    audit["covered_area_share"] = (
+        audit["covered_area_ha"] / total_area if total_area > 0.0 else 0.0
+    )
+    target_area = audit.groupby("au_id")["covered_area_ha"].transform("sum")
+    audit["target_area_ha"] = target_area
+    audit["raw_share_of_target_area"] = np.where(
+        target_area.gt(0.0),
+        audit["covered_area_ha"] / target_area,
+        0.0,
+    )
+    return audit[
+        [
+            "raw_au_id",
+            "au_id",
+            "was_aggregated",
+            "source_fragment_count",
+            "forest_cover_id_count",
+            "covered_area_ha",
+            "covered_area_share",
+            "target_area_ha",
+            "raw_share_of_target_area",
+        ]
+    ]
 
 
 def build_mkrf_selected_au_table(

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from femic.pipeline.mkrf_au import (
+    build_mkrf_au_aggregation_audit,
     build_mkrf_au_tables,
     build_mkrf_selected_au_table,
 )
@@ -50,6 +51,7 @@ class MkrfAuBuildResult:
     output_dir: Path
     au_table_path: Path
     stand_assignment_path: Path
+    aggregation_audit_path: Path
     source_row_count: int
     au_count: int
 
@@ -1159,17 +1161,21 @@ def build_mkrf_au_input_bundle(
     output_dir.mkdir(parents=True, exist_ok=True)
     source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
     au_table, assignment = build_mkrf_au_tables(source_table)
+    aggregation_audit = build_mkrf_au_aggregation_audit(assignment)
 
     au_table_path = output_dir / "au_table.csv"
     stand_assignment_path = output_dir / "stand_au_assignment.csv"
+    aggregation_audit_path = output_dir / "au_aggregation_audit.csv"
     au_table.to_csv(au_table_path, index=False)
     assignment.to_csv(stand_assignment_path, index=False)
+    aggregation_audit.to_csv(aggregation_audit_path, index=False)
 
     return MkrfAuBuildResult(
         resultant_gdb=resultant_gdb,
         output_dir=output_dir,
         au_table_path=au_table_path,
         stand_assignment_path=stand_assignment_path,
+        aggregation_audit_path=aggregation_audit_path,
         source_row_count=len(assignment),
         au_count=len(au_table),
     )
@@ -2281,17 +2287,6 @@ def initialize_mkrf_runtime_package(
     )
 
     selected_au_count = int(selected_au["au_id"].astype(str).nunique())
-    first_growth_curve_au_count = int(first_growth_curves["au_id"].astype(str).nunique())
-    first_growth_missing_au_count = int(
-        first_growth_diagnostics.loc[
-            first_growth_diagnostics["selected_path"]
-            .astype(str)
-            .eq("insufficient_source_stands"),
-            "au_id",
-        ]
-        .astype(str)
-        .nunique()
-    )
     managed_curve_au_count = int(managed_curves["au_id"].astype(str).nunique())
     flagged_au_count = int(bad_curve_summary["flagged"].fillna(False).astype(bool).sum())
 
@@ -2345,6 +2340,12 @@ def initialize_mkrf_runtime_package(
     runtime_curve_status = runtime_curve_status.rename(
         columns={"selected_path": "first_growth_selected_path"}
     ).sort_values("au_id", kind="stable")
+    first_growth_curve_au_count = int(
+        runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool).sum()
+    )
+    first_growth_missing_au_count = int(
+        (~runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool)).sum()
+    )
     runtime_curve_status.to_csv(curve_status_path, index=False)
     tracks_status = (
         selected_au.assign(au_id=lambda df: df["au_id"].astype(str))

--- a/tests/test_mkrf_au.py
+++ b/tests/test_mkrf_au.py
@@ -5,6 +5,7 @@ import pandas as pd
 from pathlib import Path
 
 from femic.pipeline.mkrf_au import (
+    build_mkrf_au_aggregation_audit,
     build_mkrf_au_tables,
     build_mkrf_selected_au_table,
     ordered_top_two_species,
@@ -74,6 +75,71 @@ def test_build_mkrf_au_tables_filters_non_forest_and_groups_assignments() -> Non
     assert list(assignment["au_id"].unique()) == ["cwh_vm_2_hw_cw"]
     assert list(au_table["au_id"]) == ["cwh_vm_2_hw_cw"]
     assert list(au_table["stand_count"]) == [2]
+
+
+def test_build_mkrf_au_tables_applies_minor_strata_aggregation_auditably() -> None:
+    source = pd.DataFrame(
+        [
+            {
+                "RES_KEY": 20,
+                "FOREST_COVER_ID": 200,
+                "BEC": "CWHvm2",
+                "CONTCLAS": "C",
+                "Shape_Area": 10000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_1_SPECIES_PCT": 60,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "BA",
+                "TCL_1_TSP_2_SPECIES_PCT": 30,
+            },
+            {
+                "RES_KEY": 21,
+                "FOREST_COVER_ID": 201,
+                "BEC": "CWHvm2",
+                "CONTCLAS": "C",
+                "Shape_Area": 20000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "BA",
+                "TCL_1_TSP_1_SPECIES_PCT": 55,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_2_SPECIES_PCT": 35,
+            },
+            {
+                "RES_KEY": 22,
+                "FOREST_COVER_ID": 202,
+                "BEC": "CWHdm",
+                "CONTCLAS": "C",
+                "Shape_Area": 30000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_1_SPECIES_PCT": 50,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "DR",
+                "TCL_1_TSP_2_SPECIES_PCT": 40,
+            },
+        ]
+    )
+
+    au_table, assignment = build_mkrf_au_tables(source)
+    audit = build_mkrf_au_aggregation_audit(assignment)
+
+    assert assignment.loc[assignment["res_key"].eq(21), "raw_au_id"].iloc[0] == (
+        "cwh_vm_2_ba_hw"
+    )
+    assert assignment.loc[assignment["res_key"].eq(21), "au_id"].iloc[0] == (
+        "cwh_vm_2_hw_ba"
+    )
+    assert assignment.loc[assignment["res_key"].eq(21), "leading_species_1"].iloc[0] == "ba"
+    assert assignment.loc[assignment["res_key"].eq(21), "leading_species_1_share"].iloc[0] == 55
+
+    assert au_table["au_id"].tolist() == ["cwh_dm_x_dr_cw", "cwh_vm_2_hw_ba"]
+    merged = au_table.loc[au_table["au_id"].eq("cwh_vm_2_hw_ba")].iloc[0]
+    assert merged["stand_count"] == 2
+    assert merged["leading_species_1"] == "hw"
+    assert merged["leading_species_2"] == "ba"
+
+    aggregated_row = audit.loc[audit["raw_au_id"].eq("cwh_vm_2_ba_hw")].iloc[0]
+    assert aggregated_row["au_id"] == "cwh_vm_2_hw_ba"
+    assert bool(aggregated_row["was_aggregated"]) is True
+    assert aggregated_row["covered_area_ha"] == 2.0
+    assert aggregated_row["target_area_ha"] == 3.0
+    assert aggregated_row["raw_share_of_target_area"] == 2.0 / 3.0
 
 
 def test_build_mkrf_selected_au_table_uses_smallest_prefix_meeting_coverage() -> None:


### PR DESCRIPTION
## Summary

Parent FEMIC companion for `UBC-FRESH/femic-mkrf-instance#33` and issue `UBC-FRESH/femic-mkrf-instance#26`.

- Adds MKRF raw-to-canonical minor-strata aggregation in the AU builder.
- Adds `au_aggregation_audit.csv` generation to the MKRF AU input workflow.
- Fixes runtime first-growth summary counts so manifests/XML report the selected runtime AU surface after aggregation.
- Adds unit coverage for auditable AU aggregation.
- Updates `ROADMAP.md` with Phase 73 and advances the MKRF submodule pointer to the regenerated instance branch.

## QA

- `python -m pytest tests/test_mkrf_au.py tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py` passed, 18 tests.
- Instance docs build passed.
- Patchworks preflight passed.
- Matrix Builder passed: `issue26_au_aggregation_matrix_v2`.
- Default `mkrf.base` smoke passed: `issue26_au_aggregation_smoke`.
- Saved-stage sanity audit passed: 24 rows, 0 failures.
- Critical annex payloads copied to `arbutus-s3` and `git-annex` metadata pushed.

## Notes

One unrelated docs-contract check fails against the sibling TSA29 instance README (`legacy` wording assertion). This branch does not modify TSA29.