### PR TITLE
P81: Deploy FreshForge workflow planning to MKRF

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18620,3 +18620,20 @@
 - created MKRF instance branch `feature/freshforge-mkrf-rebuild-workflow`; and
 - recorded the Phase 81 boundary: MKRF owns the concrete FreshForge workflow
   document while FEMIC core keeps only the reusable non-executing provider.
+
+## 2026-06-30 - Implemented MKRF FreshForge workflow deployment
+
+- added an instance-owned MKRF FreshForge workflow at
+  `external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`;
+- documented FreshForge validate/inspect/plan usage in the MKRF README, docs,
+  and rebuild runbook while preserving `femic instance rebuild` as the
+  execution surface;
+- used the current canonical MKRF Patchworks runtime config
+  `config/patchworks.runtime.mkrf_rebuild.windows.yaml` rather than the retained
+  PoC `config/patchworks.runtime.windows.yaml` surface;
+- added a parent FreshForge integration test that validates and plans the MKRF
+  workflow when the submodule is present; and
+- verified FreshForge CLI checks from the MKRF instance, FEMIC rebuild-spec
+  validation and dry-run, MKRF docs, parent Ruff/targeted mypy/tests/docs,
+  package build, `twine check`, pre-commit, wheel entry-point metadata, and the
+  MKRF annex publication audit.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18609,3 +18609,14 @@
   direct sdist/wheel metadata inspection; and
 - verified PR `#226` docs and package-release checks passed on the corrected
   branch.
+
+## 2026-06-30 - Opened MKRF FreshForge workflow deployment lane
+
+- opened parent FEMIC issue `#227` and MKRF instance issue
+  `UBC-FRESH/femic-mkrf-instance#35` for the first concrete instance-owned
+  FreshForge workflow deployment;
+- created parent branch `feature/p81-mkrf-freshforge-workflow` stacked on the
+  P80 provider branch;
+- created MKRF instance branch `feature/freshforge-mkrf-rebuild-workflow`; and
+- recorded the Phase 81 boundary: MKRF owns the concrete FreshForge workflow
+  document while FEMIC core keeps only the reusable non-executing provider.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2274,32 +2274,32 @@ workflow passed on the feature branch.
 
 ## Phase 81: MKRF FreshForge Workflow Deployment (`#227`)
 
-- [ ] P81.1 Add MKRF instance-owned FreshForge workflow contract
+- [x] P81.1 Add MKRF instance-owned FreshForge workflow contract
   (`UBC-FRESH/femic-mkrf-instance#35`).
-  - [ ] P81.1a Create the MKRF feature branch and workflow directory.
-  - [ ] P81.1b Add `workflows/freshforge/mkrf_model_build_workflow.yaml`
+  - [x] P81.1a Create the MKRF feature branch and workflow directory.
+  - [x] P81.1b Add `workflows/freshforge/mkrf_model_build_workflow.yaml`
     using reusable `femic.*` provider references.
-  - [ ] P81.1c Encode validate-case through matrix-build graph order with
+  - [x] P81.1c Encode validate-case through matrix-build graph order with
     MKRF-owned parameters and artifact declarations only.
-- [ ] P81.2 Document MKRF FreshForge planning boundary
+- [x] P81.2 Document MKRF FreshForge planning boundary
   (`UBC-FRESH/femic-mkrf-instance#35`).
-  - [ ] P81.2a Add FreshForge validate/inspect/plan commands to MKRF docs and
+  - [x] P81.2a Add FreshForge validate/inspect/plan commands to MKRF docs and
     runbook surfaces.
-  - [ ] P81.2b Preserve `femic instance rebuild` as the execution surface and
+  - [x] P81.2b Preserve `femic instance rebuild` as the execution surface and
     state that FreshForge does not run FEMIC, BTC, Patchworks, DataLad, or
     artifact materialization.
-- [ ] P81.3 Add parent integration checks for the MKRF workflow (`#227`).
-  - [ ] P81.3a Add focused parent test coverage that loads the MKRF workflow
+- [x] P81.3 Add parent integration checks for the MKRF workflow (`#227`).
+  - [x] P81.3a Add focused parent test coverage that loads the MKRF workflow
     artifact when the submodule is present.
-  - [ ] P81.3b Validate and plan the MKRF graph with the existing generic
+  - [x] P81.3b Validate and plan the MKRF graph with the existing generic
     `femic.freshforge` provider.
 - [ ] P81.4 Verify and publish the MKRF FreshForge workflow deployment
   (`#227`, `UBC-FRESH/femic-mkrf-instance#35`).
-  - [ ] P81.4a Run FreshForge CLI validate/inspect/plan from the MKRF instance.
-  - [ ] P81.4b Run FEMIC rebuild-spec validation and dry-run execution
+  - [x] P81.4a Run FreshForge CLI validate/inspect/plan from the MKRF instance.
+  - [x] P81.4b Run FEMIC rebuild-spec validation and dry-run execution
     surfaces.
