### PR TITLE
P77 publish TFL6 docs pointer

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18331,3 +18331,11 @@
 - updated CLI and reference-doc wording for `--checkpoint-path`; and
 - added focused tests proving explicit Feather and GeoPackage checkpoint inputs
   load and normalize to BC Albers.
+
+## 2026-06-25 - Accepted exact case-code TIPSY config names
+- updated TIPSY config resolution so exact case-code filenames such as
+  `tfl6.yaml` are accepted before legacy `tsa*.yaml` fallbacks;
+- kept existing `tsa08.yaml`, `tsa29.yaml`, and `tsak3z.yaml` compatibility;
+- updated preflight error text to list both exact and legacy filename options;
+  and
+- added regression coverage for exact non-TSA case-code config loading.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18339,3 +18339,17 @@
 - updated preflight error text to list both exact and legacy filename options;
   and
 - added regression coverage for exact non-TSA case-code config loading.
+
+## 2026-06-26 - Published TFL 6 parent docs pointer
+- opened FEMIC issue `#204` to publish a parent documentation pointer for the
+  merged TFL 6 teaching instance;
+- added Phase 77 / `P77.1` to `ROADMAP.md` so the docs publication task is
+  tracked separately from TFL 6 Phase 4 implementation;
+- added `docs/sample-models/tfl6.rst` and wired it into the parent
+  sample-models toctree;
+- kept the detailed TFL 6 docs in the standalone instance repository as the
+  source of truth while making them discoverable from the FEMIC Pages site;
+- rebuilt parent Sphinx docs warning-clean; and
+- retained the Sphinx autosummary refresh to
+  `docs/reference/api/generated/femic.pipeline.tsa.rst` that the docs build
+  produced.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18318,3 +18318,16 @@
   extraction, or dependency adoption in this phase; and
 - kept future `designatedlands` manifest-mining work out of Phase 75 unless a
   new roadmap task and issue are opened for that narrower implementation.
+
+## 2026-06-25 - Added explicit GeoPackage THLB checkpoint input support
+- opened FEMIC issue `#203` for accepting explicit vector checkpoint inputs in
+  the THLB netdown runner;
+- updated the THLB checkpoint loader so `.feather` inputs still use
+  `GeoPandas.read_feather`, while explicit non-Feather vector datasets such as
+  GeoPackage use `GeoPandas.read_file`;
+- preserved the TSA29 legacy `ria_vri_vclr1p_checkpoint*.feather` rejection
+  path and the rationale for Feather restart seams as a speed/restart
+  convention rather than a raw-input requirement;
+- updated CLI and reference-doc wording for `--checkpoint-path`; and
+- added focused tests proving explicit Feather and GeoPackage checkpoint inputs
+  load and normalize to BC Albers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2078,6 +2078,16 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P76.1d Run focused tests/docs validation, update issue comments, and
     publish the branch.
 
+## Phase 77: TFL 6 Parent Documentation Publication
+
+- [x] P77.1 Publish the TFL 6 instance pointer in parent FEMIC docs (`#204`)
+  - [x] P77.1a Add TFL 6 to the parent sample-models toctree.
+  - [x] P77.1b Add a parent TFL 6 pointer page that links the standalone
+    instance repository, submodule path, roadmap, and Phase 2/Phase 3 docs
+    surfaces.
+  - [x] P77.1c Build parent Sphinx docs warning-clean and open the publication
+    PR without starting TFL 6 Phase 4 implementation.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2088,6 +2098,9 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P77.1` complete under `#204`: the parent FEMIC TFL 6 docs pointer is
+    wired into the sample-models toctree and builds warning-clean. Remaining
+    publication work is the branch/PR lifecycle, not Phase 4 implementation.
   - `P68` complete
   - `P69.1` complete
   - `P69.2` complete

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2065,6 +2065,19 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
   - [x] P75.4c Record that the benchmark justified native resolver
     improvements, so the no-change branch is not the accepted path.
 
+## Phase 76: THLB Checkpoint Input Format Support
+
+- [x] P76.1 Accept explicit GeoPackage THLB checkpoint inputs (`#203`)
+  - [x] P76.1a Preserve TSA29 legacy checkpoint rejection while documenting why
+    Feather restart seams remain useful for large repeated runs.
+  - [x] P76.1b Update the checkpoint loader so explicit Feather inputs still
+    use the fast Feather path and explicit GeoPackage/vector inputs use the
+    normal GeoPandas vector reader.
+  - [x] P76.1c Update CLI/docs wording and targeted tests for explicit Feather
+    and GeoPackage checkpoint inputs.
+  - [x] P76.1d Run focused tests/docs validation, update issue comments, and
+    publish the branch.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2137,3 +2150,6 @@ Notes: `planning/mkrf_femic_native_rebuild.md`
     native resolver improvements, `designatedlands` boundary decision, and
     closeout notes. Remaining work is branch/PR lifecycle only, not additional
     resolver implementation.
+  - `P76.1` complete under `#203`: explicit GeoPackage/vector THLB checkpoint
+    inputs are supported for TFL 6 while TSA29 Feather restart seams and
+    legacy-checkpoint rejection remain intact.

--- a/docs/reference/api/generated/femic.pipeline.tsa.rst
+++ b/docs/reference/api/generated/femic.pipeline.tsa.rst
@@ -15,6 +15,7 @@
       assign_thlb_area_and_flag
       assign_thlb_raw_from_raster
       build_au_assignment_null_summary
+      build_missing_au_assignment_summary
       build_strata_summary
       build_stratum_lexmatch_alias_map
       emit_missing_au_mapping_warning
@@ -25,5 +26,6 @@
       select_tsa_slice
       summarize_missing_au_mappings
       target_nstrata_for
+      validate_complete_au_assignment
       validate_nonempty_au_assignment
    

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -912,8 +912,9 @@ Important lock contract:
 - ``--instance-root PATH`` (instance root containing ``config/`` and ``data/``)
 - ``--thlb-netdown-recipe-path PATH`` (optional; defaults to
   ``config/tsr/thlb_netdown.recipe.yaml`` under the instance root)
-- ``--checkpoint-path PATH`` (optional; current TSA29 strict validation should
-  pass an explicit validated checkpoint path under ``data/tsr/``)
+- ``--checkpoint-path PATH`` (optional; explicit inputs may be Feather or a
+  readable vector dataset such as GeoPackage; current TSA29 strict validation
+  should pass an explicit validated checkpoint path under ``data/tsr/``)
 - ``--map-id TEXT`` (repeatable; optional explicit ``MAP_ID`` subset)
 - ``--auto-map-id-smoke-subset / --no-auto-map-id-smoke-subset`` (default:
   ``--auto-map-id-smoke-subset``)
@@ -932,8 +933,9 @@ still being refined.
 - ``--instance-root PATH`` (instance root containing ``config/`` and ``data/``)
 - ``--thlb-netdown-recipe-path PATH`` (optional; defaults to
   ``config/tsr/thlb_netdown.recipe.yaml`` under the instance root)
