### PR TITLE
Feature: support MKRF site-series strata splits

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1990,10 +1990,17 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P73.2c Regenerate AU inputs, selected AU table, managed inputs, managed curves, runtime package, Matrix Builder tracks, and the default `mkrf.base` smoke.
   - [x] P73.2d Fix runtime first-growth summary counts so manifests/XML report the selected runtime AU surface after aggregation.
   - [x] P73.2e Update MKRF docs/runbook surfaces for the AU aggregation audit and validation lane.
-- [ ] P73.3 Publish the aggregation branch bundle and close child issue `UBC-FRESH/femic-mkrf-instance#26`
-  - [ ] P73.3a Commit and push the instance and parent branches with the regenerated runtime artifacts and submodule pointer update.
-  - [ ] P73.3b Post QA commands, run IDs, and audit summary back to `#26`.
-  - [ ] P73.3c Open the instance and parent PRs for review.
+- [x] P73.3 Publish the aggregation branch bundle and close child issue `UBC-FRESH/femic-mkrf-instance#26`
+  - [x] P73.3a Commit and push the instance and parent branches with the regenerated runtime artifacts and submodule pointer update.
+  - [x] P73.3b Post QA commands, run IDs, and audit summary back to `#26`.
+  - [x] P73.3c Open and merge the instance and parent PRs for review.
+- [ ] P73.4 Implement provisional site-series splitting for larger MKRF strata (`UBC-FRESH/femic-mkrf-instance#27`)
+  - [x] P73.4a Add `SITE_SERIES` normalization and split canonical base AUs whose two-decimal relative abundance is at least `0.04`, preserving smaller AUs unsplit.
+  - [x] P73.4b Add `site_series_split_audit.csv` and carry site-series metadata through `stand_au_assignment.csv`, `au_table.csv`, and `selected_au_table.csv`.
+  - [x] P73.4c Confirm the intended top 9 base AU families are split through `cwh_dm_x_cw_hw`; current split families cover `0.708450` of all assigned area, or about `0.746` relative to the 95% selected-AU coverage target.
+  - [x] P73.4d Regenerate AU inputs, selected AU table, managed inputs, managed curves, runtime package, Matrix Builder tracks, and Patchworks smoke/sanity outputs for the site-series branch.
+  - [x] P73.4e Update MKRF docs and lineage metadata for the site-series audit and provisional split rule.
+  - [ ] P73.4f Publish the issue #27 branch bundle, post QA commands/results to `#27`, and open the instance/parent PRs.
 
 ### Detailed Next Steps Notes
 
@@ -2022,4 +2029,5 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - `P72.2d` complete: release closeout is recorded in the parent planning surfaces and governing TSA29 release issue `#8`
   - `P72` complete
   - `P73.1` complete
-  - `P73.2` complete locally for `UBC-FRESH/femic-mkrf-instance#26`; publication and issue closeout remain next
+  - `P73.3` complete: issue `UBC-FRESH/femic-mkrf-instance#26` is merged and closed
+  - `P73.4` complete locally for `UBC-FRESH/femic-mkrf-instance#27`; publication and issue closeout remain next

--- a/src/femic/pipeline/mkrf_au.py
+++ b/src/femic/pipeline/mkrf_au.py
@@ -11,6 +11,8 @@ import pandas as pd
 
 
 _SPECIES_SLOT_COUNT = 6
+_MKRF_SITE_SERIES_SPLIT_THRESHOLD = 0.04
+_MKRF_SITE_SERIES_SPLIT_SHARE_DECIMALS = 2
 _MKRF_AU_AGGREGATION_TARGETS: dict[str, str] = {
     "cwh_vm_2_ba_hw": "cwh_vm_2_hw_ba",
     "cwh_dm_x_dr_mb": "cwh_dm_x_dr_act",
@@ -18,6 +20,20 @@ _MKRF_AU_AGGREGATION_TARGETS: dict[str, str] = {
     "cwh_vm_1_ba_hw": "cwh_vm_1_hw_ba",
     "cwh_vm_1_fdc_hw": "cwh_vm_1_fdc_x",
 }
+
+
+def normalize_mkrf_site_series(value: object) -> str:
+    """Normalize MKRF site-series labels into stable AU-safe suffixes."""
+    text = "" if value is None else str(value).strip()
+    if not text or text.lower() == "nan":
+        return "ssx"
+
+    if "(" in text and ")" in text:
+        code = text.rsplit("(", 1)[-1].split(")", 1)[0].strip()
+    else:
+        code = text
+    code = "".join(ch.lower() for ch in code if ch.isalnum())
+    return f"ss{code}" if code else "ssx"
 
 
 def parse_mkrf_bec(value: object) -> tuple[str, str, str]:
@@ -117,7 +133,7 @@ def annotate_mkrf_au_keys(source_table: pd.DataFrame) -> pd.DataFrame:
     )
     table = pd.concat([table, species_frame], axis=1)
 