-  - [ ] P81.4c Run docs/package checks and artifact metadata inspection.
-  - [ ] P81.4d Audit MKRF annex publication state with
+  - [x] P81.4c Run docs/package checks and artifact metadata inspection.
+  - [x] P81.4d Audit MKRF annex publication state with
     `git annex find --not --in arbutus-s3`.
   - [ ] P81.4e Open PRs, sync issue comments, and update the parent submodule
     pointer.
@@ -2307,7 +2307,24 @@ workflow passed on the feature branch.
 Phase 81 depends on the P80 provider branch/PR because the MKRF workflow uses
 the generic `femic.freshforge` provider entry point. MKRF owns the concrete
 workflow document; FEMIC core must not add MKRF-specific workflow builder
-functions.
+functions. The workflow uses
+`config/patchworks.runtime.mkrf_rebuild.windows.yaml`, the current canonical
+MKRF Patchworks runtime config, rather than the retained PoC
+`config/patchworks.runtime.windows.yaml` surface.
+
+Phase 81 focused verification passed with:
+
+- `freshforge providers --json` from `external/femic-mkrf-instance`;
+- `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml --json`;
+- `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml --json`;
+- `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml --json`;
+- `femic instance validate-spec --spec config/rebuild.spec.yaml`;
+- `femic instance rebuild --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_freshforge_plan`;
+- `git annex find --not --in arbutus-s3` from the MKRF instance, which returned
+  no unpublished annex keys;
+- MKRF Sphinx docs build with `-W`;
+- parent Ruff, targeted mypy, FreshForge tests, parent Sphinx docs, package
+  build, `twine check`, pre-commit, and wheel entry-point inspection.
 
 ### Detailed Next Steps Notes
 
@@ -2338,7 +2355,9 @@ functions.
     branch `feature/freshforge-mkrf-rebuild-workflow` will add
     `workflows/freshforge/mkrf_model_build_workflow.yaml`, docs/runbook
     guidance, and validation evidence while leaving actual execution with
-    `femic instance rebuild`.
+    `femic instance rebuild`. Implementation and focused local validation are
+    complete; the remaining edge is PR publication/merge sequencing and parent
+    submodule pointer closeout.
   - `P79` / `#211` is planned: FEMIC will grow reusable open LiDAR
     acquisition, terrain-raster, slope, and terrain-derived hydrography
     workflows. The immediate TFL 6 instance uses a public DEM steep-slope

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2272,6 +2272,43 @@ post-TIPSY, and WS3 smoke surfaces; the new FreshForge integration tests pass.
 PR `#226` is open and its `docs-pages` build and `package-release-checks`
 workflow passed on the feature branch.
 
+## Phase 81: MKRF FreshForge Workflow Deployment (`#227`)
+
+- [ ] P81.1 Add MKRF instance-owned FreshForge workflow contract
+  (`UBC-FRESH/femic-mkrf-instance#35`).
+  - [ ] P81.1a Create the MKRF feature branch and workflow directory.
+  - [ ] P81.1b Add `workflows/freshforge/mkrf_model_build_workflow.yaml`
+    using reusable `femic.*` provider references.
+  - [ ] P81.1c Encode validate-case through matrix-build graph order with
+    MKRF-owned parameters and artifact declarations only.
+- [ ] P81.2 Document MKRF FreshForge planning boundary
+  (`UBC-FRESH/femic-mkrf-instance#35`).
+  - [ ] P81.2a Add FreshForge validate/inspect/plan commands to MKRF docs and
+    runbook surfaces.
+  - [ ] P81.2b Preserve `femic instance rebuild` as the execution surface and
+    state that FreshForge does not run FEMIC, BTC, Patchworks, DataLad, or
+    artifact materialization.
+- [ ] P81.3 Add parent integration checks for the MKRF workflow (`#227`).
+  - [ ] P81.3a Add focused parent test coverage that loads the MKRF workflow
+    artifact when the submodule is present.
+  - [ ] P81.3b Validate and plan the MKRF graph with the existing generic
+    `femic.freshforge` provider.
+- [ ] P81.4 Verify and publish the MKRF FreshForge workflow deployment
+  (`#227`, `UBC-FRESH/femic-mkrf-instance#35`).
+  - [ ] P81.4a Run FreshForge CLI validate/inspect/plan from the MKRF instance.
+  - [ ] P81.4b Run FEMIC rebuild-spec validation and dry-run execution
+    surfaces.
+  - [ ] P81.4c Run docs/package checks and artifact metadata inspection.
+  - [ ] P81.4d Audit MKRF annex publication state with
+    `git annex find --not --in arbutus-s3`.
+  - [ ] P81.4e Open PRs, sync issue comments, and update the parent submodule
+    pointer.
+
+Phase 81 depends on the P80 provider branch/PR because the MKRF workflow uses
+the generic `femic.freshforge` provider entry point. MKRF owns the concrete
+workflow document; FEMIC core must not add MKRF-specific workflow builder
+functions.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2296,6 +2333,12 @@ workflow passed on the feature branch.
     remaining edge is merge/closeout after deciding how to handle existing
     full-repo `mypy src` and `pytest` failures that are outside the new
     integration.