-- ``--checkpoint-path PATH`` (optional; current TSA29 strict validation should
-  pass an explicit validated checkpoint path under ``data/tsr/``)
+- ``--checkpoint-path PATH`` (optional; explicit inputs may be Feather or a
+  readable vector dataset such as GeoPackage; current TSA29 strict validation
+  should pass an explicit validated checkpoint path under ``data/tsr/``)
 - ``--output-path PATH`` (optional; defaults to
   ``data/tsr/thlb_netdown_checkpoint.feather`` under the instance root)
 - ``--audit-path PATH`` (optional; defaults to

--- a/docs/sample-models/index.rst
+++ b/docs/sample-models/index.rst
@@ -10,5 +10,6 @@ repository.
    k3z
    tsa29
    mkrf
+   tfl6
    k3z-metadata-lineage
    mkrf-metadata-lineage

--- a/docs/sample-models/tfl6.rst
+++ b/docs/sample-models/tfl6.rst
@@ -1,0 +1,85 @@
+TFL 6 Teaching Instance (Pointer)
+=================================
+
+Purpose
+-------
+
+FEMIC keeps this page as a short pointer for the TFL 6 teaching instance. The
+canonical student-facing and maintainer-facing documentation lives in the
+standalone TFL 6 instance repository.
+
+Current Status
+--------------
+
+The TFL 6 instance has completed Phase 3 model-design assumptions and is ready
+for Phase 4 model-input bundle work after the normal feature-branch lifecycle
+is complete. Phase 3 did not build a Patchworks runtime package.
+
+Canonical Student Docs
+----------------------
+
+- Public repository: ``https://github.com/UBC-FRESH/femic-tfl6-instance``
+- Linked submodule path in FEMIC: ``external/femic-tfl6-instance``
+- Standalone docs root:
+  ``external/femic-tfl6-instance/docs/index.rst``
+- Instance roadmap:
+  ``external/femic-tfl6-instance/ROADMAP.md``
+
+Use the standalone docs as source of truth for:
+
+- Phase 2 THLB netdown design, validation, and reproducibility evidence;
+- Phase 3 static AU definitions and TFL 6 yield-curve surfaces;
+- MP10 TIPSY parameter extraction and crosswalk rationale;
+- base treatment-option, harvesting-system, and transition contracts;
+- cedar-signal and NICF embedded-identity scenario design; and
+- student-facing teaching challenges.
+
+Standalone TFL 6 Coverage Map
+-----------------------------
+
+The currently published standalone docs set is organized around:
+
+- ``phase2-thlb-netdown``: THLB netdown steps, fallback assumptions, and the
+  accepted validation gap against the scaled MP10 benchmark;
+- ``phase3-au-yield-curves``: static AU identity, top-N stratum selection,
+  VDYP first-growth curves, MP10 TIPSY parameter library, treated-curve
+  handoff, and plot galleries;
+- ``phase3-cedar-nicf-expansion``: cedar-signal and NICF identity contracts,
+  including the boundary that expansion candidates come from proximal public
+  forest outside the TFL 6 AOI;
+- ``phase3-model-input-contract``: Phase 4 field-family and artifact handoff
+  requirements; and
+- ``teaching-challenges``: advanced student exercises such as replacing
+  aspatial RMZ fallback logic with geometry-backed spatial overlays.
+
+Submodule Sync Commands
+-----------------------
+
+From the FEMIC workspace top-level directory:
+
+.. code-block:: bash
+
+   git submodule update --init --recursive
+   git submodule update --remote external/femic-tfl6-instance
+
+FEMIC-Local Integration Notes
+-----------------------------
+
+- TFL 6 instance runtime root in this repository:
+  ``external/femic-tfl6-instance``
+- Active run profile:
+  ``external/femic-tfl6-instance/config/run_profile.tfl6.yaml``
+- TIPSY configuration:
+  ``external/femic-tfl6-instance/config/tipsy/tfl6.yaml``
+- Phase 3 AU and curve documentation:
+  ``external/femic-tfl6-instance/docs/phase3-au-yield-curves.rst``
+- Phase 3 model-input contract:
+  ``external/femic-tfl6-instance/docs/phase3-model-input-contract.rst``
+
+Publication Boundary
+--------------------
+
+This parent FEMIC page is intentionally a pointer page. It makes the TFL 6
+instance discoverable from the published FEMIC documentation, while the
+standalone instance repository remains the source of truth for detailed
+figures, planning notes, run profiles, and future runtime-package evidence.

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -601,7 +601,8 @@ TSR_THLB_CHECKPOINT_PATH_OPTION = typer.Option(
     None,
     "--checkpoint-path",
     help=(
-        "Optional stand checkpoint feather used as the THLB netdown execution base. "
+        "Optional stand checkpoint vector dataset used as the THLB netdown execution base. "
+        "Explicit inputs may be Feather or a readable vector dataset such as GeoPackage. "
         "Current TSA29 strict validation must use an explicit validated checkpoint "
         "under `data/tsr/`; legacy `ria_vri_vclr1p_checkpoint*.feather` fallbacks are rejected."
     ),
@@ -1646,6 +1647,7 @@ def _preflight_checks(*, resume: bool, instance_context: InstanceContext) -> Non
     warnings: list[str] = []
 
     data_root = repo_root / "data"
+
     def _resolve_required(primary: Path, fallback: Path | None = None) -> Path | None:
         if primary.exists():
             return primary
@@ -6679,7 +6681,9 @@ def instance_mkrf_init_runtime_package(
     console.print(f"package_root: {result.package_root}")
     console.print(f"manifest: {result.manifest_path}")
     console.print(f"curve_status_csv: {result.curve_status_path}")
-    console.print(f"analysis_au_runtime_status_csv: {result.analysis_au_runtime_status_path}")
+    console.print(
+        f"analysis_au_runtime_status_csv: {result.analysis_au_runtime_status_path}"
+    )
     console.print(f"analysis_au_curve_refs_csv: {result.analysis_au_curve_refs_path}")
     console.print(f"runtime_species_share_audit_csv: {result.species_share_audit_path}")
     console.print(f"analysis_pin: {result.analysis_pin_path}")

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -6866,6 +6866,8 @@ def run_all(
         managed_curve_y_scale=effective.managed_curve_y_scale,
         managed_curve_truncate_at_culm=effective.managed_curve_truncate_at_culm,
         managed_curve_max_age=effective.managed_curve_max_age,
+        vri_rel_candidates=effective.vri_rel_candidates,
+        vdyp_input_rel_candidates=effective.vdyp_input_rel_candidates,
         instance_root=instance_context.root,
     )
     manifest_path = run_data_prep(pipeline_run_config)
@@ -7249,6 +7251,8 @@ def prep_validate_case(
     external_paths = resolve_legacy_external_data_paths(
         repo_root=instance_context.root,
         env_override=os.environ.get("FEMIC_EXTERNAL_DATA_ROOT"),
+        vri_rel_candidates=effective.vri_rel_candidates,
+        vdyp_input_rel_candidates=effective.vdyp_input_rel_candidates,
     )
     source_root = _source_tree_root()
     required_external_paths = {

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -7240,11 +7240,10 @@ def prep_validate_case(
             errors.append(f"Invalid TIPSY config for {code}: {exc}")
             continue
         if cfg is None:
-            expected_yaml = resolved_tipsy_config_dir / f"tsa{code}.yaml"
-            expected_yml = resolved_tipsy_config_dir / f"tsa{code}.yml"
             errors.append(
                 f"Missing TIPSY config for {code} in {resolved_tipsy_config_dir} "
-                f"(expected {expected_yaml.name} or {expected_yml.name})."
+                f"(expected {code}.yaml, {code}.yml, tsa{code}.yaml, or "
+                f"tsa{code}.yml)."
             )
 
     external_paths = resolve_legacy_external_data_paths(

--- a/src/femic/pipeline/io.py
+++ b/src/femic/pipeline/io.py
@@ -110,6 +110,8 @@ class PipelineRunConfig:
     managed_curve_truncate_at_culm: bool | None = None
     managed_curve_max_age: int | None = None
     yield_assumptions_path: Path | None = None
+    vri_rel_candidates: list[Path] | None = None
+    vdyp_input_rel_candidates: list[Path] | None = None
     instance_root: Path | None = None
 
 
@@ -143,6 +145,8 @@ class PipelineRunProfile:
     managed_curve_truncate_at_culm: bool | None = None
     managed_curve_max_age: int | None = None
     yield_assumptions_path: Path | None = None
+    vri_rel_candidates: list[Path] | None = None
+    vdyp_input_rel_candidates: list[Path] | None = None
 
 
 @dataclass(frozen=True)
@@ -175,6 +179,8 @@ class EffectiveRunOptions:
     managed_curve_truncate_at_culm: bool | None
     managed_curve_max_age: int | None
     yield_assumptions_path: Path | None
+    vri_rel_candidates: list[Path] | None
+    vdyp_input_rel_candidates: list[Path] | None
 
 
 @dataclass(frozen=True)
@@ -545,9 +551,11 @@ def is_windows_annex_pointer_stub(
     if not text or "\n" in text or "\r" in text:
         return False
     normalized = text.replace("\\", "/")
-    return ".git/annex/" in normalized or normalized.startswith(
-        "/annex/objects/"
-    ) or normalized.startswith("annex/objects/")
+    return (
+        ".git/annex/" in normalized
+        or normalized.startswith("/annex/objects/")
+        or normalized.startswith("annex/objects/")
+    )
 
 
 def materialize_annex_artifact_path(
@@ -641,6 +649,15 @@ def _normalize_optional_path(value: object, *, field_name: str) -> Path | None:
     return Path(value)
 
 
+def _normalize_optional_path_list(
+    value: object, *, field_name: str
+) -> list[Path] | None:
+    values = _normalize_optional_str_list(value, field_name=field_name)
+    if values is None:
+        return None
+    return [Path(item) for item in values]
+
+
 def _normalize_optional_str(value: object, *, field_name: str) -> str | None:
     if value is None:
         return None
@@ -715,6 +732,11 @@ def load_pipeline_run_profile(config_path: Path) -> PipelineRunProfile:
         run = {}
     if not isinstance(run, dict):
         raise ValueError("run must be a mapping")
+    source_paths = parsed.get("source_paths", {})
+    if source_paths is None:
+        source_paths = {}
+    if not isinstance(source_paths, dict):
+        raise ValueError("source_paths must be a mapping")
     stratification = selection.get("stratification", {})
     if stratification is None:
         stratification = {}
@@ -805,6 +827,14 @@ def load_pipeline_run_profile(config_path: Path) -> PipelineRunProfile:
             modes.get("yield_assumptions_path"),
             field_name="modes.yield_assumptions_path",
         ),
+        vri_rel_candidates=_normalize_optional_path_list(
+            source_paths.get("vri_rel_candidates"),
+            field_name="source_paths.vri_rel_candidates",
+        ),
+        vdyp_input_rel_candidates=_normalize_optional_path_list(
+            source_paths.get("vdyp_input_rel_candidates"),
+            field_name="source_paths.vdyp_input_rel_candidates",
+        ),
         resume=_normalize_optional_bool(modes.get("resume"), field_name="modes.resume"),
         dry_run=_normalize_optional_bool(
             modes.get("dry_run"), field_name="modes.dry_run"
@@ -881,6 +911,8 @@ def resolve_effective_run_options(
         managed_curve_truncate_at_culm=active_profile.managed_curve_truncate_at_culm,
         managed_curve_max_age=active_profile.managed_curve_max_age,
         yield_assumptions_path=active_profile.yield_assumptions_path,
+        vri_rel_candidates=active_profile.vri_rel_candidates,
+        vdyp_input_rel_candidates=active_profile.vdyp_input_rel_candidates,
     )
 
 
@@ -930,6 +962,8 @@ def build_pipeline_run_config(
     managed_curve_truncate_at_culm: bool | None = None,
     managed_curve_max_age: int | None = None,
     yield_assumptions_path: Path | None = None,
+    vri_rel_candidates: Sequence[str | Path] | None = None,
+    vdyp_input_rel_candidates: Sequence[str | Path] | None = None,
     instance_root: Path | None = None,
 ) -> PipelineRunConfig:
     """Create normalized pipeline run configuration from CLI inputs."""
@@ -961,6 +995,16 @@ def build_pipeline_run_config(
         managed_curve_max_age=managed_curve_max_age,
         yield_assumptions_path=(
             Path(yield_assumptions_path) if yield_assumptions_path is not None else None
+        ),
+        vri_rel_candidates=(
+            [Path(path) for path in vri_rel_candidates]
+            if vri_rel_candidates is not None
+            else None
+        ),
+        vdyp_input_rel_candidates=(
+            [Path(path) for path in vdyp_input_rel_candidates]
+            if vdyp_input_rel_candidates is not None
+            else None
         ),
         instance_root=Path(instance_root) if instance_root is not None else None,
     )
@@ -1061,6 +1105,14 @@ def build_legacy_execution_plan(
         )
     if run_config.managed_curve_max_age is not None:
         env["FEMIC_MANAGED_CURVE_MAX_AGE"] = str(int(run_config.managed_curve_max_age))
+    if run_config.vri_rel_candidates is not None:
+        env["FEMIC_VRI_REL_CANDIDATES"] = os.pathsep.join(
+            path.as_posix() for path in run_config.vri_rel_candidates
+        )
+    if run_config.vdyp_input_rel_candidates is not None:
+        env["FEMIC_VDYP_INPUT_REL_CANDIDATES"] = os.pathsep.join(
+            path.as_posix() for path in run_config.vdyp_input_rel_candidates
+        )
     env.setdefault("FEMIC_RUN_UUID", str(uuid.uuid4()))
     run_uuid = env["FEMIC_RUN_UUID"]
 

--- a/src/femic/pipeline/tipsy_config.py
+++ b/src/femic/pipeline/tipsy_config.py
@@ -66,9 +66,20 @@ def resolve_tipsy_runtime_options(
 
 
 def tipsy_config_path_for_tsa(tsa_code: str, config_dir: str | Path) -> Path:
-    """Resolve default config path (`tsaXX.yaml`) for a TSA code."""
+    """Resolve legacy default config path (`tsaXX.yaml`) for a case code."""
     tsa = str(tsa_code).zfill(2)
     return Path(config_dir) / f"tsa{tsa}.yaml"
+
+
+def _tipsy_config_path_candidates(tsa_code: str, config_dir: str | Path) -> list[Path]:
+    code = str(tsa_code).zfill(2)
+    base = Path(config_dir)
+    return [
+        base / f"{code}.yaml",
+        base / f"{code}.yml",
+        base / f"tsa{code}.yaml",
+        base / f"tsa{code}.yml",
+    ]
 
 
 def _resolve_tipsy_config_path(
@@ -76,12 +87,9 @@ def _resolve_tipsy_config_path(
     tsa_code: str,
     config_dir: str | Path,
 ) -> Path | None:
-    path_yaml = tipsy_config_path_for_tsa(tsa_code, config_dir)
-    path_yml = path_yaml.with_suffix(".yml")
-    if path_yaml.exists():
-        return path_yaml
-    if path_yml.exists():
-        return path_yml
+    for path in _tipsy_config_path_candidates(tsa_code, config_dir):
+        if path.exists():
+            return path
     return None
 
 
@@ -169,8 +177,8 @@ def discover_tipsy_config_tsas(
     found: dict[str, Path] = {}
     if not base.exists():
         return found
-    for path in sorted(base.glob("tsa*.y*ml")):
-        match = re.fullmatch(r"tsa([A-Za-z0-9_-]+)\.ya?ml", path.name)
+    for path in sorted(base.glob("*.y*ml")):
+        match = re.fullmatch(r"(?:tsa)?([A-Za-z0-9_-]+)\.ya?ml", path.name)
         if not match:
             continue
         code = match.group(1)

--- a/src/femic/resources/legacy/00_data-prep.py
+++ b/src/femic/resources/legacy/00_data-prep.py
@@ -189,6 +189,13 @@ def _row_apply(df, func, axis=1):
     return df.apply(func, axis=axis)
 
 
+def _pathsep_env_candidates(name: str) -> list[str] | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return [item.strip() for item in raw.split(os.pathsep) if item.strip()]
+
+
 # --- cell 7 ---
 # %ipcluster --help
 # %load_ext ipyparallel
@@ -217,6 +224,10 @@ _repo_root = (
 _external_paths = resolve_legacy_external_data_paths(
     repo_root=_repo_root,
     env_override=os.environ.get("FEMIC_EXTERNAL_DATA_ROOT"),
+    vri_rel_candidates=_pathsep_env_candidates("FEMIC_VRI_REL_CANDIDATES"),
+    vdyp_input_rel_candidates=_pathsep_env_candidates(
+        "FEMIC_VDYP_INPUT_REL_CANDIDATES"
+    ),
 )
 vri_vclr1p_path = _external_paths.vri_vclr1p_path
 _legacy_data_paths = build_legacy_data_artifact_paths(output_root=_repo_root / "data")
@@ -278,7 +289,9 @@ _siteprod_artifacts = resolve_legacy_siteprod_artifacts(
 siteprod_tif_path = _siteprod_artifacts.siteprod_tif_path
 siteprod_bandmap_path = _siteprod_artifacts.siteprod_bandmap_path
 print(f"using siteprod raster source: {siteprod_tif_path}")
-print(f"siteprod export fallback used: {'no' if _siteprod_artifacts.use_prestacked else 'yes'}")
+print(
+    f"siteprod export fallback used: {'no' if _siteprod_artifacts.use_prestacked else 'yes'}"
+)
 if _siteprod_artifacts.use_prestacked:
     print(f"using siteprod band map: {siteprod_bandmap_path}")
 
@@ -573,7 +586,9 @@ if _siteprod_artifacts.use_prestacked:
     siteprod_layerspecies, siteprod_specieslayer = load_siteprod_bandmap(
         bandmap_path=siteprod_bandmap_path,
     )
-    print("Using pre-stacked SiteProd TIFF + band map; skipping ArcRasterRescue/ArcPy layer listing and export.")
+    print(
+        "Using pre-stacked SiteProd TIFF + band map; skipping ArcRasterRescue/ArcPy layer listing and export."
+    )
 else:
     siteprod_layerspecies, siteprod_specieslayer = list_siteprod_layers(
         arc_raster_rescue_exe_path=arc_raster_rescue_exe_path,

--- a/src/femic/tsr_catalog/recipes.py
+++ b/src/femic/tsr_catalog/recipes.py
@@ -1593,8 +1593,10 @@ def _default_dwds_order_manifest_path(*, instance_root: Path, entry_id: str) -> 
 
 
 def _load_override_map(
-    overrides_path: Path,
+    overrides_path: Path | None,
 ) -> dict[str, TsrSourceLayerOverrideEntry]:
+    if overrides_path is None:
+        return {}
     if not overrides_path.exists():
         return {}
     record = load_tsr_source_layer_overrides(overrides_path)
@@ -1602,8 +1604,10 @@ def _load_override_map(
 
 
 def _load_overlay_attempt_map(
-    overlay_path: Path,
+    overlay_path: Path | None,
 ) -> dict[str, dict[str, Any]]:
+    if overlay_path is None:
+        return {}
     if not overlay_path.exists():
         return {}
     payload = yaml.safe_load(overlay_path.read_text(encoding="utf-8"))
@@ -5127,11 +5131,13 @@ def build_tsr_source_layers_recipe(
         source_root_resolved, recipe.canonical_inputs.candidate_facts_path
     )
     instance_root = recipe_path.expanduser().resolve().parents[2]
-    overrides_path = _resolve_instance_path(
-        instance_root, recipe.instance_inputs.source_layer_overrides_path
+    overrides_path = _resolve_optional_instance_path(
+        instance_root=instance_root,
+        value=recipe.instance_inputs.source_layer_overrides_path,
     )
-    overlay_path = _resolve_instance_path(
-        instance_root, recipe.instance_inputs.overlay_path
+    overlay_path = _resolve_optional_instance_path(
+        instance_root=instance_root,
+        value=recipe.instance_inputs.overlay_path,
     )
     override_map = _load_override_map(overrides_path)
     overlay_attempt_map = _load_overlay_attempt_map(overlay_path)
@@ -5198,8 +5204,9 @@ def build_tsr_thlb_netdown_recipe(
     )
     source_recipe = load_tsr_source_layers_recipe(source_layer_recipe_path)
     source_index = _build_source_recipe_index(source_recipe)
-    overrides_path = _resolve_instance_path(
-        instance_root, recipe.instance_inputs.source_layer_overrides_path
+    overrides_path = _resolve_optional_instance_path(
+        instance_root=instance_root,
+        value=recipe.instance_inputs.source_layer_overrides_path,
     )
     override_entries = _load_override_map(overrides_path)
 
@@ -5821,6 +5828,16 @@ def _load_checkpoint_geodataframe(path: Path) -> gpd.GeoDataFrame:
         checkpoint = checkpoint.set_crs(BC_ALBERS_EPSG)
     else:
         checkpoint = checkpoint.to_crs(BC_ALBERS_EPSG)
+    rename_columns = {
+        lower_name: upper_name
+        for lower_name, upper_name in (
+            ("feature_id", "FEATURE_ID"),
+            ("map_id", "MAP_ID"),
+        )
+        if upper_name not in checkpoint.columns and lower_name in checkpoint.columns
+    }
+    if rename_columns:
+        checkpoint = checkpoint.rename(columns=rename_columns)
     return checkpoint
 
 
@@ -7358,6 +7375,34 @@ def _auto_select_smoke_map_ids(
 
 
 def _find_landscape_unit_layer_path(instance_root: Path) -> Path | None:
+    source_recipe_path = (
+        instance_root.expanduser().resolve()
+        / "config"
+        / "tsr"
+        / "source_layers.recipe.yaml"
+    )
+    if source_recipe_path.exists():
+        payload = yaml.safe_load(source_recipe_path.read_text(encoding="utf-8"))
+        entries = payload.get("entries", []) if isinstance(payload, dict) else []
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                entry_text = " ".join(
+                    str(entry.get(key, ""))
+                    for key in ("entry_id", "label", "recommended_query")
+                ).casefold()
+                if "landscape" not in entry_text:
+                    continue
+                artifact_path = str(entry.get("artifact_path", "")).strip()
+                if not artifact_path:
+                    continue
+                candidate = Path(artifact_path).expanduser()
+                if not candidate.is_absolute():
+                    candidate = instance_root / candidate
+                resolved = candidate.resolve()
+                if resolved.exists():
+                    return resolved
     candidates = (
         instance_root
         / "data"
@@ -8486,6 +8531,29 @@ def _checkpoint_has_step13_enrichment(path: Path) -> bool:
             "curve2",
         )
     )
+
+
+def _recipe_steps_require_lhlb_curve_ready(
+    recipe_steps: Sequence[dict[str, Any]],
+) -> bool:
+    step13_fields = {
+        "femic_slope_pct_median",
+        "femic_hwy97_side",
+        "femic_step13_steep_slope_flag",
+    }
+    for step in recipe_steps:
+        operation_type = str(step.get("compiled_operation_type", "")).strip()
+        if operation_type == "curve_volume_threshold_exclusion":
+            return True
+        if step.get("curve_id_column") or step.get("minimum_volume_m3_per_ha"):
+            return True
+        for item in step.get("checkpoint_attribute_filters", ()) or ():
+            if not isinstance(item, dict):
+                continue
+            field = str(item.get("field", "")).strip()
+            if field in step13_fields or field.startswith("femic_step13_"):
+                return True
+    return False
 
 
 def _validate_reconstructed_restart_equivalence(
@@ -10007,9 +10075,14 @@ def _compute_legacy_reference_managed_area_ha(
         checkpoint_path=checkpoint_path,
     ):
         return None
-    latest_checkpoint = _find_tsr_checkpoint_path(
-        instance_root=instance_root, mode="latest"
-    )
+    try:
+        latest_checkpoint = _find_tsr_checkpoint_path(
+            instance_root=instance_root, mode="latest"
+        )
+    except TsrRecipeError as exc:
+        if "No stand checkpoint feather found" in str(exc):
+            return None
+        raise
     if latest_checkpoint == checkpoint_path:
         return None
     comparison = _load_checkpoint_geodataframe(latest_checkpoint)
@@ -10121,12 +10194,12 @@ def _format_thlb_filter_value(value: Any) -> str:
 def _describe_thlb_filter(item: dict[str, Any]) -> str:
     field = str(item.get("field", "")).strip()
     operator = str(item.get("operator", "")).strip()
-    value = item.get("value")
+    value = item.get("value", item.get("values"))
     if operator == "eq":
         return f"`{field}` = {_format_thlb_filter_value(value)}"
     if operator == "ne":
         return f"`{field}` != {_format_thlb_filter_value(value)}"
-    if operator == "lt":
+    if operator in {"lt", "less_than"}:
         return f"`{field}` < {_format_thlb_filter_value(value)}"
     if operator == "le":
         return f"`{field}` <= {_format_thlb_filter_value(value)}"
@@ -10136,10 +10209,14 @@ def _describe_thlb_filter(item: dict[str, Any]) -> str:
         return f"`{field}` >= {_format_thlb_filter_value(value)}"
     if operator == "in":
         return f"`{field}` in [{_format_thlb_filter_value(value)}]"
+    if operator == "in_or_null":
+        return f"`{field}` in [{_format_thlb_filter_value(value)}] or null"
     if operator == "not_in":
         return f"`{field}` not in [{_format_thlb_filter_value(value)}]"
     if operator == "is_null":
         return f"`{field}` is null"
+    if operator == "is_not_null":
+        return f"`{field}` is not null"
     if operator == "not_blank":
         return f"`{field}` is not blank"
     return f"`{field}` {operator} {_format_thlb_filter_value(value)}"
@@ -11891,8 +11968,9 @@ def _load_tsr_thlb_recipe_context(
         instance_root, recipe.instance_inputs.source_layer_recipe_path
     )
     source_recipe = load_tsr_source_layers_recipe(source_layer_recipe_path)
-    overrides_path = _resolve_instance_path(
-        instance_root, recipe.instance_inputs.source_layer_overrides_path
+    overrides_path = _resolve_optional_instance_path(
+        instance_root=instance_root,
+        value=recipe.instance_inputs.source_layer_overrides_path,
     )
     return (
         recipe,
@@ -12039,7 +12117,7 @@ def _evaluate_attribute_filter(
         return series == value
     if operator == "ne":
         return series != value
-    if operator == "lt":
+    if operator in {"lt", "less_than"}:
         return pd.to_numeric(series, errors="coerce") < float(value)
     if operator == "le":
         return pd.to_numeric(series, errors="coerce") <= float(value)
@@ -12049,10 +12127,14 @@ def _evaluate_attribute_filter(
         return pd.to_numeric(series, errors="coerce") >= float(value)
     if operator == "in":
         return series.isin(list(value))
+    if operator == "in_or_null":
+        return series.isna() | series.isin(list(value))
     if operator == "not_in":
         return ~series.isin(list(value))
     if operator == "is_null":
         return series.isna()
+    if operator == "is_not_null":
+        return series.notna()
     if operator == "not_blank":
         return series.notna() & (series.astype(str).str.strip() != "")
     raise TsrRecipeError(f"Unsupported attribute filter operator: {operator}")
@@ -12132,7 +12214,7 @@ def _build_checkpoint_attribute_mask(
     for item in filters:
         field = str(item.get("field", "")).strip()
         operator = str(item.get("operator", "")).strip()
-        value = item.get("value")
+        value = item.get("value", item.get("values"))
         if field not in checkpoint.columns:
             continue
         masks.append(
@@ -12162,7 +12244,7 @@ def _apply_source_attribute_filters(
     for item in filters:
         field = str(item.get("field", "")).strip()
         operator = str(item.get("operator", "")).strip()
-        value = item.get("value")
+        value = item.get("value", item.get("values"))
         if field not in filtered.columns:
             continue
         mask = _evaluate_attribute_filter(
@@ -19684,8 +19766,9 @@ def run_tsr_thlb_netdown_recipe(
     )
     source_recipe = load_tsr_source_layers_recipe(source_layer_recipe_path)
     source_entry_map = _load_source_recipe_entry_map(source_recipe)
-    overrides_path = _resolve_instance_path(
-        instance_root, recipe.instance_inputs.source_layer_overrides_path
+    overrides_path = _resolve_optional_instance_path(
+        instance_root=instance_root,
+        value=recipe.instance_inputs.source_layer_overrides_path,
     )
     override_entries = _load_override_map(overrides_path)
 
@@ -19947,32 +20030,41 @@ def run_tsr_thlb_netdown_recipe(
         recipe_contract["lhlb_checkpoint_area_ha"] = float(lhlb_checkpoint_area_ha)
         payload["recipe_contract"] = recipe_contract
         _write_recipe_yaml(resolved_recipe_path, payload)
-        (
-            written_lhlb_curve_ready_checkpoint_path,
-            written_lhlb_curve_ready_gpkg_path,
-            lhlb_curve_ready_checkpoint_area_ha,
-            lhlb_curve_ready_lu_cache_warmed,
-        ) = _ensure_lhlb_curve_ready_checkpoint_artifacts(
-            instance_root=instance_root,
-            checkpoint_path=written_lhlb_checkpoint_path,
-            write_gpkg=write_lhlb_curve_ready_gpkg,
-        )
-        recipe_contract["lhlb_curve_ready_checkpoint_path"] = str(
-            written_lhlb_curve_ready_checkpoint_path.relative_to(
-                instance_root
-            ).as_posix()
-        )
-        if written_lhlb_curve_ready_gpkg_path is not None:
-            recipe_contract["lhlb_curve_ready_gpkg_path"] = str(
-                written_lhlb_curve_ready_gpkg_path.relative_to(instance_root).as_posix()
+        if _recipe_steps_require_lhlb_curve_ready(selected_recipe_steps):
+            (
+                written_lhlb_curve_ready_checkpoint_path,
+                written_lhlb_curve_ready_gpkg_path,
+                lhlb_curve_ready_checkpoint_area_ha,
+                lhlb_curve_ready_lu_cache_warmed,
+            ) = _ensure_lhlb_curve_ready_checkpoint_artifacts(
+                instance_root=instance_root,
+                checkpoint_path=written_lhlb_checkpoint_path,
+                write_gpkg=write_lhlb_curve_ready_gpkg,
             )
+            recipe_contract["lhlb_curve_ready_checkpoint_path"] = str(
+                written_lhlb_curve_ready_checkpoint_path.relative_to(
+                    instance_root
+                ).as_posix()
+            )
+            if written_lhlb_curve_ready_gpkg_path is not None:
+                recipe_contract["lhlb_curve_ready_gpkg_path"] = str(
+                    written_lhlb_curve_ready_gpkg_path.relative_to(
+                        instance_root
+                    ).as_posix()
+                )
+            else:
+                recipe_contract.pop("lhlb_curve_ready_gpkg_path", None)
+            recipe_contract["lhlb_curve_ready_checkpoint_area_ha"] = float(
+                lhlb_curve_ready_checkpoint_area_ha
+            )
+            payload["recipe_contract"] = recipe_contract
+            _write_recipe_yaml(resolved_recipe_path, payload)
         else:
+            recipe_contract.pop("lhlb_curve_ready_checkpoint_path", None)
             recipe_contract.pop("lhlb_curve_ready_gpkg_path", None)
-        recipe_contract["lhlb_curve_ready_checkpoint_area_ha"] = float(
-            lhlb_curve_ready_checkpoint_area_ha
-        )
-        payload["recipe_contract"] = recipe_contract
-        _write_recipe_yaml(resolved_recipe_path, payload)
+            recipe_contract.pop("lhlb_curve_ready_checkpoint_area_ha", None)
+            payload["recipe_contract"] = recipe_contract
+            _write_recipe_yaml(resolved_recipe_path, payload)
     elif (
         execution_mode == TSR_THLB_EXECUTION_MODE_RECONSTRUCTED
         and checkpoint_restart_mode == "lhlb_curve_ready_checkpoint_restart"

--- a/src/femic/tsr_catalog/recipes.py
+++ b/src/femic/tsr_catalog/recipes.py
@@ -5804,10 +5804,16 @@ def _workbench_stage_window_for_target(
 
 
 def _load_checkpoint_geodataframe(path: Path) -> gpd.GeoDataFrame:
+    suffix = path.suffix.casefold()
     try:
-        checkpoint = gpd.read_feather(path)
+        if suffix == ".feather":
+            checkpoint = gpd.read_feather(path)
+        else:
+            checkpoint = gpd.read_file(path)
     except Exception as exc:  # pragma: no cover - filesystem/runtime seam
-        raise TsrRecipeError(f"Unable to read THLB checkpoint feather: {path}") from exc
+        raise TsrRecipeError(
+            f"Unable to read THLB checkpoint vector dataset: {path}"
+        ) from exc
     if "geometry" not in checkpoint.columns:
         raise TsrRecipeError(f"THLB checkpoint is missing a geometry column: {path}")
     checkpoint = checkpoint.copy()
@@ -17781,9 +17787,7 @@ def _preflight_locked_parent_step_required_sources(
                 seen_entry_ids.add(entry_id)
                 source_entry = source_entry_map.get(entry_id)
                 if source_entry is None:
-                    blockers.append(
-                        f"`{entry_id}` has no source-layer recipe entry."
-                    )
+                    blockers.append(f"`{entry_id}` has no source-layer recipe entry.")
                     continue
                 artifact_path = str(source_entry.get("artifact_path", "")).strip()
                 candidate_path = (
@@ -17795,7 +17799,11 @@ def _preflight_locked_parent_step_required_sources(
                     instance_root=instance_root,
                     source_entry=dict(source_entry),
                 )
-                if resolved_path is None and artifact_path and candidate_path is not None:
+                if (
+                    resolved_path is None
+                    and artifact_path
+                    and candidate_path is not None
+                ):
                     materialized_path = materialize_annex_artifact_path(candidate_path)
                     if materialized_path is not None:
                         resolved_path = _resolve_source_artifact_path(
@@ -17826,7 +17834,9 @@ def _preflight_locked_parent_step_required_sources(
                     continue
                 if _probe_vector_artifact_bounds(resolved_path) is None:
                     try:
-                        display_path = resolved_path.relative_to(instance_root).as_posix()
+                        display_path = resolved_path.relative_to(
+                            instance_root
+                        ).as_posix()
                     except ValueError:
                         display_path = str(resolved_path)
                     blockers.append(

--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from femic.pipeline.io import (
@@ -1120,6 +1121,13 @@ def test_load_pipeline_run_profile_from_yaml(tmp_path: Path) -> None:
                 "    species_combo_count: 2",
                 "    include_tm_species2_for_single: false",
                 "    top_area_coverage: 0.95",
+                "source_paths:",
+                "  vri_rel_candidates:",
+                "    - bc/vri/2025/VEG_COMP_LYR_R1_POLY_2025.gdb",
+                "    - bc/vri/2024/VEG_COMP_LYR_R1_POLY_2024.gdb",
+                "  vdyp_input_rel_candidates:",
+                "    - bc/vri/2025/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2025.gdb",
+                "    - bc/vri/2024/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2024.gdb",
                 "modes:",
                 "  resume: true",
                 "  dry_run: false",
@@ -1161,6 +1169,14 @@ def test_load_pipeline_run_profile_from_yaml(tmp_path: Path) -> None:
     assert profile.strat_species_combo_count == 2
     assert profile.strat_include_tm_species2_for_single is False
     assert profile.strat_top_area_coverage == pytest.approx(0.95)
+    assert profile.vri_rel_candidates == [
+        Path("bc/vri/2025/VEG_COMP_LYR_R1_POLY_2025.gdb"),
+        Path("bc/vri/2024/VEG_COMP_LYR_R1_POLY_2024.gdb"),
+    ]
+    assert profile.vdyp_input_rel_candidates == [
+        Path("bc/vri/2025/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2025.gdb"),
+        Path("bc/vri/2024/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2024.gdb"),
+    ]
     assert profile.vdyp_sampling_mode == "all"
     assert profile.vdyp_two_pass_rebin is True
     assert profile.vdyp_min_stands_per_si_bin == 10
@@ -1290,6 +1306,14 @@ def test_build_legacy_execution_plan_resolves_env_and_paths(tmp_path: Path) -> N
         managed_curve_truncate_at_culm=True,
         managed_curve_max_age=300,
         yield_assumptions_path=Path("config/tsr/yield_assumptions.yaml"),
+        vri_rel_candidates=[
+            Path("bc/vri/2025/VEG_COMP_LYR_R1_POLY_2025.gdb"),
+            Path("bc/vri/2024/VEG_COMP_LYR_R1_POLY_2024.gdb"),
+        ],
+        vdyp_input_rel_candidates=[
+            Path("bc/vri/2025/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2025.gdb"),
+            Path("bc/vri/2024/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2024.gdb"),
+        ],
     )
 
     plan = build_legacy_execution_plan(
@@ -1331,6 +1355,18 @@ def test_build_legacy_execution_plan_resolves_env_and_paths(tmp_path: Path) -> N
     assert plan.env["FEMIC_MANAGED_CURVE_Y_SCALE"] == "1.2"
     assert plan.env["FEMIC_MANAGED_CURVE_TRUNCATE_AT_CULM"] == "1"
     assert plan.env["FEMIC_MANAGED_CURVE_MAX_AGE"] == "300"
+    assert plan.env["FEMIC_VRI_REL_CANDIDATES"] == os.pathsep.join(
+        [
+            "bc/vri/2025/VEG_COMP_LYR_R1_POLY_2025.gdb",
+            "bc/vri/2024/VEG_COMP_LYR_R1_POLY_2024.gdb",
+        ]
+    )
+    assert plan.env["FEMIC_VDYP_INPUT_REL_CANDIDATES"] == os.pathsep.join(
+        [
+            "bc/vri/2025/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2025.gdb",
+            "bc/vri/2024/VEG_COMP_VDYP7_INPUT_POLY_AND_LAYER_2024.gdb",
+        ]
+    )
     assert plan.cmd == ["/usr/bin/python3", str(script_path)]
     assert plan.working_dir == script_path.parent.resolve()
 

--- a/tests/test_tipsy_config.py
+++ b/tests/test_tipsy_config.py
@@ -41,6 +41,31 @@ rules:
     assert payload["tsa_code"] == "08"
 
 
+def test_load_tipsy_tsa_config_accepts_exact_case_code_filename(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tfl6.yaml"
+    path.write_text(
+        """
+schema_version: 1
+tsa_code: "tfl6"
+rules:
+  - id: cedar
+    when:
+      leading_species_in: ["CW"]
+      bec_in: ["CWH"]
+    assign:
+      e: {Density: 1200, SPP_1: "CW", PCT_1: 100}
+      f: {Density: 1100, SPP_1: "CW", PCT_1: 100}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    payload = load_tipsy_tsa_config(tsa_code="tfl6", config_dir=tmp_path)
+    assert payload is not None
+    assert payload["tsa_code"] == "tfl6"
+
+
 def test_resolve_tipsy_runtime_options_defaults_and_overrides() -> None:
     default_dir, default_legacy = resolve_tipsy_runtime_options(env={})
     assert default_dir == "config/tipsy"

--- a/tests/test_tsr_recipes.py
+++ b/tests/test_tsr_recipes.py
@@ -24,6 +24,40 @@ from femic.tsr_catalog import recipes as tsr_recipes
 from femic.tsr_catalog import step13_attributes as tsr_step13_attributes
 
 
+def test_load_checkpoint_geodataframe_reads_explicit_feather(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "checkpoint.feather"
+    gdf = gpd.GeoDataFrame(
+        {"feature_id": [1], "area_ha_calc": [1.0]},
+        geometry=[box(0, 0, 1, 1)],
+        crs="EPSG:3005",
+    )
+    gdf.to_feather(checkpoint_path)
+
+    loaded = tsr_recipes._load_checkpoint_geodataframe(checkpoint_path)
+
+    assert len(loaded) == 1
+    assert loaded.crs is not None
+    assert loaded.crs.to_epsg() == 3005
+    assert loaded.loc[0, "feature_id"] == 1
+
+
+def test_load_checkpoint_geodataframe_reads_explicit_geopackage(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "checkpoint.gpkg"
+    gdf = gpd.GeoDataFrame(
+        {"feature_id": [7], "area_ha_calc": [2.0]},
+        geometry=[box(-123.0, 49.0, -122.9, 49.1)],
+        crs="EPSG:4326",
+    )
+    gdf.to_file(checkpoint_path, driver="GPKG", layer="checkpoint")
+
+    loaded = tsr_recipes._load_checkpoint_geodataframe(checkpoint_path)
+
+    assert len(loaded) == 1
+    assert loaded.crs is not None
+    assert loaded.crs.to_epsg() == 3005
+    assert loaded.loc[0, "feature_id"] == 7
+
+
 def _write_registry(tmp_path: Path) -> Path:
     payload = {
         "generated_utc": "2026-04-04T00:00:00+00:00",
@@ -558,7 +592,9 @@ def test_run_tsr_thlb_locked_parent_step_preserves_lu_chunk_cache_records(
         "_resolve_tsr_thlb_parent_step",
         lambda recipe, parent_step_id: parent_step,
     )
-    monkeypatch.setattr(tsr_recipes, "_resolve_tsr_total_area_benchmark", lambda recipe: 2.0)
+    monkeypatch.setattr(
+        tsr_recipes, "_resolve_tsr_total_area_benchmark", lambda recipe: 2.0
+    )
     monkeypatch.setattr(
         tsr_recipes,
         "_load_cached_landscape_unit_partition_records",
@@ -590,7 +626,8 @@ def test_run_tsr_thlb_locked_parent_step_preserves_lu_chunk_cache_records(
         updated["thlb_fact"] = updated["thlb_fact"] * 0.8
         removed_area_ha = float(
             checkpoint.geometry.area.astype(float).sum() / 10000.0
-            - (updated.geometry.area.astype(float) * updated["thlb_fact"]).sum() / 10000.0
+            - (updated.geometry.area.astype(float) * updated["thlb_fact"]).sum()
+            / 10000.0
         )
         return updated, {
             "step_id": "thlb_parent_002_compiled_01",
@@ -599,7 +636,8 @@ def test_run_tsr_thlb_locked_parent_step_preserves_lu_chunk_cache_records(
             "removed_area_ha": removed_area_ha,
             "net_removed_area_ha": removed_area_ha,
             "remaining_area_ha": float(
-                (updated.geometry.area.astype(float) * updated["thlb_fact"]).sum() / 10000.0
+                (updated.geometry.area.astype(float) * updated["thlb_fact"]).sum()
+                / 10000.0
             ),
             "runtime_notes": ["bounded locked step"],
         }
@@ -1158,9 +1196,7 @@ def test_locked_parent_step_source_preflight_auto_materializes_annex_stub(
                 ),
                 "label": "Growth and yield permanent sample plots",
                 "compiled_operation_type": "select_spatial_intersect",
-                "linked_source_entry_ids": [
-                    "whse_forest_vegetation_gry_psp_status"
-                ],
+                "linked_source_entry_ids": ["whse_forest_vegetation_gry_psp_status"],
             },
         ),
         source_entry_map=source_entry_map,
@@ -12235,8 +12271,8 @@ def test_load_highway_97_geometry_uses_annex_payload_path(
 
     monkeypatch.setattr(tsr_step13_attributes.gpd, "read_file", _fake_read_file)
 
-    resolved_artifact_path, highway_line = tsr_step13_attributes._load_highway_97_geometry(
-        instance_root=instance_root
+    resolved_artifact_path, highway_line = (
+        tsr_step13_attributes._load_highway_97_geometry(instance_root=instance_root)
     )
 
     assert resolved_artifact_path == payload_path
@@ -12753,12 +12789,10 @@ def test_write_yield_bridge_tipsy_handoff_artifacts_writes_excel_and_csv_inputs(
         _fake_build_tipsy_input_table,
     )
 
-    excel_path, btc_path = (
-        tsr_recipes._write_yield_bridge_tipsy_handoff_artifacts(
-            instance_root=instance_root,
-            tsa="29",
-            au_checkpoint=au_checkpoint,
-        )
+    excel_path, btc_path = tsr_recipes._write_yield_bridge_tipsy_handoff_artifacts(
+        instance_root=instance_root,
+        tsa="29",
+        au_checkpoint=au_checkpoint,
     )
 
     assert excel_path.is_file()

--- a/tests/test_tsr_recipes.py
+++ b/tests/test_tsr_recipes.py
@@ -38,13 +38,14 @@ def test_load_checkpoint_geodataframe_reads_explicit_feather(tmp_path: Path) -> 
     assert len(loaded) == 1
     assert loaded.crs is not None
     assert loaded.crs.to_epsg() == 3005
-    assert loaded.loc[0, "feature_id"] == 1
+    assert "feature_id" not in loaded.columns
+    assert loaded.loc[0, "FEATURE_ID"] == 1
 
 
 def test_load_checkpoint_geodataframe_reads_explicit_geopackage(tmp_path: Path) -> None:
     checkpoint_path = tmp_path / "checkpoint.gpkg"
     gdf = gpd.GeoDataFrame(
-        {"feature_id": [7], "area_ha_calc": [2.0]},
+        {"feature_id": [7], "map_id": ["092L000"], "area_ha_calc": [2.0]},
         geometry=[box(-123.0, 49.0, -122.9, 49.1)],
         crs="EPSG:4326",
     )
@@ -55,7 +56,86 @@ def test_load_checkpoint_geodataframe_reads_explicit_geopackage(tmp_path: Path) 
     assert len(loaded) == 1
     assert loaded.crs is not None
     assert loaded.crs.to_epsg() == 3005
-    assert loaded.loc[0, "feature_id"] == 7
+    assert "feature_id" not in loaded.columns
+    assert "map_id" not in loaded.columns
+    assert loaded.loc[0, "FEATURE_ID"] == 7
+    assert loaded.loc[0, "MAP_ID"] == "092L000"
+
+
+def test_blank_optional_recipe_paths_do_not_resolve_to_instance_root(
+    tmp_path: Path,
+) -> None:
+    assert (
+        tsr_recipes._resolve_optional_instance_path(instance_root=tmp_path, value="")
+        is None
+    )
+    assert tsr_recipes._load_override_map(None) == {}
+    assert tsr_recipes._load_overlay_attempt_map(None) == {}
+
+
+def test_legacy_reference_managed_area_is_optional_without_legacy_checkpoints(
+    tmp_path: Path,
+) -> None:
+    checkpoint_path = tmp_path / "data" / "input" / "checkpoint.gpkg"
+
+    assert (
+        tsr_recipes._compute_legacy_reference_managed_area_ha(
+            instance_root=tmp_path,
+            checkpoint_path=checkpoint_path,
+        )
+        is None
+    )
+
+
+def test_find_landscape_unit_layer_path_uses_source_layer_recipe(
+    tmp_path: Path,
+) -> None:
+    lu_path = tmp_path / "data" / "source" / "strata" / "landscape_units.gpkg"
+    lu_path.parent.mkdir(parents=True)
+    lu_path.write_bytes(b"placeholder")
+    recipe_path = tmp_path / "config" / "tsr" / "source_layers.recipe.yaml"
+    recipe_path.parent.mkdir(parents=True)
+    recipe_path.write_text(
+        """
+entries:
+  - entry_id: landscape_units_tfl6
+    label: Landscape units clipped to TFL 6
+    artifact_path: data/source/strata/landscape_units.gpkg
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    assert tsr_recipes._find_landscape_unit_layer_path(tmp_path) == lu_path.resolve()
+
+
+def test_recipe_steps_require_lhlb_curve_ready_only_for_curve_bridge_steps() -> None:
+    assert not tsr_recipes._recipe_steps_require_lhlb_curve_ready(
+        (
+            {
+                "step_id": "tfl6_nd_180_stand_level_retention",
+                "compiled_operation_type": "aspatial_reduction",
+                "checkpoint_attribute_filters": [],
+            },
+        )
+    )
+    assert tsr_recipes._recipe_steps_require_lhlb_curve_ready(
+        (
+            {
+                "step_id": "tsa29_low_productivity",
+                "compiled_operation_type": "curve_volume_threshold_exclusion",
+            },
+        )
+    )
+    assert tsr_recipes._recipe_steps_require_lhlb_curve_ready(
+        (
+            {
+                "step_id": "tsa29_steep_slope",
+                "checkpoint_attribute_filters": [
+                    {"field": "femic_step13_steep_slope_flag", "operator": "eq"}
+                ],
+            },
+        )
+    )
 
 
 def _write_registry(tmp_path: Path) -> Path:
@@ -6352,6 +6432,66 @@ def test_apply_checkpoint_attribute_filters_preserves_fractional_state_on_remain
     assert removed_area_ha == pytest.approx(1.0)
     assert updated["thlb_fact"].tolist() == pytest.approx([0.35, 0.8])
     assert updated["thlb"].tolist() == [0, 1]
+
+
+def test_apply_checkpoint_attribute_filters_supports_in_or_null_values() -> None:
+    checkpoint = gpd.GeoDataFrame(
+        {
+            "FEATURE_ID": [1, 2, 3],
+            "BCLCS_LEVEL_2": ["N", None, "T"],
+            "thlb_fact": [1.0, 1.0, 1.0],
+            "thlb": [1, 1, 1],
+        },
+        geometry=[box(0, 0, 100, 100), box(110, 0, 210, 100), box(220, 0, 320, 100)],
+        crs="EPSG:3005",
+    )
+    checkpoint = tsr_recipes._assign_fragment_feature_ids(checkpoint)
+
+    updated, removed_area_ha = tsr_recipes._apply_checkpoint_attribute_filters(
+        checkpoint,
+        filters=[
+            {
+                "field": "BCLCS_LEVEL_2",
+                "operator": "in_or_null",
+                "values": ["N", "W"],
+            }
+        ],
+        mode="any",
+        preserve_geometry=True,
+    )
+
+    assert removed_area_ha == pytest.approx(2.0)
+    assert updated["thlb_fact"].tolist() == pytest.approx([0.0, 0.0, 1.0])
+    assert updated["thlb"].tolist() == [0, 0, 1]
+
+
+def test_apply_checkpoint_attribute_filters_supports_readable_aliases() -> None:
+    checkpoint = gpd.GeoDataFrame(
+        {
+            "FEATURE_ID": [1, 2, 3],
+            "NON_PRODUCTIVE_CD": ["X", None, None],
+            "SITE_INDEX": [4.0, 7.0, 3.0],
+            "thlb_fact": [1.0, 1.0, 1.0],
+            "thlb": [1, 1, 1],
+        },
+        geometry=[box(0, 0, 100, 100), box(110, 0, 210, 100), box(220, 0, 320, 100)],
+        crs="EPSG:3005",
+    )
+    checkpoint = tsr_recipes._assign_fragment_feature_ids(checkpoint)
+
+    updated, removed_area_ha = tsr_recipes._apply_checkpoint_attribute_filters(
+        checkpoint,
+        filters=[
+            {"field": "NON_PRODUCTIVE_CD", "operator": "is_not_null"},
+            {"field": "SITE_INDEX", "operator": "less_than", "value": 5},
+        ],
+        mode="any",
+        preserve_geometry=True,
+    )
+
+    assert removed_area_ha == pytest.approx(2.0)
+    assert updated["thlb_fact"].tolist() == pytest.approx([0.0, 1.0, 0.0])
+    assert updated["thlb"].tolist() == [0, 1, 0]
 
 
 def test_run_tsr_thlb_parent_step_preserves_geometry_for_later_stage_spatial_exclusion(


### PR DESCRIPTION
﻿## Summary

Publishes the parent FEMIC docs pointer for the TFL 6 teaching instance.

This PR:
- adds `docs/sample-models/tfl6.rst`;
- wires TFL 6 into the parent `docs/sample-models/index.rst` toctree;
- records Phase 77 / P77.1 in `ROADMAP.md` under FEMIC issue #204;
- updates `CHANGE_LOG.md`; and
- keeps detailed TFL 6 documentation in `external/femic-tfl6-instance/docs` as the canonical source of truth.

## Validation

- `git diff --check`
- `sphinx-build -b html docs _build/html -W`

## Boundaries

- No TFL 6 Phase 4 model-input work.
- No Patchworks runtime package work.
- No public-data materialization changes committed.
