### PR TITLE
P83: Remove tracked TSA29 runtime artifacts

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18667,3 +18667,17 @@
   missing locally; and
 - updated the parent FEMIC submodule pointer to the repaired TFL6 `main`
   commit `60f696d`.
+
+## 2026-06-30 - Removed tracked TSA29 runtime artifacts
+
+- opened parent issue `#232` and TSA29 instance issue
+  `UBC-FRESH/femic-tsa29-instance#13` for runtime tracking hygiene;
+- updated the TSA29 instance so `runtime/` is ignored broadly and 1,276
+  previously tracked `runtime/**` artifacts are removed from the Git index;
+- verified the TSA29 branch no longer tracks runtime paths and the Patchworks
+  block payload has no keys missing from `arbutus-s3`;
+- proved a fresh short-path Windows clone can check out TSA29 without tracked
+  runtime long-path failures and can materialize
+  `models/tsa29_patchworks_model/blocks` from `arbutus-s3`; and
+- updated the parent FEMIC submodule pointer to the cleaned TSA29 `main`
+  commit `a038a47`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2359,6 +2359,31 @@ output directories under `models/**/analysis/p*/` and
 `models/**/analysis/headless_runs/` remain local run evidence, not required
 fresh-clone model inputs.
 
+## Phase 83: TSA29 Runtime Tracking Hygiene (`#232`)
+
+- [x] P83.1 Remove tracked TSA29 `runtime/**` artifacts
+  (`UBC-FRESH/femic-tsa29-instance#13`).
+  - [x] P83.1a Add a broad TSA29 `runtime/` ignore rule.
+  - [x] P83.1b Remove all tracked TSA29 `runtime/**` files from the Git index
+    without deleting local working-tree copies.
+  - [x] P83.1c Verify `git ls-files runtime` is empty in the TSA29 instance.
+- [x] P83.2 Verify TSA29 clone and model materialization.
+  - [x] P83.2a Verify the Patchworks block payload remains present on
+    `arbutus-s3`.
+  - [x] P83.2b Prove a fresh short-path Windows clone can check out TSA29
+    without tracked `runtime/**` long-path failures.
+  - [x] P83.2c Prove `datalad get -r models/tsa29_patchworks_model/blocks`
+    materializes a valid polygon shapefile.
+- [x] P83.3 Update parent pointer and close out.
+  - [x] P83.3a Update `external/femic-tsa29-instance` to the cleaned TSA29
+    commit.
+  - [x] P83.3b Record verification in parent and instance changelogs.
+  - [x] P83.3c Push branches, open PRs, and synchronize GitHub issue status.
+
+Phase 83 treats TSA29 `runtime/` as local/generated only, matching MKRF and
+TFL6. Curated evidence that needs to remain durable must live outside
+`runtime/` in explicit evidence, docs, config, planning, or release surfaces.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2370,6 +2395,11 @@ fresh-clone model inputs.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P83` / `#232` is complete pending parent PR merge: tracked TSA29
+    `runtime/**` artifacts were removed from the instance Git index, the
+    cleaned TSA29 PR was merged, and a fresh short-path Windows clone
+    materialized `models/tsa29_patchworks_model/blocks` from `arbutus-s3` with
+    a valid polygon shapefile header.
   - `P82` / `#230` is active: expanded TFL6 Patchworks runtime model
     directories, excluding scenario/run outputs under `analysis/`, must become
     tracked, public-annexed instance payloads so recursive DataLad


### PR DESCRIPTION
﻿## Summary

Updates the parent FEMIC repo to point at the cleaned TSA29 instance commit from UBC-FRESH/femic-tsa29-instance#14.

## Changes

- records P83 runtime hygiene closeout in `ROADMAP.md` and `CHANGE_LOG.md`;
- updates `external/femic-tsa29-instance` to merged TSA29 `main` commit `a038a47`;
- leaves `external/femic-public-data` unrelated local dirt untouched.

## Verification

TSA29 instance PR #14 passed docs build and was squash-merged to `main`.

Instance verification completed before this pointer update:

- `git ls-files runtime` returns no tracked paths;
- `git status --ignored runtime` reports `runtime/` as ignored;
- `git annex find models/tsa29_patchworks_model/blocks --not --in arbutus-s3` returns no missing block payload keys;
- a fresh short-path Windows clone checked out without tracked `runtime/**` long-path failures;
- from that fresh clone, `datalad get -r models/tsa29_patchworks_model/blocks` fetched `blocks.dbf`, `blocks.shp`, and `blocks.shx` from `arbutus-s3`;
- fetched `blocks.shp` header is valid for Patchworks: file code `9994`, shape type `5`, size `583443688` bytes.

Closes #232.