-    table["au_id"] = (
+    table["base_au_id"] = (
         table["bec_zone"].astype(str)
         + "_"
         + table["bec_subzone"].astype(str)
@@ -128,12 +144,55 @@ def annotate_mkrf_au_keys(source_table: pd.DataFrame) -> pd.DataFrame:
         + "_"
         + table["leading_species_2"].astype(str)
     )
-    table["raw_au_id"] = table["au_id"]
-    table["au_id"] = table["raw_au_id"].map(
+    table["raw_au_id"] = table["base_au_id"]
+    table["canonical_base_au_id"] = table["raw_au_id"].map(
         lambda value: _MKRF_AU_AGGREGATION_TARGETS.get(str(value), str(value))
     )
-    table["au_aggregation_target"] = table["au_id"]
-    table["au_aggregation_applied"] = table["raw_au_id"] != table["au_id"]
+
+    has_site_series = "SITE_SERIES" in table.columns
+    if has_site_series:
+        table["site_series_label"] = table["SITE_SERIES"].astype(str).str.strip()
+        table["site_series_id"] = table["SITE_SERIES"].map(normalize_mkrf_site_series)
+    else:
+        table["site_series_label"] = ""
+        table["site_series_id"] = "ssx"
+
+    shape_area = (
+        table["Shape_Area"]
+        if "Shape_Area" in table.columns
+        else pd.Series(0.0, index=table.index)
+    )
+    table["_shape_area_ha_for_split"] = (
+        pd.to_numeric(shape_area, errors="coerce").fillna(0.0) / 10000.0
+    )
+    base_area = table.groupby("canonical_base_au_id")[
+        "_shape_area_ha_for_split"
+    ].transform("sum")
+    total_area = float(table["_shape_area_ha_for_split"].sum())
+    table["base_au_area_share"] = np.where(
+        total_area > 0.0,
+        base_area / total_area,
+        0.0,
+    )
+    table["base_au_area_share_for_split"] = table["base_au_area_share"].round(
+        _MKRF_SITE_SERIES_SPLIT_SHARE_DECIMALS
+    )
+    table["site_series_split_applied"] = has_site_series & (
+        table["base_au_area_share_for_split"] >= _MKRF_SITE_SERIES_SPLIT_THRESHOLD
+    )
+    table["site_series_split_threshold"] = _MKRF_SITE_SERIES_SPLIT_THRESHOLD
+    table["au_id"] = np.where(
+        table["site_series_split_applied"],
+        table["canonical_base_au_id"].astype(str)
+        + "_"
+        + table["site_series_id"].astype(str),
+        table["canonical_base_au_id"].astype(str),
+    )
+    table["au_aggregation_target"] = table["canonical_base_au_id"]
+    table["au_aggregation_applied"] = (
+        table["raw_au_id"] != table["canonical_base_au_id"]
+    )
+    table = table.drop(columns=["_shape_area_ha_for_split"])
     return table
 
 
@@ -161,6 +220,15 @@ def build_mkrf_assignment_rows(source_table: pd.DataFrame) -> pd.DataFrame:
             "leading_species_2_share": table["leading_species_2_share"],
             "species_count": table["species_count"].astype(int),
             "tie_break_used": table["tie_break_used"].astype(bool),
+            "site_series_label": table["site_series_label"],
+            "site_series_id": table["site_series_id"],
+            "base_au_id": table["canonical_base_au_id"],
+            "base_au_area_share": table["base_au_area_share"],
+            "base_au_area_share_for_split": table["base_au_area_share_for_split"],
+            "site_series_split_applied": table["site_series_split_applied"].astype(
+                bool
+            ),
+            "site_series_split_threshold": table["site_series_split_threshold"],
             "shape_area_ha": (
                 pd.to_numeric(shape_area, errors="coerce").fillna(0.0) / 10000.0
             ),
@@ -183,13 +251,19 @@ def build_mkrf_au_tables(
         table = table.loc[table["CONTCLAS"] != "X"].copy()
 
     assignment = build_mkrf_assignment_rows(table)
-    canonical_parts = assignment["au_id"].astype(str).str.split("_", expand=True)
+    canonical_parts = assignment["base_au_id"].astype(str).str.split("_", expand=True)
     if canonical_parts.shape[1] != 5:
         raise ValueError("MKRF AU aggregation produced non-canonical AU identifiers.")
     assignment = assignment.copy()
-    assignment[["au_bec_zone", "au_bec_subzone", "au_bec_variant", "au_species_1", "au_species_2"]] = (
-        canonical_parts
-    )
+    assignment[
+        [
+            "au_bec_zone",
+            "au_bec_subzone",
+            "au_bec_variant",
+            "au_species_1",
+            "au_species_2",
+        ]
+    ] = canonical_parts
     au_table = (
         assignment.groupby(
             [
@@ -206,6 +280,23 @@ def build_mkrf_au_tables(
         .agg(
             stand_count=("res_key", "count"),
             tie_break_record_count=("tie_break_used", "sum"),
+            site_series_id=(
+                "site_series_id",
+                lambda values: "; ".join(
+                    sorted(
+                        {str(value).strip() for value in values if str(value).strip()}
+                    )
+                ),
+            ),
+            site_series_label=(
+                "site_series_label",
+                lambda values: "; ".join(
+                    sorted(
+                        {str(value).strip() for value in values if str(value).strip()}
+                    )
+                ),
+            ),
+            site_series_split_applied=("site_series_split_applied", "max"),
         )
         .sort_values("au_id", kind="stable")
         .rename(
@@ -222,6 +313,117 @@ def build_mkrf_au_tables(
     au_table["tie_break_record_count"] = au_table["tie_break_record_count"].astype(int)
     au_table["stand_count"] = au_table["stand_count"].astype(int)
     return au_table.reset_index(drop=True), assignment
+
+
+def build_mkrf_site_series_split_audit(assignment: pd.DataFrame) -> pd.DataFrame:
+    """Summarize provisional MKRF base-stratum site-series split membership."""
+    required = {
+        "base_au_id",
+        "au_id",
+        "site_series_id",
+        "site_series_label",
+        "site_series_split_applied",
+        "site_series_split_threshold",
+        "base_au_area_share_for_split",
+        "shape_area_ha",
+        "res_key",
+        "forest_cover_id",
+    }
+    missing = sorted(required - set(assignment.columns))
+    if missing:
+        raise ValueError(
+            "MKRF assignment table missing site-series split audit columns: "
+            + ", ".join(missing)
+        )
+
+    audit = (
+        assignment.assign(
+            shape_area_ha=lambda df: pd.to_numeric(
+                df["shape_area_ha"], errors="coerce"
+            ).fillna(0.0),
+            forest_cover_id=lambda df: pd.to_numeric(
+                df["forest_cover_id"], errors="coerce"
+            ),
+        )
+        .groupby(
+            [
+                "base_au_id",
+                "au_id",
+                "site_series_id",
+                "site_series_label",
+                "site_series_split_applied",
+                "site_series_split_threshold",
+                "base_au_area_share_for_split",
+            ],
+            as_index=False,
+            dropna=False,
+        )
+        .agg(
+            source_fragment_count=("res_key", "count"),
+            forest_cover_id_count=("forest_cover_id", "nunique"),
+            covered_area_ha=("shape_area_ha", "sum"),
+        )
+    )
+    total_area = float(audit["covered_area_ha"].sum())
+    audit["covered_area_share"] = (
+        audit["covered_area_ha"] / total_area if total_area > 0.0 else 0.0
+    )
+    audit["base_au_area_ha"] = audit.groupby("base_au_id")["covered_area_ha"].transform(
+        "sum"
+    )
+    audit["base_au_area_share"] = (
+        audit["base_au_area_ha"] / total_area if total_area > 0.0 else 0.0
+    )
+    audit["site_series_share_of_base_au"] = np.where(
+        audit["base_au_area_ha"].gt(0.0),
+        audit["covered_area_ha"] / audit["base_au_area_ha"],
+        0.0,
+    )
+    base_rank = (
+        audit[["base_au_id", "base_au_area_ha"]]
+        .drop_duplicates()
+        .sort_values(
+            ["base_au_area_ha", "base_au_id"], ascending=[False, True], kind="stable"
+        )
+        .reset_index(drop=True)
+    )
+    base_rank["base_au_rank"] = range(1, len(base_rank) + 1)
+    base_rank["base_au_cumulative_area_share"] = (
+        base_rank["base_au_area_ha"].cumsum() / total_area if total_area > 0.0 else 0.0
+    )
+    audit = audit.merge(
+        base_rank[["base_au_id", "base_au_rank", "base_au_cumulative_area_share"]],
+        on="base_au_id",
+        how="left",
+    )
+    return (
+        audit[
+            [
+                "base_au_rank",
+                "base_au_id",
+                "au_id",
+                "site_series_id",
+                "site_series_label",
+                "site_series_split_applied",
+                "site_series_split_threshold",
+                "base_au_area_share_for_split",
+                "source_fragment_count",
+                "forest_cover_id_count",
+                "covered_area_ha",
+                "covered_area_share",
+                "base_au_area_ha",
+                "base_au_area_share",
+                "base_au_cumulative_area_share",
+                "site_series_share_of_base_au",
+            ]
+        ]
+        .sort_values(
+            ["base_au_rank", "site_series_share_of_base_au", "site_series_id"],
+            ascending=[True, False, True],
+            kind="stable",
+        )
+        .reset_index(drop=True)
+    )
 
 
 def build_mkrf_au_aggregation_audit(assignment: pd.DataFrame) -> pd.DataFrame:

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -17,6 +17,7 @@ from femic.pipeline.mkrf_au import (
     build_mkrf_au_aggregation_audit,
     build_mkrf_au_tables,
     build_mkrf_selected_au_table,
+    build_mkrf_site_series_split_audit,
 )
 from femic.pipeline.mkrf_first_growth import (
     _MIN_FIRST_GROWTH_SOURCE_STANDS,
@@ -52,6 +53,7 @@ class MkrfAuBuildResult:
     au_table_path: Path
     stand_assignment_path: Path
     aggregation_audit_path: Path
+    site_series_split_audit_path: Path
     source_row_count: int
     au_count: int
 
@@ -74,9 +76,16 @@ class MkrfFirstGrowthBuildResult:
 
 def _parse_mkrf_au_id(au_id: str) -> tuple[str, str, str, str, str] | None:
     parts = str(au_id).split("_")
-    if len(parts) != 5:
+    if len(parts) < 5:
         return None
     return (parts[0], parts[1], parts[2], parts[3], parts[4])
+
+
+def _mkrf_au_site_series_suffix(au_id: str) -> str:
+    parts = str(au_id).split("_")
+    if len(parts) <= 5:
+        return ""
+    return "_".join(parts[5:])
 
 
 def _normalize_species_bucket(species_code: str) -> str:
@@ -177,7 +186,9 @@ def _build_managed_species_share_table(
             if bucket:
                 shares[bucket] += float(pct_value)
         row_payload = {"au_id": str(row.au_id).strip()}
-        row_payload.update({f"share_{bucket.lower()}": shares[bucket] for bucket in shares})
+        row_payload.update(
+            {f"share_{bucket.lower()}": shares[bucket] for bucket in shares}
+        )
         rows.append(row_payload)
     return pd.DataFrame(rows)
 
@@ -193,7 +204,9 @@ def _build_unmanaged_species_share_table(
         selected_ids = set(selected_au_table["au_id"].astype(str).str.strip())
         rows = rows.loc[rows["au_id"].isin(selected_ids)].copy()
 
-    rows["shape_area_ha"] = pd.to_numeric(rows["shape_area_ha"], errors="coerce").fillna(0.0)
+    rows["shape_area_ha"] = pd.to_numeric(
+        rows["shape_area_ha"], errors="coerce"
+    ).fillna(0.0)
     rows["leading_species_1_share"] = pd.to_numeric(
         rows["leading_species_1_share"], errors="coerce"
     ).fillna(0.0)
@@ -225,15 +238,28 @@ def _build_unmanaged_species_share_table(
             "au_id": str(row.au_id).strip(),
             "area_ha": area_ha,
         }
-        payload.update({f"share_{bucket.lower()}_ha": shares[bucket] for bucket in _SPECIES_BUCKETS})
+        payload.update(
+            {
+                f"share_{bucket.lower()}_ha": shares[bucket]
+                for bucket in _SPECIES_BUCKETS
+            }
+        )
         payload_rows.append(payload)
 
     if not payload_rows:
         return pd.DataFrame(
-            columns=["au_id", "area_ha", *[f"share_{bucket.lower()}" for bucket in _SPECIES_BUCKETS]]
+            columns=[
+                "au_id",
+                "area_ha",
+                *[f"share_{bucket.lower()}" for bucket in _SPECIES_BUCKETS],
+            ]
         )
 
-    aggregated = pd.DataFrame(payload_rows).groupby("au_id", as_index=False).sum(numeric_only=True)
+    aggregated = (
+        pd.DataFrame(payload_rows)
+        .groupby("au_id", as_index=False)
+        .sum(numeric_only=True)
+    )
     for bucket in _SPECIES_BUCKETS:
         area_column = f"share_{bucket.lower()}_ha"
         share_column = f"share_{bucket.lower()}"
@@ -243,7 +269,9 @@ def _build_unmanaged_species_share_table(
             0.0,
         )
 
-    return aggregated[["au_id", *[f"share_{bucket.lower()}" for bucket in _SPECIES_BUCKETS]]]
+    return aggregated[
+        ["au_id", *[f"share_{bucket.lower()}" for bucket in _SPECIES_BUCKETS]]
+    ]
 
 
 def _build_species_share_audit_table(
@@ -262,7 +290,12 @@ def _build_species_share_audit_table(
         working["au_id"] = working["au_id"].astype(str).str.strip()
         for row in working.itertuples(index=False):
             for bucket in _SPECIES_BUCKETS:
-                share_pct = float(pd.to_numeric(getattr(row, f"share_{bucket.lower()}", 0.0), errors="coerce") or 0.0)
+                share_pct = float(
+                    pd.to_numeric(
+                        getattr(row, f"share_{bucket.lower()}", 0.0), errors="coerce"
+                    )
+                    or 0.0
+                )
                 rows.append(
                     {
                         "origin_lane": origin_lane,
@@ -286,7 +319,10 @@ def _build_ct_eligibility_audit_table(
 ) -> pd.DataFrame:
     selected = selected_au_table.copy()
     selected["au_id"] = selected["au_id"].astype(str).str.strip()
-    if "leading_species_1" not in selected.columns or "leading_species_2" not in selected.columns:
+    if (
+        "leading_species_1" not in selected.columns
+        or "leading_species_2" not in selected.columns
+    ):
         parsed = selected["au_id"].map(_parse_mkrf_au_id)
         selected["leading_species_1"] = [
             parts[3] if parts is not None else "" for parts in parsed
@@ -327,8 +363,7 @@ def _build_ct_eligibility_audit_table(
     audit["cw_fd_threshold_pct"] = float(_MKRF_CT_MIN_CW_FD_SHARE_PCT)
     audit["cw_fd_ge_threshold"] = audit["share_cw_fd"].ge(_MKRF_CT_MIN_CW_FD_SHARE_PCT)
     audit["final_ct_eligible"] = (
-        audit["runtime_ct_eligible_before_species_filter"]
-        & audit["cw_fd_ge_threshold"]
+        audit["runtime_ct_eligible_before_species_filter"] & audit["cw_fd_ge_threshold"]
     )
 
     def _reasons(row: pd.Series) -> str:
@@ -365,7 +400,9 @@ def _build_ct_eligibility_audit_table(
     ].sort_values("au_id", kind="stable")
 
 
-def _ct_product_fraction_values(*, hw_share: float, fd_share: float) -> dict[str, float]:
+def _ct_product_fraction_values(
+    *, hw_share: float, fd_share: float
+) -> dict[str, float]:
     target = float(_MKRF_CT_TARGET_BA_REMOVAL_FRACTION)
     hw_fraction = 1.0 if hw_share > target else hw_share / target
     if hw_share > target:
@@ -375,9 +412,7 @@ def _ct_product_fraction_values(*, hw_share: float, fd_share: float) -> dict[str
     else:
         fd_fraction = fd_share / target
     other_fraction = (
-        0.0
-        if hw_share + fd_share > target
-        else (target - hw_share - fd_share) / target
+        0.0 if hw_share + fd_share > target else (target - hw_share - fd_share) / target
     )
     return {
         "cw": 0.0,
@@ -404,9 +439,15 @@ def _build_ct_intensity_audit_tables(
         if share_row.empty:
             continue
         share = share_row.iloc[0]
-        treated_cw = float(pd.to_numeric(share.get("share_cw", 0.0), errors="coerce") or 0.0)
-        treated_hw = float(pd.to_numeric(share.get("share_hw", 0.0), errors="coerce") or 0.0)
-        treated_fd = float(pd.to_numeric(share.get("share_fd", 0.0), errors="coerce") or 0.0)
+        treated_cw = float(
+            pd.to_numeric(share.get("share_cw", 0.0), errors="coerce") or 0.0
+        )
+        treated_hw = float(
+            pd.to_numeric(share.get("share_hw", 0.0), errors="coerce") or 0.0
+        )
+        treated_fd = float(
+            pd.to_numeric(share.get("share_fd", 0.0), errors="coerce") or 0.0
+        )
         treated_other = max(0.0, 100.0 - treated_cw - treated_hw - treated_fd)
         fractions = _ct_product_fraction_values(
             hw_share=treated_hw / 100.0,
@@ -507,9 +548,7 @@ def _build_hw_ingrowth_overlay_audit_tables(
                 )
                 or 0.0
             ),
-            "hw_ingrowth_source": str(
-                getattr(bootstrap_row, "hw_ingrowth_source", "")
-            ),
+            "hw_ingrowth_source": str(getattr(bootstrap_row, "hw_ingrowth_source", "")),
             "managed_species_overflow_to_hw_pct": float(
                 pd.to_numeric(
                     getattr(bootstrap_row, "managed_species_overflow_to_hw_pct", 0.0),
@@ -549,7 +588,9 @@ def _build_hw_ingrowth_overlay_audit_tables(
             payload[f"delta_{code}_pct"] = adjusted_pct - base_pct
             payload[f"base_{code}_sph"] = density_total * base_pct / 100.0
             payload[f"adjusted_{code}_sph"] = density_total * adjusted_pct / 100.0
-            payload[f"delta_{code}_sph"] = density_total * (adjusted_pct - base_pct) / 100.0
+            payload[f"delta_{code}_sph"] = (
+                density_total * (adjusted_pct - base_pct) / 100.0
+            )
         payload["base_pct_total"] = sum(
             float(payload[f"base_{species_code.lower()}_pct"])
             for species_code in species_codes
@@ -558,7 +599,9 @@ def _build_hw_ingrowth_overlay_audit_tables(
             float(payload[f"adjusted_{species_code.lower()}_pct"])
             for species_code in species_codes
         )
-        payload["base_sph_total"] = density_total * float(payload["base_pct_total"]) / 100.0
+        payload["base_sph_total"] = (
+            density_total * float(payload["base_pct_total"]) / 100.0
+        )
         payload["adjusted_sph_total"] = (
             density_total * float(payload["adjusted_pct_total"]) / 100.0
         )
@@ -586,7 +629,9 @@ def _build_hw_ingrowth_overlay_audit_tables(
             mean_delta_hw_sph=("delta_hw_sph", "mean"),
             overflow_au_count=(
                 "managed_species_overflow_to_hw_pct",
-                lambda values: int((pd.to_numeric(values, errors="coerce").fillna(0.0) > 0).sum()),
+                lambda values: int(
+                    (pd.to_numeric(values, errors="coerce").fillna(0.0) > 0).sum()
+                ),
             ),
         )
         .sort_values("managed_family_id", kind="stable")
@@ -606,9 +651,15 @@ def _normalize_runtime_au_assignments(
     selected["au_id"] = selected["au_id"].astype(str).str.strip()
     selected_parts = selected["au_id"].map(_parse_mkrf_au_id)
     selected = selected.loc[selected_parts.notna()].copy()
-    selected[["bec_zone", "bec_subzone", "bec_variant", "leading_species_1", "leading_species_2"]] = (
-        pd.DataFrame(selected_parts.loc[selected.index].tolist(), index=selected.index)
-    )
+    selected[
+        [
+            "bec_zone",
+            "bec_subzone",
+            "bec_variant",
+            "leading_species_1",
+            "leading_species_2",
+        ]
+    ] = pd.DataFrame(selected_parts.loc[selected.index].tolist(), index=selected.index)
     if "selected_rank" in selected.columns:
         selected["selected_rank"] = pd.to_numeric(
             selected["selected_rank"], errors="coerce"
@@ -658,7 +709,9 @@ def _normalize_runtime_au_assignments(
         if not candidates:
             return raw_au_id, "no_selected_au_same_bec"
 
-        def score(candidate: dict[str, object]) -> tuple[int, int, int, int, float, str]:
+        def score(
+            candidate: dict[str, object],
+        ) -> tuple[int, int, int, int, float, str]:
             cand_sp1 = str(candidate["leading_species_1"])
             cand_sp2 = str(candidate["leading_species_2"])
             overlap = len({raw_sp1, raw_sp2} & {cand_sp1, cand_sp2})
@@ -677,7 +730,9 @@ def _normalize_runtime_au_assignments(
     normalized = (
         stand_origin_assignment.copy()
         .assign(
-            forest_cover_id=lambda df: pd.to_numeric(df["forest_cover_id"], errors="coerce"),
+            forest_cover_id=lambda df: pd.to_numeric(
+                df["forest_cover_id"], errors="coerce"
+            ),
             raw_au_id=lambda df: df["au_id"].astype(str).str.strip(),
         )
         .dropna(subset=["forest_cover_id"])
@@ -694,7 +749,9 @@ def _normalize_runtime_au_assignments(
 
     remap_audit = (
         normalized.groupby(
-            ["raw_au_id", "au_id", "was_remapped", "remap_reason"], dropna=False, as_index=False
+            ["raw_au_id", "au_id", "was_remapped", "remap_reason"],
+            dropna=False,
+            as_index=False,
         )
         .agg(
             forest_cover_id_count=("forest_cover_id", "nunique"),
@@ -730,7 +787,9 @@ def _apply_young_skewed_sibling_borrow(
     source_subset["forest_cover_id"] = pd.to_numeric(
         source_subset["FOREST_COVER_ID"], errors="coerce"
     )
-    source_subset["AGE_2020"] = pd.to_numeric(source_subset["AGE_2020"], errors="coerce")
+    source_subset["AGE_2020"] = pd.to_numeric(
+        source_subset["AGE_2020"], errors="coerce"
+    )
     age_rows = stand_assignment.merge(
         source_subset[["forest_cover_id", "AGE_2020"]],
         on="forest_cover_id",
@@ -738,7 +797,11 @@ def _apply_young_skewed_sibling_borrow(
     )
     old_support = (
         age_rows.groupby("au_id", as_index=False)["AGE_2020"]
-        .apply(lambda s: int((pd.to_numeric(s, errors="coerce") >= min_first_growth_age).sum()))
+        .apply(
+            lambda s: int(
+                (pd.to_numeric(s, errors="coerce") >= min_first_growth_age).sum()
+            )
+        )
         .rename(columns={"AGE_2020": "age_gte_80_count"})
     )
 
@@ -758,9 +821,13 @@ def _apply_young_skewed_sibling_borrow(
         terminal_curves, on="au_id", how="left"
     )
     summary["age_gte_80_count"] = (
-        pd.to_numeric(summary["age_gte_80_count"], errors="coerce").fillna(0).astype(int)
+        pd.to_numeric(summary["age_gte_80_count"], errors="coerce")
+        .fillna(0)
+        .astype(int)
     )
-    summary["terminal_volume"] = pd.to_numeric(summary["terminal_volume"], errors="coerce")
+    summary["terminal_volume"] = pd.to_numeric(
+        summary["terminal_volume"], errors="coerce"
+    )
 
     curves_out = curves.copy()
     terminal_lookup = {
@@ -782,7 +849,10 @@ def _apply_young_skewed_sibling_borrow(
         if parsed is None:
             continue
         bec_zone, bec_subzone, bec_variant, sp1, sp2 = parsed
+        site_series_suffix = _mkrf_au_site_series_suffix(au_id)
         sibling_au_id = f"{bec_zone}_{bec_subzone}_{bec_variant}_{sp2}_{sp1}"
+        if site_series_suffix:
+            sibling_au_id = f"{sibling_au_id}_{site_series_suffix}"
         sibling_terminal = terminal_lookup.get(sibling_au_id)
         if sibling_terminal is None or sibling_terminal < sibling_terminal_threshold:
             continue
@@ -792,19 +862,25 @@ def _apply_young_skewed_sibling_borrow(
             continue
         curves_out = curves_out.loc[curves_out["au_id"] != au_id].copy()
         sibling_curve["au_id"] = au_id
-        curves_out = pd.concat([curves_out, sibling_curve], ignore_index=True, sort=False)
+        curves_out = pd.concat(
+            [curves_out, sibling_curve], ignore_index=True, sort=False
+        )
         diagnostics_out.loc[diagnostics_out["au_id"] == au_id, "selected_path"] = (
             "borrowed_young_skewed_sibling"
         )
-        diagnostics_out.loc[diagnostics_out["au_id"] == au_id, "borrowed_from_au_id"] = (
-            sibling_au_id
-        )
+        diagnostics_out.loc[
+            diagnostics_out["au_id"] == au_id, "borrowed_from_au_id"
+        ] = sibling_au_id
         diagnostics_out.loc[diagnostics_out["au_id"] == au_id, "borrow_reason"] = (
             f"old_support<={max_old_support_count}_and_terminal<{low_terminal_threshold:g}"
         )
 
-    curves_out = curves_out.sort_values(["au_id", "age"], kind="stable").reset_index(drop=True)
-    diagnostics_out = diagnostics_out.sort_values("au_id", kind="stable").reset_index(drop=True)
+    curves_out = curves_out.sort_values(["au_id", "age"], kind="stable").reset_index(
+        drop=True
+    )
+    diagnostics_out = diagnostics_out.sort_values("au_id", kind="stable").reset_index(
+        drop=True
+    )
     return curves_out, diagnostics_out
 
 
@@ -839,7 +915,9 @@ def _apply_insufficient_support_merge(
     source_subset["forest_cover_id"] = pd.to_numeric(
         source_subset["FOREST_COVER_ID"], errors="coerce"
     )
-    source_subset["AGE_2020"] = pd.to_numeric(source_subset["AGE_2020"], errors="coerce")
+    source_subset["AGE_2020"] = pd.to_numeric(
+        source_subset["AGE_2020"], errors="coerce"
+    )
     age_rows = assignment_rows.merge(
         source_subset[["forest_cover_id", "AGE_2020"]],
         on="forest_cover_id",
@@ -871,8 +949,12 @@ def _apply_insufficient_support_merge(
     summary = base_summary.merge(area_by_au, on="au_id", how="left").merge(
         terminal_curves, on="au_id", how="left"
     )
-    summary["covered_area_ha"] = pd.to_numeric(summary["covered_area_ha"], errors="coerce").fillna(0.0)
-    summary["terminal_volume"] = pd.to_numeric(summary["terminal_volume"], errors="coerce")
+    summary["covered_area_ha"] = pd.to_numeric(
+        summary["covered_area_ha"], errors="coerce"
+    ).fillna(0.0)
+    summary["terminal_volume"] = pd.to_numeric(
+        summary["terminal_volume"], errors="coerce"
+    )
     summary["old_support_stand_count"] = (
         pd.to_numeric(summary["old_support_stand_count"], errors="coerce")
         .fillna(0)
@@ -881,11 +963,15 @@ def _apply_insufficient_support_merge(
     summary["accepted"] = summary["accepted"].fillna(False)
 
     curves_out = curves.copy()
-    for _, row in summary.sort_values(["covered_area_ha", "au_id"], ascending=[False, True]).iterrows():
+    for _, row in summary.sort_values(
+        ["covered_area_ha", "au_id"], ascending=[False, True]
+    ).iterrows():
         target_au_id = str(row["au_id"])
         target_selected_path = str(row.get("selected_path", ""))
         has_missing_curve = pd.isna(row.get("terminal_volume"))
-        insufficient_support = 0 < int(row["old_support_stand_count"]) < int(min_source_stands)
+        insufficient_support = (
+            0 < int(row["old_support_stand_count"]) < int(min_source_stands)
+        )
         if not (
             target_selected_path == "insufficient_source_stands"
             or (has_missing_curve and insufficient_support)
@@ -895,7 +981,10 @@ def _apply_insufficient_support_merge(
         parsed_target = _parse_mkrf_au_id(target_au_id)
         if parsed_target is None:
             continue
-        target_zone, target_subzone, target_variant, target_sp1, target_sp2 = parsed_target
+        target_zone, target_subzone, target_variant, target_sp1, target_sp2 = (
+            parsed_target
+        )
+        target_site_series_suffix = _mkrf_au_site_series_suffix(target_au_id)
 
         candidates: list[tuple[int, float, str]] = []
         for _, candidate in summary.iterrows():
@@ -904,7 +993,9 @@ def _apply_insufficient_support_merge(
                 continue
             if not bool(candidate.get("accepted", False)):
                 continue
-            candidate_terminal = pd.to_numeric(candidate.get("terminal_volume"), errors="coerce")
+            candidate_terminal = pd.to_numeric(
+                candidate.get("terminal_volume"), errors="coerce"
+            )
             if (
                 pd.isna(candidate_terminal)
                 or float(candidate_terminal) <= 0.0
@@ -921,20 +1012,31 @@ def _apply_insufficient_support_merge(
                 target_variant,
             ):
                 continue
+            if target_site_series_suffix and (
+                _mkrf_au_site_series_suffix(candidate_au_id)
+                != target_site_series_suffix
+            ):
+                continue
             shared_species = len({target_sp1, target_sp2} & {cand_sp1, cand_sp2})
-            candidate_area = float(pd.to_numeric(candidate["covered_area_ha"], errors="coerce"))
+            candidate_area = float(
+                pd.to_numeric(candidate["covered_area_ha"], errors="coerce")
+            )
             candidates.append((shared_species, candidate_area, candidate_au_id))
 
         if not candidates:
             continue
 
-        _, _, source_au_id = max(candidates, key=lambda item: (item[0], item[1], item[2]))
+        _, _, source_au_id = max(
+            candidates, key=lambda item: (item[0], item[1], item[2])
+        )
         source_curve = curves_out.loc[curves_out["au_id"] == source_au_id].copy()
         if source_curve.empty:
             continue
         curves_out = curves_out.loc[curves_out["au_id"] != target_au_id].copy()
         source_curve["au_id"] = target_au_id
-        curves_out = pd.concat([curves_out, source_curve], ignore_index=True, sort=False)
+        curves_out = pd.concat(
+            [curves_out, source_curve], ignore_index=True, sort=False
+        )
         target_mask = diagnostics_out["au_id"] == target_au_id
         if not target_mask.any():
             diagnostics_out = pd.concat(
@@ -966,8 +1068,12 @@ def _apply_insufficient_support_merge(
             )
             diagnostics_out.loc[target_mask, "accepted"] = True
 
-    curves_out = curves_out.sort_values(["au_id", "age"], kind="stable").reset_index(drop=True)
-    diagnostics_out = diagnostics_out.sort_values("au_id", kind="stable").reset_index(drop=True)
+    curves_out = curves_out.sort_values(["au_id", "age"], kind="stable").reset_index(
+        drop=True
+    )
+    diagnostics_out = diagnostics_out.sort_values("au_id", kind="stable").reset_index(
+        drop=True
+    )
     return curves_out, diagnostics_out
 
 
@@ -1107,7 +1213,9 @@ def _manifest_path_value(path: Path | str | None) -> str | None:
         return None
     candidate = Path(path)
     try:
-        return os.path.relpath(candidate.resolve(), Path.cwd().resolve()).replace("\\", "/")
+        return os.path.relpath(candidate.resolve(), Path.cwd().resolve()).replace(
+            "\\", "/"
+        )
     except Exception:
         return candidate.name
 
@@ -1126,7 +1234,9 @@ _MKRF_RUNTIME_FRAGMENT_FIELD_MAP: tuple[tuple[str, str], ...] = (
 )
 
 
-def _project_mkrf_runtime_fragments(*, source_gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+def _project_mkrf_runtime_fragments(
+    *, source_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
     """Project MKRF Resultant rows into the recovered runtime fragments field surface."""
     missing = sorted(
         source_name
@@ -1162,13 +1272,16 @@ def build_mkrf_au_input_bundle(
     source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
     au_table, assignment = build_mkrf_au_tables(source_table)
     aggregation_audit = build_mkrf_au_aggregation_audit(assignment)
+    site_series_split_audit = build_mkrf_site_series_split_audit(assignment)
 
     au_table_path = output_dir / "au_table.csv"
     stand_assignment_path = output_dir / "stand_au_assignment.csv"
     aggregation_audit_path = output_dir / "au_aggregation_audit.csv"
+    site_series_split_audit_path = output_dir / "site_series_split_audit.csv"
     au_table.to_csv(au_table_path, index=False)
     assignment.to_csv(stand_assignment_path, index=False)
     aggregation_audit.to_csv(aggregation_audit_path, index=False)
+    site_series_split_audit.to_csv(site_series_split_audit_path, index=False)
 
     return MkrfAuBuildResult(
         resultant_gdb=resultant_gdb,
@@ -1176,6 +1289,7 @@ def build_mkrf_au_input_bundle(
         au_table_path=au_table_path,
         stand_assignment_path=stand_assignment_path,
         aggregation_audit_path=aggregation_audit_path,
+        site_series_split_audit_path=site_series_split_audit_path,
         source_row_count=len(assignment),
         au_count=len(au_table),
     )
@@ -1297,11 +1411,14 @@ def build_mkrf_first_growth_input_bundle(
 
 def _format_mkrf_au_label(au_id: str) -> str:
     parts = str(au_id).split("_")
-    if len(parts) != 5:
+    if len(parts) < 5:
         return str(au_id).upper()
-    bec_zone, bec_subzone, bec_variant, sp1, sp2 = parts
+    bec_zone, bec_subzone, bec_variant, sp1, sp2 = parts[:5]
     bec = f"{bec_zone.upper()}{bec_subzone}{bec_variant}"
-    return f"{bec}_{sp1.upper()}+{sp2.upper()}"
+    suffix = ""
+    if len(parts) > 5:
+        suffix = "_" + "_".join(part.upper() for part in parts[5:])
+    return f"{bec}_{sp1.upper()}+{sp2.upper()}{suffix}"
 
 
 def build_mkrf_au_distribution_plot(
@@ -1404,9 +1521,7 @@ def _filter_assignment_to_selected_aus(
     selected_au_table: pd.DataFrame,
 ) -> pd.DataFrame:
     selected_ids = set(selected_au_table["au_id"].astype(str))
-    return assignment.loc[
-        assignment["au_id"].astype(str).isin(selected_ids)
-    ].copy()
+    return assignment.loc[assignment["au_id"].astype(str).isin(selected_ids)].copy()
 
 
 def _classify_site_index_levels(site_index: pd.Series) -> pd.Series:
@@ -1418,8 +1533,10 @@ def _classify_site_index_levels(site_index: pd.Series) -> pd.Series:
         labeled = pd.Series("M", index=valid.index, dtype="object")
     else:
         quantile_count = min(3, int(valid.nunique()))
-        labels = ["M"] if quantile_count == 1 else (
-            ["L", "H"] if quantile_count == 2 else ["L", "M", "H"]
+        labels = (
+            ["M"]
+            if quantile_count == 1
+            else (["L", "H"] if quantile_count == 2 else ["L", "M", "H"])
         )
         ranked = valid.rank(method="first")
         labeled = pd.qcut(ranked, q=quantile_count, labels=labels).astype("object")
@@ -1443,7 +1560,9 @@ def _build_fitdiag_summary(raw_subset: pd.DataFrame) -> pd.DataFrame:
     table["Age"] = pd.to_numeric(table["Age"], errors="coerce")
     table["Vdwb"] = pd.to_numeric(table["Vdwb"], errors="coerce")
     table = table.dropna(subset=["Age", "Vdwb"])
-    table = table.loc[(table["Age"] >= 30) & (table["Age"] <= 350) & (table["Vdwb"] >= 0)]
+    table = table.loc[
+        (table["Age"] >= 30) & (table["Age"] <= 350) & (table["Vdwb"] >= 0)
+    ]
     if table.empty:
         return pd.DataFrame(columns=["age_bin", "median_volume", "p25", "p75"])
     table["age_bin"] = (np.floor(table["Age"] / 5.0) * 5.0).astype(float)
@@ -1459,7 +1578,9 @@ def _build_fitdiag_summary(raw_subset: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def _fitdiag_plot_path(*, output_dir: Path, tsa_code: str, au_label: str, level: str) -> Path:
+def _fitdiag_plot_path(
+    *, output_dir: Path, tsa_code: str, au_label: str, level: str
+) -> Path:
     tsa = str(tsa_code).zfill(2)
     return output_dir / f"vdyp_fitdiag_tsa{tsa}-{au_label}-{level}.png"
 
@@ -1550,7 +1671,9 @@ def build_mkrf_managed_au_input_bundle(
         msyt_path=msyt_path,
         selected_au_count=int(len(selected_au_table)),
         included_au_count=int(included.sum()),
-        unmatched_au_count=int((bootstrap_table["bootstrap_status"] == "unmatched").sum()),
+        unmatched_au_count=int(
+            (bootstrap_table["bootstrap_status"] == "unmatched").sum()
+        ),
         logging_origin_si_au_count=int(
             (bootstrap_table["managed_si_source"] == "logging_origin_median").sum()
         ),
@@ -1574,9 +1697,7 @@ def build_mkrf_managed_au_curves(
     log_dir.mkdir(parents=True, exist_ok=True)
     bootstrap_table = pd.read_csv(bootstrap_csv)
     manifest_path = output_dir / "managed_au_run_manifest.json"
-    included_count = int(
-        bootstrap_table["included_in_msyt"].fillna(False).sum()
-    )
+    included_count = int(bootstrap_table["included_in_msyt"].fillna(False).sum())
     try:
         btc_result = run_btc_cli(
             input_csv=msyt_csv,
@@ -1681,7 +1802,9 @@ def build_mkrf_all_plots(
     source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
 
     selected_ids = list(
-        selected_au_table.sort_values(["selected_rank", "au_id"], kind="stable")["au_id"]
+        selected_au_table.sort_values(["selected_rank", "au_id"], kind="stable")[
+            "au_id"
+        ]
     )
     label_map = _build_selected_au_label_map(selected_au_table)
 
@@ -1767,7 +1890,9 @@ def build_mkrf_all_plots(
             if curve.empty:
                 continue
             plotted = True
-            ax.plot(curve["age"], curve["volume"], linewidth=2.0, color=color, label=level)
+            ax.plot(
+                curve["age"], curve["volume"], linewidth=2.0, color=color, label=level
+            )
             ymax = max(ymax, float(curve["volume"].max()))
         if plotted:
             ax.set_title(f"VDYP L/M/H Comparison: {label}")
@@ -1779,7 +1904,9 @@ def build_mkrf_all_plots(
             ax.legend(fontsize=8)
             fig.tight_layout()
             fig.savefig(
-                _lmh_plot_path(output_dir=output_dir, tsa_code=tsa_code, au_label=label),
+                _lmh_plot_path(
+                    output_dir=output_dir, tsa_code=tsa_code, au_label=label
+                ),
                 dpi=150,
             )
             lmh_plot_count += 1
@@ -1797,7 +1924,9 @@ def build_mkrf_all_plots(
             ]
             if not stand_ids:
                 continue
-            raw_subset = vdyp_yields.loc[vdyp_yields["FEATURE_ID"].isin(stand_ids)].copy()
+            raw_subset = vdyp_yields.loc[
+                vdyp_yields["FEATURE_ID"].isin(stand_ids)
+            ].copy()
             feature_tables = _extract_feature_curve_tables(raw_subset)
             if not feature_tables:
                 continue
@@ -1816,7 +1945,9 @@ def build_mkrf_all_plots(
             raw_label_used = False
             for table in feature_tables.values():
                 raw = table.reset_index().dropna()
-                raw = raw.loc[(raw["Age"] >= 0) & (raw["Age"] <= 350) & (raw["Vdwb"] >= 0)]
+                raw = raw.loc[
+                    (raw["Age"] >= 0) & (raw["Age"] <= 350) & (raw["Vdwb"] >= 0)
+                ]
                 if raw.empty:
                     continue
                 ax.plot(
@@ -1845,7 +1976,13 @@ def build_mkrf_all_plots(
                     color="tab:blue",
                     label="Observed median (5y bins)",
                 )
-            ax.plot(curve["age"], curve["volume"], color="black", linewidth=2.2, label="Selected fit")
+            ax.plot(
+                curve["age"],
+                curve["volume"],
+                color="black",
+                linewidth=2.2,
+                label="Selected fit",
+            )
             ax.set_title(f"VDYP Fit Diagnostic: {label} {level}")
             ax.set_xlabel("Age")
             ax.set_ylabel("Volume (m3/ha)")
@@ -1917,7 +2054,9 @@ def build_mkrf_all_plots(
     for au_id in selected_ids:
         label = label_map[str(au_id)]
         tipsy_curve = managed_curves.loc[managed_curves["au_id"] == str(au_id)].copy()
-        vdyp_curve = first_growth_curves.loc[first_growth_curves["au_id"] == str(au_id)].copy()
+        vdyp_curve = first_growth_curves.loc[
+            first_growth_curves["au_id"] == str(au_id)
+        ].copy()
         if tipsy_curve.empty or vdyp_curve.empty:
             continue
         fig, ax = plt.subplots(1, 1, figsize=(8, 6))
@@ -1950,7 +2089,9 @@ def build_mkrf_all_plots(
         ax.legend(fontsize=8)
         fig.tight_layout()
         fig.savefig(
-            _tipsy_vdyp_plot_path(output_dir=output_dir, tsa_code=tsa_code, au_label=label),
+            _tipsy_vdyp_plot_path(
+                output_dir=output_dir, tsa_code=tsa_code, au_label=label
+            ),
             dpi=150,
         )
         tipsy_vdyp_plot_count += 1
@@ -2010,7 +2151,9 @@ def build_mkrf_bad_curve_audit(
         "BEC_SUBZONE",
         "BEC_VARIANT",
     }
-    source_subset = source_subset[[c for c in source_subset.columns if c in keep_columns]].copy()
+    source_subset = source_subset[
+        [c for c in source_subset.columns if c in keep_columns]
+    ].copy()
     terminal_stands = (
         vdyp_yields.sort_values(["FEATURE_ID", "PRJ_TOTAL_AGE"], kind="stable")
         .groupby("FEATURE_ID", as_index=False)
@@ -2026,10 +2169,16 @@ def build_mkrf_bad_curve_audit(
 
     detail_rows: list[dict[str, object]] = []
     summary_rows: list[dict[str, object]] = []
-    for _, selected_row in selected.sort_values(["selected_rank", "au_id"], kind="stable").iterrows():
+    for _, selected_row in selected.sort_values(
+        ["selected_rank", "au_id"], kind="stable"
+    ).iterrows():
         au_id = str(selected_row["au_id"])
-        assignment_rows = assignment.loc[assignment["au_id"].astype(str) == au_id].copy()
-        joined = assignment_rows.merge(source_subset, on="forest_cover_id", how="left").merge(
+        assignment_rows = assignment.loc[
+            assignment["au_id"].astype(str) == au_id
+        ].copy()
+        joined = assignment_rows.merge(
+            source_subset, on="forest_cover_id", how="left"
+        ).merge(
             terminal_stands,
             on="forest_cover_id",
             how="left",
@@ -2070,15 +2219,31 @@ def build_mkrf_bad_curve_audit(
         else:
             pattern = "midrange"
 
-        terminal_volume = pd.to_numeric(selected_row["terminal_volume"], errors="coerce")
+        terminal_volume = pd.to_numeric(
+            selected_row["terminal_volume"], errors="coerce"
+        )
         initial_flag = (
-            float(pd.to_numeric(pd.Series([selected_row["terminal_volume"]]), errors="coerce").fillna(0.0).iloc[0])
+            float(
+                pd.to_numeric(
+                    pd.Series([selected_row["terminal_volume"]]), errors="coerce"
+                )
+                .fillna(0.0)
+                .iloc[0]
+            )
             < low_terminal_threshold
         ) or (
-            float(pd.to_numeric(pd.Series([selected_row["covered_area_ha"]]), errors="coerce").fillna(0.0).iloc[0])
+            float(
+                pd.to_numeric(
+                    pd.Series([selected_row["covered_area_ha"]]), errors="coerce"
+                )
+                .fillna(0.0)
+                .iloc[0]
+            )
             > large_area_threshold
             and float(
-                pd.to_numeric(pd.Series([selected_row["terminal_volume"]]), errors="coerce")
+                pd.to_numeric(
+                    pd.Series([selected_row["terminal_volume"]]), errors="coerce"
+                )
                 .fillna(0.0)
                 .iloc[0]
             )
@@ -2126,11 +2291,21 @@ def build_mkrf_bad_curve_audit(
                 "age_gte_80_count": age_gte_80_count,
                 "age_gte_80_share": _share(age_gte_80_count),
                 "old_support_stand_count": old_support_stand_count,
-                "terminal_vdyp_min": float(terminal.min()) if len(terminal.dropna()) else np.nan,
-                "terminal_vdyp_p25": float(terminal.quantile(0.25)) if len(terminal.dropna()) else np.nan,
-                "terminal_vdyp_median": float(terminal.median()) if len(terminal.dropna()) else np.nan,
-                "terminal_vdyp_p75": float(terminal.quantile(0.75)) if len(terminal.dropna()) else np.nan,
-                "terminal_vdyp_max": float(terminal.max()) if len(terminal.dropna()) else np.nan,
+                "terminal_vdyp_min": float(terminal.min())
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_p25": float(terminal.quantile(0.25))
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_median": float(terminal.median())
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_p75": float(terminal.quantile(0.75))
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_max": float(terminal.max())
+                if len(terminal.dropna())
+                else np.nan,
                 "low_terminal_stand_count": low_count,
                 "high_terminal_stand_count": high_count,
                 "population_pattern": pattern,
@@ -2141,7 +2316,9 @@ def build_mkrf_bad_curve_audit(
         if not flagged:
             continue
         for _, row in joined.sort_values(
-            ["terminal_vdyp_volume", "forest_cover_id"], kind="stable", na_position="last"
+            ["terminal_vdyp_volume", "forest_cover_id"],
+            kind="stable",
+            na_position="last",
         ).iterrows():
             detail_rows.append(
                 {
@@ -2218,7 +2395,9 @@ def initialize_mkrf_runtime_package(
     ct_eligibility_audit_path = analysis_dir / "ct_eligibility_audit.csv"
     ct_intensity_audit_path = analysis_dir / "ct_intensity_audit.csv"
     ct_intensity_summary_path = analysis_dir / "ct_intensity_summary.csv"
-    hw_ingrowth_overlay_audit_path = analysis_dir / "planted_hw_ingrowth_overlay_audit.csv"
+    hw_ingrowth_overlay_audit_path = (
+        analysis_dir / "planted_hw_ingrowth_overlay_audit.csv"
+    )
     hw_ingrowth_overlay_summary_path = (
         analysis_dir / "planted_hw_ingrowth_overlay_summary.csv"
     )
@@ -2288,7 +2467,9 @@ def initialize_mkrf_runtime_package(
 
     selected_au_count = int(selected_au["au_id"].astype(str).nunique())
     managed_curve_au_count = int(managed_curves["au_id"].astype(str).nunique())
-    flagged_au_count = int(bad_curve_summary["flagged"].fillna(False).astype(bool).sum())
+    flagged_au_count = int(
+        bad_curve_summary["flagged"].fillna(False).astype(bool).sum()
+    )
 
     first_growth_path_by_au = (
         first_growth_diagnostics[["au_id", "selected_path"]]
@@ -2317,17 +2498,24 @@ def initialize_mkrf_runtime_package(
         runtime_curve_status["flagged"].fillna(False).astype(bool)
     )
     runtime_curve_status = runtime_curve_status.drop(columns=["flagged"])
-    runtime_curve_status["has_first_growth_curve"] = runtime_curve_status["selected_path"].notna() & (
+    runtime_curve_status["has_first_growth_curve"] = runtime_curve_status[
+        "selected_path"
+    ].notna() & (
         ~runtime_curve_status["selected_path"].eq("insufficient_source_stands")
     )
-    runtime_curve_status["has_managed_curve"] = runtime_curve_status["au_id"].isin(managed_curve_aus)
+    runtime_curve_status["has_managed_curve"] = runtime_curve_status["au_id"].isin(
+        managed_curve_aus
+    )
     runtime_curve_status["runtime_curve_mode"] = np.where(
-        runtime_curve_status["has_first_growth_curve"] & runtime_curve_status["has_managed_curve"],
+        runtime_curve_status["has_first_growth_curve"]
+        & runtime_curve_status["has_managed_curve"],
         "first_growth_and_managed",
         np.where(
             (~runtime_curve_status["has_first_growth_curve"])
             & runtime_curve_status["has_managed_curve"]
-            & runtime_curve_status["selected_path"].fillna("").eq("insufficient_source_stands"),
+            & runtime_curve_status["selected_path"]
+            .fillna("")
+            .eq("insufficient_source_stands"),
             "managed_only",
             "incomplete",
         ),
@@ -2344,26 +2532,25 @@ def initialize_mkrf_runtime_package(
         runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool).sum()
     )
     first_growth_missing_au_count = int(
-        (~runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool)).sum()
+        (
+            ~runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool)
+        ).sum()
     )
     runtime_curve_status.to_csv(curve_status_path, index=False)
-    tracks_status = (
-        selected_au.assign(au_id=lambda df: df["au_id"].astype(str))
-        .merge(
-            runtime_curve_status[
-                [
-                    "au_id",
-                    "first_growth_selected_path",
-                    "has_first_growth_curve",
-                    "has_managed_curve",
-                    "runtime_curve_mode",
-                    "runtime_curve_note",
-                    "flagged_bad_curve",
-                ]
-            ],
-            on="au_id",
-            how="left",
-        )
+    tracks_status = selected_au.assign(au_id=lambda df: df["au_id"].astype(str)).merge(
+        runtime_curve_status[
+            [
+                "au_id",
+                "first_growth_selected_path",
+                "has_first_growth_curve",
+                "has_managed_curve",
+                "runtime_curve_mode",
+                "runtime_curve_note",
+                "flagged_bad_curve",
+            ]
+        ],
+        on="au_id",
+        how="left",
     )
     tracks_sort_columns = ["au_id"]
     if "selected_rank" in tracks_status.columns:
@@ -2371,7 +2558,9 @@ def initialize_mkrf_runtime_package(
     tracks_status = tracks_status.sort_values(tracks_sort_columns, kind="stable")
     tracks_status.to_csv(analysis_au_runtime_status_path, index=False)
     curve_ref_rows: list[dict[str, object]] = []
-    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(index=False):
+    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(
+        index=False
+    ):
         au_token = str(row.au_id).upper().replace("-", "_")
         curve_ref_rows.append(
             {
@@ -2387,22 +2576,35 @@ def initialize_mkrf_runtime_package(
                 "first_growth_curve_id": (
                     f"FG_{au_token}" if bool(row.has_first_growth_curve) else ""
                 ),
-                "managed_curve_id": f"MG_{au_token}" if bool(row.has_managed_curve) else "",
+                "managed_curve_id": f"MG_{au_token}"
+                if bool(row.has_managed_curve)
+                else "",
                 "flagged_bad_curve": bool(row.flagged_bad_curve),
                 "runtime_curve_note": (
                     str(row.runtime_curve_note)
-                    if pd.notna(row.runtime_curve_note) and str(row.runtime_curve_note).strip()
+                    if pd.notna(row.runtime_curve_note)
+                    and str(row.runtime_curve_note).strip()
                     else ""
                 ),
             }
         )
     pd.DataFrame(curve_ref_rows).to_csv(analysis_au_curve_refs_path, index=False)
-    managed_curve_lookup_rows = [row for row in curve_ref_rows if row["managed_curve_id"]]
+    managed_curve_lookup_rows = [
+        row for row in curve_ref_rows if row["managed_curve_id"]
+    ]
     managed_curve_au_ids = [str(row["au_id"]) for row in managed_curve_lookup_rows]
-    managed_curve_ids = [str(row["managed_curve_id"]) for row in managed_curve_lookup_rows]
-    first_growth_curve_lookup_rows = [row for row in curve_ref_rows if row["first_growth_curve_id"]]
-    first_growth_curve_au_ids = [str(row["au_id"]) for row in first_growth_curve_lookup_rows]
-    first_growth_curve_ids = [str(row["first_growth_curve_id"]) for row in first_growth_curve_lookup_rows]
+    managed_curve_ids = [
+        str(row["managed_curve_id"]) for row in managed_curve_lookup_rows
+    ]
+    first_growth_curve_lookup_rows = [
+        row for row in curve_ref_rows if row["first_growth_curve_id"]
+    ]
+    first_growth_curve_au_ids = [
+        str(row["au_id"]) for row in first_growth_curve_lookup_rows
+    ]
+    first_growth_curve_ids = [
+        str(row["first_growth_curve_id"]) for row in first_growth_curve_lookup_rows
+    ]
     ct_bucket_specs = _mkrf_ct_bucket_specs()
     runtime_base_au_expr = (
         f"if(startswith(au,'thn'),substring(au,{len(_mkrf_ct_bucket_prefix(40))}),au)"
@@ -2467,7 +2669,9 @@ def initialize_mkrf_runtime_package(
         .astype(str)
         .str.strip()
     )
-    unmanaged_share_assignment = unmanaged_share_assignment.drop(columns=["runtime_au_id"])
+    unmanaged_share_assignment = unmanaged_share_assignment.drop(
+        columns=["runtime_au_id"]
+    )
     unmanaged_species_shares = _build_unmanaged_species_share_table(
         unmanaged_share_assignment,
         selected_au_table=selected_au,
@@ -2499,10 +2703,10 @@ def initialize_mkrf_runtime_package(
         )
         managed_share_lookup_exprs[share_column] = f"Number({lookup_expr})/100"
     ct_eligibility_species_shares = ct_eligibility_species_shares.assign(
-        share_cw_fd=lambda df: pd.to_numeric(
-            df["share_cw"], errors="coerce"
-        ).fillna(0.0)
-        + pd.to_numeric(df["share_fd"], errors="coerce").fillna(0.0)
+        share_cw_fd=lambda df: (
+            pd.to_numeric(df["share_cw"], errors="coerce").fillna(0.0)
+            + pd.to_numeric(df["share_fd"], errors="coerce").fillna(0.0)
+        )
     )
     ct_eligibility_cw_fd_values = [
         str(float(value))
@@ -2581,7 +2785,9 @@ def initialize_mkrf_runtime_package(
     ct_product_keys: list[str] = []
     natural_ct_product_curve_ids: list[str] = []
     treated_ct_product_curve_ids: list[str] = []
-    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(index=False):
+    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(
+        index=False
+    ):
         au_id = str(row.au_id)
         managed_group = managed_by_au.get(au_id)
         if managed_group is None or managed_group.empty:
@@ -2704,16 +2910,23 @@ def initialize_mkrf_runtime_package(
         au_node = et.SubElement(aus_node, "au")
         au_node.set("id", str(row.au_id))
         au_node.set("runtimeCurveMode", str(row.runtime_curve_mode))
-        au_node.set("hasManagedCurve", "true" if bool(row.has_managed_curve) else "false")
         au_node.set(
-            "hasFirstGrowthCurve", "true" if bool(row.has_first_growth_curve) else "false"
+            "hasManagedCurve", "true" if bool(row.has_managed_curve) else "false"
         )
-        au_node.set("flaggedBadCurve", "true" if bool(row.flagged_bad_curve) else "false")
+        au_node.set(
+            "hasFirstGrowthCurve",
+            "true" if bool(row.has_first_growth_curve) else "false",
+        )
+        au_node.set(
+            "flaggedBadCurve", "true" if bool(row.flagged_bad_curve) else "false"
+        )
         if pd.notna(row.first_growth_selected_path):
             au_node.set("firstGrowthSelectedPath", str(row.first_growth_selected_path))
         if pd.notna(row.runtime_curve_note) and str(row.runtime_curve_note).strip():
             au_node.set("note", str(row.runtime_curve_note))
-    et.ElementTree(root).write(xml_contract_path, encoding="utf-8", xml_declaration=True)
+    et.ElementTree(root).write(
+        xml_contract_path, encoding="utf-8", xml_declaration=True
+    )
 
     curve_bank_root = et.Element(
         "mkrfRuntimeCurveBank",
@@ -2786,22 +2999,32 @@ def initialize_mkrf_runtime_package(
         if bool(row.has_first_growth_curve):
             fg_group = first_growth_by_au.get(str(row.au_id))
             if fg_group is not None and not fg_group.empty:
-                fg_curve = et.SubElement(forestmodel_root, "curve", {"id": f"FG_{au_token}"})
+                fg_curve = et.SubElement(
+                    forestmodel_root, "curve", {"id": f"FG_{au_token}"}
+                )
                 for curve_row in fg_group.itertuples(index=False):
                     et.SubElement(
                         fg_curve,
                         "point",
-                        {"x": str(float(curve_row.age)), "y": str(float(curve_row.volume))},
+                        {
+                            "x": str(float(curve_row.age)),
+                            "y": str(float(curve_row.volume)),
+                        },
                     )
         if bool(row.has_managed_curve):
             managed_group = managed_by_au.get(str(row.au_id))
             if managed_group is not None and not managed_group.empty:
-                mg_curve = et.SubElement(forestmodel_root, "curve", {"id": f"MG_{au_token}"})
+                mg_curve = et.SubElement(
+                    forestmodel_root, "curve", {"id": f"MG_{au_token}"}
+                )
                 for curve_row in managed_group.itertuples(index=False):
                     et.SubElement(
                         mg_curve,
                         "point",
-                        {"x": str(float(curve_row.age)), "y": str(float(curve_row.volume))},
+                        {
+                            "x": str(float(curve_row.age)),
+                            "y": str(float(curve_row.volume)),
+                        },
                     )
         managed_group = managed_by_au.get(str(row.au_id))
         if managed_group is None or managed_group.empty:
@@ -2854,8 +3077,12 @@ def initialize_mkrf_runtime_package(
             if not age_values:
                 age_values = [0.0, 100.0]
             for age_value in age_values:
-                natural_volume = _curve_group_value_at_age(natural_group, int(age_value))
-                treated_volume = _curve_group_value_at_age(managed_group, int(age_value))
+                natural_volume = _curve_group_value_at_age(
+                    natural_group, int(age_value)
+                )
+                treated_volume = _curve_group_value_at_age(
+                    managed_group, int(age_value)
+                )
                 et.SubElement(
                     natural_residual_curve,
                     "point",
@@ -4011,7 +4238,9 @@ def initialize_mkrf_runtime_package(
             "managed_run_manifest_json": str(managed_run_manifest_json.resolve()),
             "bad_curve_audit_summary_csv": str(bad_curve_audit_summary_csv.resolve()),
             "runtime_curve_status_csv": str(curve_status_path.resolve()),
-            "analysis_au_runtime_status_csv": str(analysis_au_runtime_status_path.resolve()),
+            "analysis_au_runtime_status_csv": str(
+                analysis_au_runtime_status_path.resolve()
+            ),
             "analysis_au_curve_refs_csv": str(analysis_au_curve_refs_path.resolve()),
             "runtime_au_remap_audit_csv": str(runtime_au_remap_audit_path.resolve()),
             "runtime_species_share_audit_csv": str(species_share_audit_path.resolve()),
@@ -4045,7 +4274,9 @@ def initialize_mkrf_runtime_package(
             "selected_passthrough_count": int((~remap_audit["was_remapped"]).sum()),
             "remapped_source_au_count": int(remap_audit["was_remapped"].sum()),
             "remapped_forest_cover_id_count": int(
-                remap_audit.loc[remap_audit["was_remapped"], "forest_cover_id_count"].sum()
+                remap_audit.loc[
+                    remap_audit["was_remapped"], "forest_cover_id_count"
+                ].sum()
             ),
         },
         "curve_policy": {
@@ -4162,7 +4393,9 @@ def audit_mkrf_runtime_sanity(
         for bucket in _SPECIES_BUCKETS:
             label = f"{surface}.yield.{ifm_lane}.indsp.{bucket}"
             target_csv_path = targets_dir / f"{label.replace('.', '_')}.csv"
-            target_has_signal, target_max_current = _target_signal_status(target_csv_path)
+            target_has_signal, target_max_current = _target_signal_status(
+                target_csv_path
+            )
             track_labels = feature_labels if surface == "feature" else product_labels
             account_present = label in accounts_labels
             track_present = label in track_labels
@@ -4173,7 +4406,8 @@ def audit_mkrf_runtime_sanity(
             natural_nonzero = bool(
                 pd.to_numeric(
                     source_rows.loc[
-                        source_rows["origin_lane"].astype(str).eq("natural"), "share_pct"
+                        source_rows["origin_lane"].astype(str).eq("natural"),
+                        "share_pct",
                     ],
                     errors="coerce",
                 )
@@ -4184,7 +4418,8 @@ def audit_mkrf_runtime_sanity(
             treated_nonzero = bool(
                 pd.to_numeric(
                     source_rows.loc[
-                        source_rows["origin_lane"].astype(str).eq("treated"), "share_pct"
+                        source_rows["origin_lane"].astype(str).eq("treated"),
+                        "share_pct",
                     ],
                     errors="coerce",
                 )
@@ -4229,7 +4464,9 @@ def audit_mkrf_runtime_sanity(
         kind="stable",
     )
     audit_frame.to_csv(audit_csv_path, index=False)
-    failure_count = int(audit_frame["audit_status"].astype(str).str.startswith("fail_").sum())
+    failure_count = int(
+        audit_frame["audit_status"].astype(str).str.startswith("fail_").sum()
+    )
     summary_payload = {
         "schema_version": 1,
         "package_root": str(package_root),

--- a/tests/test_mkrf_au.py
+++ b/tests/test_mkrf_au.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from pathlib import Path
 
 from femic.pipeline.mkrf_au import (
     build_mkrf_au_aggregation_audit,
     build_mkrf_au_tables,
+    build_mkrf_site_series_split_audit,
     build_mkrf_selected_au_table,
+    normalize_mkrf_site_series,
     ordered_top_two_species,
     parse_mkrf_bec,
 )
@@ -18,6 +21,13 @@ def test_parse_mkrf_bec_splits_zone_subzone_variant() -> None:
     assert parse_mkrf_bec("CWHvm2") == ("cwh", "vm", "2")
     assert parse_mkrf_bec("CWHdm") == ("cwh", "dm", "x")
     assert parse_mkrf_bec(None) == ("x", "x", "x")
+
+
+def test_normalize_mkrf_site_series_extracts_stable_suffix() -> None:
+    assert normalize_mkrf_site_series("Cw - Swordfern (05)") == "ss05"
+    assert normalize_mkrf_site_series("BaCw - Foamflower (05)") == "ss05"
+    assert normalize_mkrf_site_series("Non-forested: aquatic") == "ssnonforestedaquatic"
+    assert normalize_mkrf_site_series(None) == "ssx"
 
 
 def test_ordered_top_two_species_uses_lexical_tie_break() -> None:
@@ -77,6 +87,74 @@ def test_build_mkrf_au_tables_filters_non_forest_and_groups_assignments() -> Non
     assert list(au_table["stand_count"]) == [2]
 
 
+def test_build_mkrf_au_tables_splits_large_strata_by_site_series() -> None:
+    source = pd.DataFrame(
+        [
+            {
+                "RES_KEY": 1,
+                "FOREST_COVER_ID": 101,
+                "BEC": "CWHvm1",
+                "CONTCLAS": "C",
+                "Shape_Area": 60000.0,
+                "SITE_SERIES": "Cw - Swordfern (05)",
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_1_SPECIES_PCT": 60,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_2_SPECIES_PCT": 40,
+            },
+            {
+                "RES_KEY": 2,
+                "FOREST_COVER_ID": 102,
+                "BEC": "CWHvm1",
+                "CONTCLAS": "C",
+                "Shape_Area": 40000.0,
+                "SITE_SERIES": "BaCw - Foamflower (06)",
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_1_SPECIES_PCT": 55,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_2_SPECIES_PCT": 45,
+            },
+            {
+                "RES_KEY": 3,
+                "FOREST_COVER_ID": 103,
+                "BEC": "CWHdm",
+                "CONTCLAS": "C",
+                "Shape_Area": 3000.0,
+                "SITE_SERIES": "Cw - Swordfern (05)",
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "DR",
+                "TCL_1_TSP_1_SPECIES_PCT": 70,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_2_SPECIES_PCT": 30,
+            },
+        ]
+    )
+
+    au_table, assignment = build_mkrf_au_tables(source)
+    audit = build_mkrf_site_series_split_audit(assignment)
+
+    assert set(assignment["au_id"]) == {
+        "cwh_vm_1_cw_hw_ss05",
+        "cwh_vm_1_cw_hw_ss06",
+        "cwh_dm_x_dr_cw",
+    }
+    assert assignment.loc[
+        assignment["res_key"].isin([1, 2]), "site_series_split_applied"
+    ].all()
+    assert not bool(
+        assignment.loc[assignment["res_key"].eq(3), "site_series_split_applied"].iloc[0]
+    )
+    split_aus = au_table.loc[
+        au_table["au_id"].str.startswith("cwh_vm_1_cw_hw")
+    ].sort_values("au_id")
+    assert split_aus["site_series_id"].tolist() == ["ss05", "ss06"]
+    assert split_aus["stand_count"].tolist() == [1, 1]
+
+    base_rows = audit.loc[audit["base_au_id"].eq("cwh_vm_1_cw_hw")]
+    assert base_rows["site_series_split_applied"].all()
+    assert base_rows["base_au_area_share"].iloc[0] == pytest.approx(100000.0 / 103000.0)
+    assert set(base_rows["site_series_share_of_base_au"]) == {0.6, 0.4}
+
+
 def test_build_mkrf_au_tables_applies_minor_strata_aggregation_auditably() -> None:
     source = pd.DataFrame(
         [
@@ -125,8 +203,14 @@ def test_build_mkrf_au_tables_applies_minor_strata_aggregation_auditably() -> No
     assert assignment.loc[assignment["res_key"].eq(21), "au_id"].iloc[0] == (
         "cwh_vm_2_hw_ba"
     )
-    assert assignment.loc[assignment["res_key"].eq(21), "leading_species_1"].iloc[0] == "ba"
-    assert assignment.loc[assignment["res_key"].eq(21), "leading_species_1_share"].iloc[0] == 55
+    assert (
+        assignment.loc[assignment["res_key"].eq(21), "leading_species_1"].iloc[0]
+        == "ba"
+    )
+    assert (
+        assignment.loc[assignment["res_key"].eq(21), "leading_species_1_share"].iloc[0]
+        == 55
+    )
 
     assert au_table["au_id"].tolist() == ["cwh_dm_x_dr_cw", "cwh_vm_2_hw_ba"]
     merged = au_table.loc[au_table["au_id"].eq("cwh_vm_2_hw_ba")].iloc[0]


### PR DESCRIPTION
## Summary

Adds parent FEMIC support for MKRF site-series strata splitting and points the MKRF instance submodule at the regenerated issue #27 artifact commit.

- adds `SITE_SERIES` normalization and provisional split logic to the MKRF AU builder;
- keeps downstream AU parsing compatible with site-series-suffixed AU ids;
- adds focused tests for normalization, split application, and split audit behavior;
- updates the parent roadmap for Phase 73 / issue #27.

## QA

- `python -m ruff check src/femic/pipeline/mkrf_au.py src/femic/workflows/mkrf.py tests/test_mkrf_au.py` -> passed
- `python -m pytest tests/test_mkrf_au.py tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py tests/test_tipsy_config.py` -> 53 passed
- Downstream MKRF instance QA passed in UBC-FRESH/femic-mkrf-instance PR for issue #27.