+  - `P81` / `#227` is active: deploy the P80 FreshForge provider against the
+    MKRF instance as the first real instance-owned workflow contract. The MKRF
+    branch `feature/freshforge-mkrf-rebuild-workflow` will add
+    `workflows/freshforge/mkrf_model_build_workflow.yaml`, docs/runbook
+    guidance, and validation evidence while leaving actual execution with
+    `femic instance rebuild`.
   - `P79` / `#211` is planned: FEMIC will grow reusable open LiDAR
     acquisition, terrain-raster, slope, and terrain-derived hydrography
     workflows. The immediate TFL 6 instance uses a public DEM steep-slope

--- a/docs/sample-models/mkrf.rst
+++ b/docs/sample-models/mkrf.rst
@@ -131,6 +131,8 @@ FEMIC-Local Integration Notes
 
 - MKRF instance runtime root in this repository:
   ``external/femic-mkrf-instance``
+- FreshForge workflow contract:
+  ``external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
 - Current canonical rebuild runtime package path:
   ``external/femic-mkrf-instance/models/mkrf_patchworks_model``
 - Retained PoC benchmark package path:

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -17,6 +17,9 @@ freshforge = pytest.importorskip("freshforge")
 
 
 EXAMPLE_PATH = Path("examples/freshforge/model_build_workflow.yaml")
+MKRF_WORKFLOW_PATH = Path(
+    "external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml"
+)
 EXPECTED_MODEL_BUILD_ORDER = [
     "validate_case",
     "geospatial_preflight",
@@ -235,3 +238,33 @@ def test_default_freshforge_registry_discovers_installed_femic_provider() -> Non
 
     assert not diagnostics
     assert registry.get("femic") is not None
+
+
+def test_mkrf_instance_workflow_validates_and_plans_when_available() -> None:
+    if not MKRF_WORKFLOW_PATH.exists():
+        pytest.skip("MKRF instance FreshForge workflow is not available")
+
+    from freshforge.loading import load_workflow
+    from freshforge.planning import create_run_plan
+    from freshforge.validation import validate_workflow_with_providers
+
+    spec, load_diagnostics = load_workflow(MKRF_WORKFLOW_PATH)
+    assert spec is not None
+    assert load_diagnostics == []
+    assert spec.id == "mkrf_model_build"
+
+    diagnostics = validate_workflow_with_providers(
+        spec,
+        registry=_registry_with_femic_provider(),
+        structural_diagnostics=load_diagnostics,
+    )
+    assert diagnostics == []
+
+    plan = create_run_plan(
+        spec,
+        diagnostics=diagnostics,
+        registry=_registry_with_femic_provider(),
+    )
+    assert not plan.has_errors
+    assert [node.id for node in plan.nodes] == EXPECTED_MODEL_BUILD_ORDER
+    assert {node.provider_id for node in plan.nodes} == {"femic"}


### PR DESCRIPTION
## Summary
- Deploy the P80 FEMIC FreshForge provider against the MKRF instance as the first concrete instance-owned workflow contract.
- Advance the MKRF submodule to UBC-FRESH/femic-mkrf-instance#36, which adds `workflows/freshforge/mkrf_model_build_workflow.yaml` and MKRF docs/runbook guidance.
- Add a parent FreshForge integration test that validates and plans the MKRF workflow when the submodule is present.
- Keep `femic.freshforge` generic and non-executing; no MKRF-specific workflow builders are added to FEMIC core.

## Validation
Passed locally:
- `freshforge providers --json` from `external/femic-mkrf-instance`
- `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `femic instance validate-spec --spec config/rebuild.spec.yaml`
- `femic instance rebuild --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_freshforge_plan`
- `git annex find --not --in arbutus-s3` returned no unpublished annex keys
- MKRF docs: `sphinx-build -b html docs docs/_build/html -W`
- parent: `ruff format src tests`
- parent: `ruff check src tests`
- parent: `mypy src/femic/freshforge.py`
- parent: `pytest tests/test_freshforge_integration.py`
- parent: `pytest tests/test_freshforge_integration.py tests/test_docs_contract.py::test_guides_pages_are_in_docs_tree`
- parent: `sphinx-build -b html docs _build/html -W`
- parent: `python -m build`
- parent: `twine check dist/*`
- parent: `pre-commit run --all-files`
- wheel metadata includes `[freshforge.providers] femic = femic.freshforge:provider_factory`

## Notes
- This PR is stacked on P80 / PR #226 because the MKRF workflow depends on the generic `femic` FreshForge provider.
- The MKRF workflow uses `config/patchworks.runtime.mkrf_rebuild.windows.yaml`, the current canonical MKRF runtime config, rather than the retained PoC `config/patchworks.runtime.windows.yaml` surface.
- Full parent `mypy src` and full `pytest` remain governed by the existing P80 baseline note; this branch adds focused passing coverage for the new MKRF workflow.

Closes #227