### PR TITLE
P84: FreshForge execution hooks for MKRF

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18681,3 +18681,38 @@
   `models/tsa29_patchworks_model/blocks` from `arbutus-s3`; and
 - updated the parent FEMIC submodule pointer to the cleaned TSA29 `main`
   commit `a038a47`.
+
+## 2026-06-30 - Opened FreshForge execution phase for MKRF
+
+- opened FEMIC issue `#234` with child issues `#235` through `#239` for
+  executable FreshForge provider hooks, the MKRF provider namespace, the MKRF
+  executable workflow/docs, validation, and closeout;
+- opened MKRF instance issue `UBC-FRESH/femic-mkrf-instance#37` for the
+  instance-owned workflow and documentation updates;
+- created parent branch `feature/p84-freshforge-execution-mkrf` and MKRF branch
+  `feature/freshforge-executable-workflow`; and
+- recorded the execution/materialization boundary: Phase 84 proves explicit
+  `freshforge run` execution for MKRF model rebuilding, while deterministic
+  model-instance materialization remains the next separate workflow family.
+
+## 2026-06-30 - Implemented FreshForge execution hooks and MKRF graph
+
+- extended `femic.freshforge` with lazy provider execution hooks backed by
+  `sys.executable -m femic` commands while preserving non-mutating validation,
+  inspection, and planning behavior;
+- added the `femic.mkrf` provider namespace and entry point for MKRF-owned
+  runtime-package regeneration commands;
+- updated the MKRF FreshForge workflow to an executable, source-aware graph that
+  validates the rebuild spec, runs geospatial preflight, regenerates MKRF AU and
+  managed-curve inputs, initializes the runtime package, preflights Patchworks,
+  and invokes Matrix Builder;
+- updated FEMIC and MKRF docs/runbooks to distinguish non-mutating
+  validate/inspect/plan from explicit `freshforge run` execution, and to keep
+  model-instance materialization as the next separate workflow family;
+- verified provider discovery, MKRF workflow validation/planning/dry-run,
+  focused provider tests, `ruff check src tests`, targeted mypy, warning-clean
+  Sphinx docs, package build, and `twine check`; and
+- attempted full MKRF execution locally. The workflow regenerated MKRF
+  model-input/runtime package surfaces and reached Patchworks Matrix Builder,
+  but Matrix Builder did not complete because local Patchworks stderr reported
+  `No matching license`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18716,3 +18716,27 @@
   model-input/runtime package surfaces and reached Patchworks Matrix Builder,
   but Matrix Builder did not complete because local Patchworks stderr reported
   `No matching license`.
+
+## 2026-07-01 - Restored FEMIC/MKRF FreshForge provider boundary
+
+- opened FEMIC issue `#241` and MKRF issue
+  `UBC-FRESH/femic-mkrf-instance#39` for the P85 namespace repair;
+- removed the MKRF-specific FreshForge provider id, factory, metadata, command
+  builders, and entry point from `femic.freshforge`, leaving FEMIC core with the
+  reusable executable `femic` provider only;
+- added an instance-owned MKRF adapter package in the MKRF repository that
+  exposes provider id `mkrf` through `freshforge.providers` and delegates
+  execution to existing `python -m femic instance mkrf-*` compatibility
+  commands;
+- updated the MKRF FreshForge workflow from `femic.mkrf.*` provider references
+  to `mkrf.*` and documented the adapter installation/ownership boundary in
+  parent and MKRF docs;
+- recorded Phase 86 as the follow-on lane for moving mature MKRF-specific
+  workflow and pipeline code out of FEMIC core after the adapter boundary is
+  reviewed; and
+- verified focused parent and MKRF adapter Ruff, pytest, targeted mypy, parent
+  and MKRF Sphinx builds, FreshForge CLI provider discovery/validate/inspect/
+  plan/dry-run, package builds, `twine check`, and wheel entry-point metadata;
+  and
+- opened MKRF PR `UBC-FRESH/femic-mkrf-instance#40` and parent FEMIC PR `#242`
+  for review.

--- a/README.md
+++ b/README.md
@@ -74,19 +74,22 @@ femic prep validate-case --instance-root external/femic-k3z-instance --run-confi
 femic prep geospatial-preflight
 ```
 
-FreshForge can inspect plan-only FEMIC model-build graphs when FEMIC is
-installed with the optional integration. FEMIC core ships a generic provider
-example; concrete K3Z or other instance workflow documents belong in the
-corresponding instance repositories.
+FreshForge can inspect, plan, and explicitly run provider-backed FEMIC
+model-build graphs when FEMIC is installed with the optional integration. FEMIC
+core ships a generic provider example; concrete K3Z, MKRF, or other instance
+workflow documents belong in the corresponding instance repositories.
 
 ```bash
 freshforge providers
 freshforge validate examples/freshforge/model_build_workflow.yaml
 freshforge plan examples/freshforge/model_build_workflow.yaml
+freshforge run examples/freshforge/model_build_workflow.yaml --run-id smoke --dry-run
 ```
 
-FreshForge validation and planning do not run FEMIC stages, launch BTC,
-launch Patchworks, read declared artifacts, or replace `femic instance rebuild`.
+FreshForge validation, inspection, and planning are non-mutating. `freshforge
+run` launches provider-owned FEMIC commands only when called explicitly. It does
+not materialize DataLad content, read declared artifacts, or replace
+`femic instance rebuild`.
 
 If `git annex version` fails, install `git-annex` at the OS level and re-open
 the shell before retrying.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2384,6 +2384,60 @@ Phase 83 treats TSA29 `runtime/` as local/generated only, matching MKRF and
 TFL6. Curated evidence that needs to remain durable must live outside
 `runtime/` in explicit evidence, docs, config, planning, or release surfaces.
 
+## Phase 84: FreshForge Execution For MKRF Workflows
+
+Parent issue: #234
+
+Branch: `feature/p84-freshforge-execution-mkrf`
+
+Status: active
+
+Goal: consume FreshForge Phase 6 execution support from FEMIC and MKRF so the
+MKRF FreshForge workflow can explicitly run the canonical rebuild lane through
+runtime-package regeneration and Patchworks Matrix Builder.
+
+- [x] P84.1 Add executable FEMIC provider hooks (#235)
+  - [x] Keep `femic.freshforge` lazy-import safe.
+  - [x] Preserve validation, inspection, and planning behavior for existing
+        provider references.
+  - [x] Map generic FEMIC node types to existing `python -m femic ...`
+        commands.
+  - [x] Add command construction and mocked execution tests.
+- [x] P84.2 Add MKRF executable provider namespace (#236)
+  - [x] Add `femic.mkrf.*` metadata for MKRF runtime-package regeneration
+        commands.
+  - [x] Add provider validation for required broad parameters such as
+        `instance_root`, `resultant_gdb`, and `run_id`.
+  - [x] Register the MKRF provider through the `freshforge.providers` entry
+        point without adding instance-specific workflow builders to FEMIC core.
+- [x] P84.3 Update MKRF executable workflow and docs (#237;
+       MKRF issue UBC-FRESH/femic-mkrf-instance#37)
+  - [x] Replace the plan-only MKRF workflow with an explicit executable graph.
+  - [x] Use the accepted MKRF source input, run config, Patchworks config, and
+        model package paths.
+  - [x] Update MKRF README/docs/runbook language from plan-only to explicit
+        `freshforge run` execution.
+- [ ] P84.4 Validate MKRF FreshForge execution cycle (#238)
+  - [x] Verify providers, validate, inspect, plan, and dry-run output.
+  - [x] Attempt full local execution through Matrix Builder.
+  - [ ] Resolve local Patchworks license blocker and rerun Matrix Builder to
+        completion.
+  - [x] Inspect produced run reports, FEMIC logs, regenerated model-input
+        bundle files, and ForestModel XML.
+  - [ ] Inspect Matrix Builder manifest after the Patchworks license blocker is
+        resolved.
+- [ ] P84.5 Close out execution integration (#239)
+  - [x] Update roadmap and changelog closeout notes.
+  - [ ] Open PRs and verify checks.
+  - [ ] Record model-instance materialization as the next separate FreshForge
+        workflow family.
+
+Phase 84 deliberately does not add model-instance materialization workflow
+support. That is the next FreshForge deployment family after executable
+workflow semantics are proven because it solves the separate user problem of
+bootstrapping Git, Python, DataLad, git-annex, special remotes, virtual
+environments, and required payload materialization before model workflows run.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2395,6 +2449,12 @@ TFL6. Curated evidence that needs to remain durable must live outside
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P84` / `#234` is active: FEMIC will consume FreshForge Phase 6 execution
+    support and MKRF owns the first executable instance workflow. Provider
+    hooks, the MKRF provider namespace, docs, validation, planning, dry-run, and
+    runtime-package regeneration are working locally. The remaining acceptance
+    blocker is Patchworks Matrix Builder licensing: the full run reaches
+    Matrix Builder, then stderr reports `No matching license`.
   - `P83` / `#232` is complete pending parent PR merge: tracked TSA29
     `runtime/**` artifacts were removed from the instance Git index, the
     cleaned TSA29 PR was merged, and a fresh short-path Windows clone
@@ -2409,12 +2469,10 @@ TFL6. Curated evidence that needs to remain durable must live outside
     a plan-only FreshForge provider. PR `#226` was squash-merged to `main`
     after focused local verification plus green docs and release-artifact
     checks.
-  - `P81` / `#227` is in final closeout: MKRF now owns the first real
-    instance-level FreshForge workflow contract at
-    `workflows/freshforge/mkrf_model_build_workflow.yaml`. MKRF PR
-    `UBC-FRESH/femic-mkrf-instance#36` was squash-merged, the parent branch has
-    been rebased onto P80 on `main`, and the remaining edge is final
-    post-rebase validation plus merge of parent PR `#228`.
+  - `P81` / `#227` is complete: MKRF owns the first real instance-level
+    FreshForge workflow contract at
+    `workflows/freshforge/mkrf_model_build_workflow.yaml`; the next evolution is
+    P84 executable orchestration.
   - `P79` / `#211` is planned: FEMIC will grow reusable open LiDAR
     acquisition, terrain-raster, slope, and terrain-derived hydrography
     workflows. The immediate TFL 6 instance uses a public DEM steep-slope

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2438,6 +2438,83 @@ workflow semantics are proven because it solves the separate user problem of
 bootstrapping Git, Python, DataLad, git-annex, special remotes, virtual
 environments, and required payload materialization before model workflows run.
 
+## Phase 85: FreshForge Instance Provider Boundary Repair
+
+Parent issue: #241
+
+Branch: `feature/p85-freshforge-instance-provider-boundary`
+
+Status: active
+
+Goal: restore the provider namespace boundary after the Phase 84 executable
+prototype put MKRF-specific FreshForge provider logic under `femic.mkrf` in
+FEMIC core. FEMIC core should expose reusable FEMIC stages through provider id
+`femic`; MKRF-specific orchestration belongs to the MKRF instance as provider
+id `mkrf`.
+
+- [x] P85.1 Remove MKRF FreshForge provider ownership from FEMIC core
+  - [x] Remove the `femic.mkrf` provider id, factory, metadata, command
+        builders, and entry point from `femic.freshforge`.
+  - [x] Keep generic executable `femic.*` stages and lazy FreshForge imports.
+  - [x] Update parent tests and docs so FEMIC core is instance-neutral.
+- [x] P85.2 Add the MKRF-owned FreshForge adapter package
+      (MKRF issue UBC-FRESH/femic-mkrf-instance#39)
+  - [x] Add a lightweight installable `mkrf_freshforge` package in the MKRF
+        instance repository.
+  - [x] Register provider id `mkrf` through the `freshforge.providers` entry
+        point.
+  - [x] Move MKRF provider metadata and command construction into the instance
+        adapter while continuing to call existing `python -m femic ...`
+        compatibility commands.
+- [x] P85.3 Update MKRF workflow and docs for `mkrf.*`
+  - [x] Rewrite MKRF workflow provider references from `femic.mkrf.*` to
+        `mkrf.*`.
+  - [x] Document adapter installation and the boundary between FEMIC core,
+        FreshForge, and instance-owned orchestration.
+- [x] P85.4 Record the broader MKRF core extraction follow-up
+  - [x] Inventory MKRF-specific core modules and `femic instance mkrf-*`
+        commands.
+  - [x] Add a follow-on phase for moving mature MKRF-specific workflow and
+        pipeline code out of FEMIC core after the adapter path is proven.
+- [x] P85.5 Verify, commit, push, and open PRs
+  - [x] Run focused parent and MKRF adapter tests.
+  - [x] Verify provider metadata no longer advertises `femic.mkrf` from FEMIC
+        and advertises `mkrf` only from the MKRF adapter.
+  - [x] Open linked parent and MKRF PRs.
+
+Phase 85 intentionally does not remove the existing `femic instance mkrf-*`
+compatibility commands. Those commands remain the execution target for the
+MKRF adapter until a separate extraction phase moves mature MKRF-specific
+scientific and workflow code into an instance-owned or companion package.
+
+## Phase 86: Extract MKRF-Specific Workflow Code From FEMIC Core
+
+Parent issue: pending
+
+Branch: pending
+
+Status: planned
+
+Goal: move mature MKRF-specific pipeline and workflow implementation out of
+FEMIC core after the P85 adapter package boundary is proven. The current
+inventory found MKRF-specific implementation surfaces in
+`src/femic/workflows/mkrf.py`, `src/femic/pipeline/mkrf_au.py`,
+`src/femic/pipeline/mkrf_first_growth.py`, `src/femic/pipeline/mkrf_managed.py`,
+and `femic instance mkrf-*` CLI commands.
+
+- [ ] P86.1 Define the extraction target and compatibility policy
+  - [ ] Decide whether mature MKRF code moves into the MKRF instance package or
+        a separately named companion package.
+  - [ ] Define temporary compatibility wrappers for existing
+        `femic instance mkrf-*` commands.
+- [ ] P86.2 Move MKRF implementation behind the chosen package boundary
+  - [ ] Preserve current tests and command behavior during the move.
+  - [ ] Keep generic FEMIC package APIs instance-neutral.
+- [ ] P86.3 Update docs, tests, packaging, and FreshForge adapter commands
+  - [ ] Point the MKRF FreshForge adapter at the extracted implementation or
+        retained compatibility commands according to the P86 policy.
+  - [ ] Remove stale FEMIC-core MKRF ownership language.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2449,6 +2526,16 @@ environments, and required payload materialization before model workflows run.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P85` / `#241` is active: restore the FreshForge provider boundary by
+    removing `femic.mkrf` from FEMIC core and moving MKRF executable provider
+    metadata and command construction into the MKRF instance as provider id
+    `mkrf`. Local verification has passed for focused Ruff, pytest, mypy,
+    Sphinx, FreshForge CLI validate/inspect/plan/dry-run, package builds,
+    `twine check`, wheel entry-point inspection, MKRF PR
+    `UBC-FRESH/femic-mkrf-instance#40`, and parent PR `#242`.
+  - `P86` is planned: broader extraction of existing MKRF-specific FEMIC
+    workflow and pipeline code should happen after the P85 adapter boundary is
+    reviewed, rather than being bundled into the namespace repair.
   - `P84` / `#234` is active: FEMIC will consume FreshForge Phase 6 execution
     support and MKRF owns the first executable instance workflow. Provider
     hooks, the MKRF provider namespace, docs, validation, planning, dry-run, and

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -4,11 +4,11 @@ FreshForge Provider Integration
 Purpose
 -------
 
-FEMIC exposes a plan-only FreshForge provider for model-build workflow stages.
-FreshForge owns declarative graph validation, provider discovery,
-inspection, and deterministic non-executing planning. FEMIC still owns actual
-execution through existing commands such as ``femic run``,
-``femic tsa btc-post-tipsy``, ``femic export patchworks``,
+FEMIC exposes FreshForge providers for model-build workflow stages. FreshForge
+owns declarative graph validation, provider discovery, inspection,
+deterministic planning, and explicit ``freshforge run`` orchestration. FEMIC
+still owns the actual stage behavior through existing commands such as
+``femic run``, ``femic tsa btc-post-tipsy``, ``femic export patchworks``,
 ``femic patchworks matrix-build``, and ``femic instance rebuild``.
 
 The provider is intentionally instance-neutral. Concrete workflow documents
@@ -29,15 +29,15 @@ through FEMIC's ``dev`` extra. For a smaller runtime install, use:
 Provider Discovery
 ------------------
 
-FEMIC registers a provider entry point in the ``freshforge.providers`` group.
+FEMIC registers provider entry points in the ``freshforge.providers`` group.
 When FEMIC is installed with the optional FreshForge dependency, FreshForge can
-discover provider id ``femic``:
+discover provider IDs ``femic`` and ``femic.mkrf``:
 
 .. code-block:: bash
 
    freshforge providers
 
-The provider references currently exposed for model-build planning are:
+The generic provider references currently exposed for model-build workflows are:
 
 - ``femic.validate_case``
 - ``femic.geospatial_preflight``
@@ -46,6 +46,15 @@ The provider references currently exposed for model-build planning are:
 - ``femic.export_patchworks``
 - ``femic.patchworks_preflight``
 - ``femic.matrix_build``
+
+The MKRF-specific provider references exposed for the first executable MKRF
+workflow are:
+
+- ``femic.mkrf.build_au_inputs``
+- ``femic.mkrf.select_aus``
+- ``femic.mkrf.build_managed_au_inputs``
+- ``femic.mkrf.build_managed_au_curves``
+- ``femic.mkrf.init_runtime_package``
 
 Generic Workflow Example
 ------------------------
@@ -63,6 +72,7 @@ Validate and plan it with:
    freshforge validate examples/freshforge/model_build_workflow.yaml
    freshforge inspect examples/freshforge/model_build_workflow.yaml
    freshforge plan examples/freshforge/model_build_workflow.yaml
+   freshforge run examples/freshforge/model_build_workflow.yaml --run-id smoke --dry-run
 
 The graph declares this order:
 
@@ -77,11 +87,11 @@ The graph declares this order:
 Relationship To FEMIC Execution
 -------------------------------
 
-FreshForge graph planning is not the same surface as FEMIC rebuild execution.
-Use the FreshForge workflow to make the model-build graph explicit and
-checkable before execution. Use ``config/rebuild.spec.yaml`` and
-``femic instance rebuild`` for the current deterministic execution and
-invariant-checking path.
+FreshForge validation, inspection, and planning are non-mutating. ``freshforge
+run`` launches provider-owned FEMIC commands in deterministic plan order only
+when called explicitly. Use ``config/rebuild.spec.yaml`` and
+``femic instance rebuild --dry-run`` as the legacy execution dry-run comparison
+surface.
 
 Named pipelines remain a narrower TSR/THLB recipe and runbook lane. The
 FreshForge integration is the cross-package workflow graph surface intended to
@@ -90,23 +100,24 @@ describe broader model-building pipelines.
 Instance Workflow Ownership
 ---------------------------
 
-``femic.freshforge`` owns only the reusable FEMIC provider vocabulary. It does
-not ship K3Z-specific workflow builders or default paths. Instance-specific
-FreshForge documents should live in the instance repository that owns the
-model-build contract. For example, a K3Z workflow document should live in the
-K3Z instance repository, while FEMIC core supplies reusable provider references
-such as ``femic.validate_case`` and ``femic.matrix_build``.
+``femic.freshforge`` owns only the reusable FEMIC provider vocabulary and
+provider execution hooks. It does not ship K3Z-specific or MKRF-specific
+workflow builders. Instance-specific FreshForge documents should live in the
+instance repository that owns the model-build contract. For example, the MKRF
+workflow document lives in the MKRF instance repository, while FEMIC core
+supplies reusable provider references such as ``femic.validate_case`` and
+``femic.matrix_build`` plus the MKRF command namespace ``femic.mkrf``.
 
 Boundaries
 ----------
 
-The FEMIC provider validates broad node shape only. It does not:
+The FEMIC providers validate broad node shape and can execute existing FEMIC CLI
+commands when ``freshforge run`` is called. They do not:
 
-- execute FreshForge nodes;
-- add ``freshforge run``;
-- launch FEMIC stage commands;
-- read model inputs or declared artifact files;
-- launch BTC or Patchworks;
+- run during ``freshforge validate``, ``inspect``, or ``plan``;
+- materialize DataLad content;
+- read model inputs or declared artifact files outside the launched FEMIC
+  command;
 - replace ``femic instance rebuild``; or
 - change FEMIC scientific stage logic.
 
@@ -114,5 +125,7 @@ API
 ---
 
 Use :func:`femic.freshforge.provider_factory` when a caller needs explicit
-registry control. Concrete workflow assembly is intentionally left to instance
-repositories or caller-owned workflow documents.
+registry control for the generic FEMIC provider. Use
+:func:`femic.freshforge.mkrf_provider_factory` for the MKRF-specific provider.
+Concrete workflow assembly is intentionally left to instance repositories or
+caller-owned workflow documents.

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -31,7 +31,7 @@ Provider Discovery
 
 FEMIC registers provider entry points in the ``freshforge.providers`` group.
 When FEMIC is installed with the optional FreshForge dependency, FreshForge can
-discover provider IDs ``femic`` and ``femic.mkrf``:
+discover provider ID ``femic``:
 
 .. code-block:: bash
 
@@ -47,14 +47,10 @@ The generic provider references currently exposed for model-build workflows are:
 - ``femic.patchworks_preflight``
 - ``femic.matrix_build``
 
-The MKRF-specific provider references exposed for the first executable MKRF
-workflow are:
-
-- ``femic.mkrf.build_au_inputs``
-- ``femic.mkrf.select_aus``
-- ``femic.mkrf.build_managed_au_inputs``
-- ``femic.mkrf.build_managed_au_curves``
-- ``femic.mkrf.init_runtime_package``
+Instance-specific provider references are not shipped by FEMIC core. For
+example, the MKRF instance owns its executable adapter package and exposes
+provider references such as ``mkrf.build_au_inputs`` only when that instance
+adapter is installed.
 
 Generic Workflow Example
 ------------------------
@@ -106,7 +102,8 @@ workflow builders. Instance-specific FreshForge documents should live in the
 instance repository that owns the model-build contract. For example, the MKRF
 workflow document lives in the MKRF instance repository, while FEMIC core
 supplies reusable provider references such as ``femic.validate_case`` and
-``femic.matrix_build`` plus the MKRF command namespace ``femic.mkrf``.
+``femic.matrix_build``. The MKRF instance supplies its own provider namespace
+``mkrf`` through its adapter package.
 
 Boundaries
 ----------
@@ -125,7 +122,6 @@ API
 ---
 
 Use :func:`femic.freshforge.provider_factory` when a caller needs explicit
-registry control for the generic FEMIC provider. Use
-:func:`femic.freshforge.mkrf_provider_factory` for the MKRF-specific provider.
-Concrete workflow assembly is intentionally left to instance repositories or
+registry control for the generic FEMIC provider. Concrete workflow assembly and
+instance-specific providers are intentionally left to instance repositories or
 caller-owned workflow documents.

--- a/docs/reference/api/femic-freshforge.rst
+++ b/docs/reference/api/femic-freshforge.rst
@@ -10,12 +10,13 @@ dependency boundary. Normal FEMIC imports do not import FreshForge eagerly.
 Responsibilities
 ----------------
 
-- expose provider IDs ``femic`` and ``femic.mkrf`` through
-  ``freshforge.providers`` entry-point discovery;
+- expose provider ID ``femic`` through ``freshforge.providers`` entry-point
+  discovery;
 - describe reusable FEMIC model-build stages as FreshForge node types;
 - validate broad node parameters, inputs, outputs, and artifact declarations;
 - execute existing FEMIC CLI commands only when ``freshforge run`` is called;
-- leave instance-specific workflow composition to instance repositories; and
+- leave instance-specific workflow composition and provider namespaces to
+  instance repositories; and
 - preserve the boundary that FreshForge validation, inspection, and planning do
   not execute FEMIC.
 

--- a/docs/reference/api/femic-freshforge.rst
+++ b/docs/reference/api/femic-freshforge.rst
@@ -10,13 +10,14 @@ dependency boundary. Normal FEMIC imports do not import FreshForge eagerly.
 Responsibilities
 ----------------
 
-- expose provider id ``femic`` through ``freshforge.providers`` entry-point
-  discovery;
-- describe reusable FEMIC model-build stages as non-executing FreshForge node
-  types;
+- expose provider IDs ``femic`` and ``femic.mkrf`` through
+  ``freshforge.providers`` entry-point discovery;
+- describe reusable FEMIC model-build stages as FreshForge node types;
 - validate broad node parameters, inputs, outputs, and artifact declarations;
+- execute existing FEMIC CLI commands only when ``freshforge run`` is called;
 - leave instance-specific workflow composition to instance repositories; and
-- preserve the boundary that FreshForge planning does not execute FEMIC.
+- preserve the boundary that FreshForge validation, inspection, and planning do
+  not execute FEMIC.
 
 API
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,14 @@ dependencies = [
 
 [project.optional-dependencies]
 freshforge = [
-    "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a1",
+    "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine",
 ]
 figures = [
     "figrecover[pdf,cv,vlm] @ git+https://github.com/UBC-FRESH/figrecover.git@v0.1.0a1",
 ]
 dev = [
     "datalad[full]",
-    "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a1",
+    "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine",
     "ipywidgets",
     "mypy",
     "pre-commit",
@@ -60,6 +60,7 @@ femic = "femic.cli.main:app"
 
 [project.entry-points."freshforge.providers"]
 femic = "femic.freshforge:provider_factory"
+femic_mkrf = "femic.freshforge:mkrf_provider_factory"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ femic = "femic.cli.main:app"
 
 [project.entry-points."freshforge.providers"]
 femic = "femic.freshforge:provider_factory"
-femic_mkrf = "femic.freshforge:mkrf_provider_factory"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/femic/freshforge.py
+++ b/src/femic/freshforge.py
@@ -1,17 +1,22 @@
 """FreshForge provider integration for FEMIC model-build workflows.
 
-This module is intentionally non-executing. It describes FEMIC workflow stages
-for FreshForge validation and planning, but it does not call FEMIC runtime
-commands, inspect artifacts, or touch model inputs.
+Validation and planning remain non-mutating. Execution is only available when a
+caller explicitly invokes ``freshforge run`` against providers from this module.
 """
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 FEMIC_PROVIDER_ID = "femic"
+FEMIC_MKRF_PROVIDER_ID = "femic.mkrf"
 FEMIC_PROVIDER_VERSION = "0.1.0a1"
+
+CommandRunner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
 
 
 @dataclass(frozen=True)
@@ -87,33 +92,70 @@ _NODE_CONTRACTS: tuple[_NodeContract, ...] = (
     ),
 )
 
+_MKRF_NODE_CONTRACTS: tuple[_NodeContract, ...] = (
+    _NodeContract(
+        id="build_au_inputs",
+        name="Build MKRF AU inputs",
+        description="Build MKRF AU and stand-assignment inputs from Resultant.gdb.",
+        outputs=("au_inputs",),
+        parameters=("instance_root", "resultant_gdb"),
+        artifacts=("au_table", "stand_assignment"),
+    ),
+    _NodeContract(
+        id="select_aus",
+        name="Select MKRF analysis units",
+        description="Publish the canonical MKRF selected AU subset.",
+        inputs=("au_inputs",),
+        outputs=("selected_aus",),
+        parameters=("instance_root",),
+        artifacts=("selected_au_table",),
+    ),
+    _NodeContract(
+        id="build_managed_au_inputs",
+        name="Build MKRF managed AU inputs",
+        description="Build managed AU bootstrap and MSYT input surfaces.",
+        inputs=("selected_aus",),
+        outputs=("managed_au_inputs",),
+        parameters=("instance_root", "resultant_gdb"),
+        artifacts=("stand_origin_assignment", "managed_au_msyt"),
+    ),
+    _NodeContract(
+        id="build_managed_au_curves",
+        name="Build MKRF managed AU curves",
+        description="Run the managed AU BTC curve-building seam.",
+        inputs=("managed_au_inputs",),
+        outputs=("managed_au_curves",),
+        parameters=("instance_root", "run_id"),
+        artifacts=("managed_au_curves", "managed_run_manifest"),
+    ),
+    _NodeContract(
+        id="init_runtime_package",
+        name="Initialize MKRF runtime package",
+        description="Initialize the canonical MKRF Patchworks runtime package.",
+        inputs=("managed_au_curves",),
+        outputs=("patchworks_package",),
+        parameters=("instance_root",),
+        artifacts=("forestmodel_xml", "runtime_manifest"),
+    ),
+)
+
 
 class FemicFreshForgeProvider:
-    """Non-executing FreshForge provider for FEMIC workflow stages."""
+    """FreshForge provider for generic FEMIC workflow stages."""
+
+    def __init__(self, command_runner: CommandRunner | None = None) -> None:
+        self._command_runner = command_runner or _default_command_runner
 
     def metadata(self) -> Any:
         """Return FreshForge provider metadata."""
-        node_type_metadata, provider_metadata = _freshforge_metadata_types()
-        return provider_metadata(
-            id=FEMIC_PROVIDER_ID,
-            version=FEMIC_PROVIDER_VERSION,
+        return _provider_metadata(
+            provider_id=FEMIC_PROVIDER_ID,
             name="FEMIC model-build provider",
             description=(
-                "Non-executing provider for FEMIC model-build workflow "
-                "validation, inspection, and planning."
+                "Provider for FEMIC model-build workflow validation, planning, "
+                "and explicit execution."
             ),
-            node_types=tuple(
-                node_type_metadata(
-                    id=contract.id,
-                    name=contract.name,
-                    description=contract.description,
-                    inputs=contract.inputs,
-                    outputs=contract.outputs,
-                    parameters=contract.parameters,
-                    artifacts=contract.artifacts,
-                )
-                for contract in _NODE_CONTRACTS
-            ),
+            contracts=_NODE_CONTRACTS,
         )
 
     def validate_node(
@@ -174,10 +216,153 @@ class FemicFreshForgeProvider:
         )
         return tuple(diagnostics)
 
+    def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
+        """Execute one generic FEMIC node through the installed FEMIC CLI."""
+        builders = _generic_command_builders()
+        return _execute_with_builder(
+            node=node,
+            node_type=node_type,
+            context=context,
+            provider_id=FEMIC_PROVIDER_ID,
+            builders=builders,
+            runner=self._command_runner,
+        )
+
+
+class FemicMkrfFreshForgeProvider:
+    """FreshForge provider for MKRF-specific runtime-package regeneration."""
+
+    def __init__(self, command_runner: CommandRunner | None = None) -> None:
+        self._command_runner = command_runner or _default_command_runner
+
+    def metadata(self) -> Any:
+        """Return FreshForge provider metadata."""
+        return _provider_metadata(
+            provider_id=FEMIC_MKRF_PROVIDER_ID,
+            name="FEMIC MKRF model-build provider",
+            description=(
+                "Provider for MKRF-specific FEMIC runtime-package regeneration "
+                "validation, planning, and explicit execution."
+            ),
+            contracts=_MKRF_NODE_CONTRACTS,
+        )
+
+    def validate_node(
+        self, node: Any, node_type: Any, *, location: str
+    ) -> tuple[Any, ...]:
+        """Validate broad MKRF node shape without executing FEMIC."""
+        return _validate_contract_node(node, node_type, location=location)
+
+    def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
+        """Execute one MKRF node through the installed FEMIC CLI."""
+        builders = _mkrf_command_builders()
+        return _execute_with_builder(
+            node=node,
+            node_type=node_type,
+            context=context,
+            provider_id=FEMIC_MKRF_PROVIDER_ID,
+            builders=builders,
+            runner=self._command_runner,
+        )
+
 
 def provider_factory() -> FemicFreshForgeProvider:
     """Return the FEMIC FreshForge provider for entry-point discovery."""
     return FemicFreshForgeProvider()
+
+
+def mkrf_provider_factory() -> FemicMkrfFreshForgeProvider:
+    """Return the MKRF FreshForge provider for entry-point discovery."""
+    return FemicMkrfFreshForgeProvider()
+
+
+def _provider_metadata(
+    *,
+    provider_id: str,
+    name: str,
+    description: str,
+    contracts: Sequence[_NodeContract],
+) -> Any:
+    node_type_metadata, provider_metadata = _freshforge_metadata_types()
+    return provider_metadata(
+        id=provider_id,
+        version=FEMIC_PROVIDER_VERSION,
+        name=name,
+        description=description,
+        node_types=tuple(
+            node_type_metadata(
+                id=contract.id,
+                name=contract.name,
+                description=contract.description,
+                inputs=contract.inputs,
+                outputs=contract.outputs,
+                parameters=contract.parameters,
+                artifacts=contract.artifacts,
+            )
+            for contract in contracts
+        ),
+    )
+
+
+def _validate_contract_node(
+    node: Any,
+    node_type: Any,
+    *,
+    location: str,
+) -> tuple[Any, ...]:
+    diagnostic, severity = _freshforge_diagnostic_types()
+    diagnostics: list[Any] = []
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.inputs),
+            actual=node.inputs,
+            field_name="inputs",
+            location=location,
+        )
+    )
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.outputs),
+            actual=node.outputs,
+            field_name="outputs",
+            location=location,
+        )
+    )
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.parameters),
+            actual=node.parameters,
+            field_name="parameters",
+            location=location,
+        )
+    )
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.artifacts),
+            actual=artifacts,
+            field_name="artifacts",
+            location=location,
+        )
+    )
+    diagnostics.extend(
+        _empty_parameter_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            parameters=node.parameters,
+            required=tuple(node_type.parameters),
+            location=location,
+        )
+    )
+    return tuple(diagnostics)
 
 
 def _freshforge_metadata_types() -> tuple[Any, Any]:
@@ -208,6 +393,374 @@ def _freshforge_diagnostic_types() -> tuple[Any, Any]:
     return Diagnostic, DiagnosticSeverity
 
 
+def _freshforge_execution_result_type() -> Any:
+    try:
+        from freshforge.records import ProviderExecutionResult  # type: ignore[import-untyped]
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The FEMIC FreshForge integration requires the optional "
+            "`femic[freshforge]` dependency."
+        ) from exc
+    return ProviderExecutionResult
+
+
+def _execute_with_builder(
+    *,
+    node: Any,
+    node_type: Any,
+    context: Any,
+    provider_id: str,
+    builders: dict[str, Callable[[Any, Any], tuple[str, ...]]],
+    runner: CommandRunner,
+) -> Any:
+    result_type = _freshforge_execution_result_type()
+    diagnostic, severity = _freshforge_diagnostic_types()
+    builder = builders.get(str(node_type.id))
+    if builder is None:
+        return result_type(
+            diagnostics=(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="femic.execution.unsupported",
+                    message=(
+                        f"FEMIC provider '{provider_id}' has no execution hook "
+                        f"for node type '{node_type.id}'."
+                    ),
+                    location=f"nodes.{node.id}",
+                ),
+            )
+        )
+    try:
+        command = builder(node, context)
+    except ValueError as exc:
+        return result_type(
+            diagnostics=(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="femic.execution.parameters.invalid",
+                    message=str(exc),
+                    location=f"nodes.{node.id}.parameters",
+                ),
+            )
+        )
+    completed = runner(command)
+    metadata: dict[str, Any] = {"returncode": completed.returncode}
+    if completed.stdout:
+        metadata["stdout"] = completed.stdout
+    if completed.stderr:
+        metadata["stderr"] = completed.stderr
+    diagnostics: tuple[Any, ...] = ()
+    if completed.returncode != 0:
+        diagnostics = (
+            diagnostic(
+                severity=severity.ERROR,
+                code="femic.execution.command.failed",
+                message=(
+                    f"FEMIC command for node '{node.id}' exited with "
+                    f"return code {completed.returncode}."
+                ),
+                location=f"nodes.{node.id}",
+            ),
+        )
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    return result_type(
+        metadata=metadata,
+        command=command,
+        diagnostics=diagnostics,
+        artifacts=artifacts,
+    )
+
+
+def _default_command_runner(
+    command: tuple[str, ...],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _python_m_femic(*args: str) -> tuple[str, ...]:
+    return (sys.executable, "-m", "femic", *args)
+
+
+def _parameter(node: Any, key: str) -> str:
+    value = node.parameters.get(key)
+    if value is None:
+        raise ValueError(f"FEMIC node '{node.id}' requires parameter '{key}'.")
+    if isinstance(value, str):
+        if not value.strip():
+            raise ValueError(
+                f"FEMIC node '{node.id}' parameter '{key}' must be nonempty."
+            )
+        return value
+    return str(value)
+
+
+def _optional_parameter(node: Any, key: str) -> str | None:
+    value = node.parameters.get(key)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value if value.strip() else None
+    return str(value)
+
+
+def _append_option(command: list[str], node: Any, key: str, option: str) -> None:
+    value = _optional_parameter(node, key)
+    if value is not None:
+        command.extend([option, value])
+
+
+def _generic_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...]]]:
+    return {
+        "validate_case": _build_validate_case_command,
+        "geospatial_preflight": _build_geospatial_preflight_command,
+        "compile_upstream": _build_compile_upstream_command,
+        "btc_post_tipsy": _build_btc_post_tipsy_command,
+        "export_patchworks": _build_export_patchworks_command,
+        "patchworks_preflight": _build_patchworks_preflight_command,
+        "matrix_build": _build_matrix_build_command,
+    }
+
+
+def _mkrf_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...]]]:
+    return {
+        "build_au_inputs": _build_mkrf_au_inputs_command,
+        "select_aus": _build_mkrf_select_aus_command,
+        "build_managed_au_inputs": _build_mkrf_managed_au_inputs_command,
+        "build_managed_au_curves": _build_mkrf_managed_au_curves_command,
+        "init_runtime_package": _build_mkrf_init_runtime_package_command,
+    }
+
+
+def _build_validate_case_command(node: Any, _context: Any) -> tuple[str, ...]:
+    rebuild_spec = _optional_parameter(node, "rebuild_spec")
+    if rebuild_spec is not None:
+        return _python_m_femic(
+            "instance",
+            "validate-spec",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--spec",
+            rebuild_spec,
+        )
+    command = list(
+        _python_m_femic(
+            "prep",
+            "validate-case",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--run-config",
+            _parameter(node, "run_config"),
+        )
+    )
+    _append_option(command, node, "tipsy_config_dir", "--tipsy-config-dir")
+    return tuple(command)
+
+
+def _build_geospatial_preflight_command(node: Any, _context: Any) -> tuple[str, ...]:
+    _ = _parameter(node, "instance_root")
+    return _python_m_femic("prep", "geospatial-preflight")
+
+
+def _build_compile_upstream_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "run",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--run-config",
+            _parameter(node, "run_config"),
+            "--run-id",
+            _parameter(node, "run_id"),
+        )
+    )
+    _append_option(command, node, "log_dir", "--log-dir")
+    return tuple(command)
+
+
+def _build_btc_post_tipsy_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "tsa",
+            "btc-post-tipsy",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--run-config",
+            _parameter(node, "run_config"),
+            "--tsa",
+            _parameter(node, "tsa"),
+            "--run-id",
+            _parameter(node, "run_id"),
+        )
+    )
+    _append_option(command, node, "log_dir", "--log-dir")
+    _append_option(command, node, "btc_exe", "--btc-exe")
+    _append_option(command, node, "scratch_dir", "--scratch-dir")
+    return tuple(command)
+
+
+def _build_export_patchworks_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "export",
+            "patchworks",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--tsa",
+            _parameter(node, "tsa"),
+        )
+    )
+    _append_option(command, node, "bundle_dir", "--bundle-dir")
+    _append_option(command, node, "checkpoint", "--checkpoint")
+    _append_option(command, node, "output_dir", "--output-dir")
+    return tuple(command)
+
+
+def _build_patchworks_preflight_command(node: Any, _context: Any) -> tuple[str, ...]:
+    return _python_m_femic(
+        "patchworks",
+        "preflight",
+        "--instance-root",
+        _parameter(node, "instance_root"),
+        "--config",
+        _parameter(node, "patchworks_config"),
+    )
+
+
+def _build_matrix_build_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "patchworks",
+            "matrix-build",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--config",
+            _parameter(node, "patchworks_config"),
+            "--run-id",
+            _parameter(node, "run_id"),
+        )
+    )
+    _append_option(command, node, "log_dir", "--log-dir")
+    return tuple(command)
+
+
+def _build_mkrf_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-build-au-inputs",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--resultant-gdb",
+            _parameter(node, "resultant_gdb"),
+        )
+    )
+    _append_option(command, node, "output_dir", "--output-dir")
+    return tuple(command)
+
+
+def _build_mkrf_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-select-aus",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+        )
+    )
+    _append_option(command, node, "au_table_csv", "--au-table-csv")
+    _append_option(command, node, "assignment_csv", "--assignment-csv")
+    _append_option(command, node, "output_csv", "--output-csv")
+    _append_option(command, node, "target_coverage", "--target-coverage")
+    return tuple(command)
+
+
+def _build_mkrf_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-build-managed-au-inputs",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--resultant-gdb",
+            _parameter(node, "resultant_gdb"),
+        )
+    )
+    _append_option(command, node, "tipsy_rules_yaml", "--tipsy-rules-yaml")
+    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
+    _append_option(command, node, "assignment_csv", "--assignment-csv")
+    _append_option(command, node, "output_dir", "--output-dir")
+    return tuple(command)
+
+
+def _build_mkrf_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-build-managed-au-curves",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--run-id",
+            _parameter(node, "run_id"),
+        )
+    )
+    _append_option(command, node, "bootstrap_csv", "--bootstrap-csv")
+    _append_option(command, node, "msyt_csv", "--msyt-csv")
+    _append_option(command, node, "output_dir", "--output-dir")
+    _append_option(command, node, "log_dir", "--log-dir")
+    _append_option(command, node, "btc_executable", "--btc-executable")
+    return tuple(command)
+
+
+def _build_mkrf_init_runtime_package_command(
+    node: Any, _context: Any
+) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-init-runtime-package",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+        )
+    )
+    _append_option(command, node, "package_root", "--package-root")
+    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
+    _append_option(
+        command,
+        node,
+        "stand_origin_assignment_csv",
+        "--stand-origin-assignment-csv",
+    )
+    _append_option(
+        command, node, "stand_au_assignment_csv", "--stand-au-assignment-csv"
+    )
+    _append_option(command, node, "managed_bootstrap_csv", "--managed-bootstrap-csv")
+    _append_option(
+        command, node, "first_growth_curves_csv", "--first-growth-curves-csv"
+    )
+    _append_option(
+        command,
+        node,
+        "first_growth_diagnostics_csv",
+        "--first-growth-diagnostics-csv",
+    )
+    _append_option(command, node, "managed_curves_csv", "--managed-curves-csv")
+    _append_option(
+        command, node, "managed_run_manifest_json", "--managed-run-manifest-json"
+    )
+    _append_option(
+        command,
+        node,
+        "bad_curve_audit_summary_csv",
+        "--bad-curve-audit-summary-csv",
+    )
+    return tuple(command)
+
+
 def _missing_key_diagnostics(
     *,
     diagnostic: Any,
@@ -223,7 +776,7 @@ def _missing_key_diagnostics(
             code=f"femic.{field_name}.missing",
             message=(
                 f"FEMIC node requires {field_name} key '{key}' for "
-                "non-executing workflow planning."
+                "FreshForge validation, planning, and execution."
             ),
             location=f"{location}.{field_name}.{key}",
         )

--- a/src/femic/freshforge.py
+++ b/src/femic/freshforge.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import Any
 
 FEMIC_PROVIDER_ID = "femic"
-FEMIC_MKRF_PROVIDER_ID = "femic.mkrf"
 FEMIC_PROVIDER_VERSION = "0.1.0a1"
 
 CommandRunner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
@@ -92,53 +91,6 @@ _NODE_CONTRACTS: tuple[_NodeContract, ...] = (
     ),
 )
 
-_MKRF_NODE_CONTRACTS: tuple[_NodeContract, ...] = (
-    _NodeContract(
-        id="build_au_inputs",
-        name="Build MKRF AU inputs",
-        description="Build MKRF AU and stand-assignment inputs from Resultant.gdb.",
-        outputs=("au_inputs",),
-        parameters=("instance_root", "resultant_gdb"),
-        artifacts=("au_table", "stand_assignment"),
-    ),
-    _NodeContract(
-        id="select_aus",
-        name="Select MKRF analysis units",
-        description="Publish the canonical MKRF selected AU subset.",
-        inputs=("au_inputs",),
-        outputs=("selected_aus",),
-        parameters=("instance_root",),
-        artifacts=("selected_au_table",),
-    ),
-    _NodeContract(
-        id="build_managed_au_inputs",
-        name="Build MKRF managed AU inputs",
-        description="Build managed AU bootstrap and MSYT input surfaces.",
-        inputs=("selected_aus",),
-        outputs=("managed_au_inputs",),
-        parameters=("instance_root", "resultant_gdb"),
-        artifacts=("stand_origin_assignment", "managed_au_msyt"),
-    ),
-    _NodeContract(
-        id="build_managed_au_curves",
-        name="Build MKRF managed AU curves",
-        description="Run the managed AU BTC curve-building seam.",
-        inputs=("managed_au_inputs",),
-        outputs=("managed_au_curves",),
-        parameters=("instance_root", "run_id"),
-        artifacts=("managed_au_curves", "managed_run_manifest"),
-    ),
-    _NodeContract(
-        id="init_runtime_package",
-        name="Initialize MKRF runtime package",
-        description="Initialize the canonical MKRF Patchworks runtime package.",
-        inputs=("managed_au_curves",),
-        outputs=("patchworks_package",),
-        parameters=("instance_root",),
-        artifacts=("forestmodel_xml", "runtime_manifest"),
-    ),
-)
-
 
 class FemicFreshForgeProvider:
     """FreshForge provider for generic FEMIC workflow stages."""
@@ -162,59 +114,7 @@ class FemicFreshForgeProvider:
         self, node: Any, node_type: Any, *, location: str
     ) -> tuple[Any, ...]:
         """Validate broad FEMIC node shape without executing FEMIC."""
-        diagnostic, severity = _freshforge_diagnostic_types()
-        diagnostics: list[Any] = []
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.inputs),
-                actual=node.inputs,
-                field_name="inputs",
-                location=location,
-            )
-        )
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.outputs),
-                actual=node.outputs,
-                field_name="outputs",
-                location=location,
-            )
-        )
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.parameters),
-                actual=node.parameters,
-                field_name="parameters",
-                location=location,
-            )
-        )
-        artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.artifacts),
-                actual=artifacts,
-                field_name="artifacts",
-                location=location,
-            )
-        )
-        diagnostics.extend(
-            _empty_parameter_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                parameters=node.parameters,
-                required=tuple(node_type.parameters),
-                location=location,
-            )
-        )
-        return tuple(diagnostics)
+        return _validate_contract_node(node, node_type, location=location)
 
     def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
         """Execute one generic FEMIC node through the installed FEMIC CLI."""
@@ -229,51 +129,9 @@ class FemicFreshForgeProvider:
         )
 
 
-class FemicMkrfFreshForgeProvider:
-    """FreshForge provider for MKRF-specific runtime-package regeneration."""
-
-    def __init__(self, command_runner: CommandRunner | None = None) -> None:
-        self._command_runner = command_runner or _default_command_runner
-
-    def metadata(self) -> Any:
-        """Return FreshForge provider metadata."""
-        return _provider_metadata(
-            provider_id=FEMIC_MKRF_PROVIDER_ID,
-            name="FEMIC MKRF model-build provider",
-            description=(
-                "Provider for MKRF-specific FEMIC runtime-package regeneration "
-                "validation, planning, and explicit execution."
-            ),
-            contracts=_MKRF_NODE_CONTRACTS,
-        )
-
-    def validate_node(
-        self, node: Any, node_type: Any, *, location: str
-    ) -> tuple[Any, ...]:
-        """Validate broad MKRF node shape without executing FEMIC."""
-        return _validate_contract_node(node, node_type, location=location)
-
-    def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
-        """Execute one MKRF node through the installed FEMIC CLI."""
-        builders = _mkrf_command_builders()
-        return _execute_with_builder(
-            node=node,
-            node_type=node_type,
-            context=context,
-            provider_id=FEMIC_MKRF_PROVIDER_ID,
-            builders=builders,
-            runner=self._command_runner,
-        )
-
-
 def provider_factory() -> FemicFreshForgeProvider:
     """Return the FEMIC FreshForge provider for entry-point discovery."""
     return FemicFreshForgeProvider()
-
-
-def mkrf_provider_factory() -> FemicMkrfFreshForgeProvider:
-    """Return the MKRF FreshForge provider for entry-point discovery."""
-    return FemicMkrfFreshForgeProvider()
 
 
 def _provider_metadata(
@@ -526,16 +384,6 @@ def _generic_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...
     }
 
 
-def _mkrf_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...]]]:
-    return {
-        "build_au_inputs": _build_mkrf_au_inputs_command,
-        "select_aus": _build_mkrf_select_aus_command,
-        "build_managed_au_inputs": _build_mkrf_managed_au_inputs_command,
-        "build_managed_au_curves": _build_mkrf_managed_au_curves_command,
-        "init_runtime_package": _build_mkrf_init_runtime_package_command,
-    }
-
-
 def _build_validate_case_command(node: Any, _context: Any) -> tuple[str, ...]:
     rebuild_spec = _optional_parameter(node, "rebuild_spec")
     if rebuild_spec is not None:
@@ -645,119 +493,6 @@ def _build_matrix_build_command(node: Any, _context: Any) -> tuple[str, ...]:
         )
     )
     _append_option(command, node, "log_dir", "--log-dir")
-    return tuple(command)
-
-
-def _build_mkrf_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-build-au-inputs",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-            "--resultant-gdb",
-            _parameter(node, "resultant_gdb"),
-        )
-    )
-    _append_option(command, node, "output_dir", "--output-dir")
-    return tuple(command)
-
-
-def _build_mkrf_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-select-aus",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-        )
-    )
-    _append_option(command, node, "au_table_csv", "--au-table-csv")
-    _append_option(command, node, "assignment_csv", "--assignment-csv")
-    _append_option(command, node, "output_csv", "--output-csv")
-    _append_option(command, node, "target_coverage", "--target-coverage")
-    return tuple(command)
-
-
-def _build_mkrf_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-build-managed-au-inputs",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-            "--resultant-gdb",
-            _parameter(node, "resultant_gdb"),
-        )
-    )
-    _append_option(command, node, "tipsy_rules_yaml", "--tipsy-rules-yaml")
-    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
-    _append_option(command, node, "assignment_csv", "--assignment-csv")
-    _append_option(command, node, "output_dir", "--output-dir")
-    return tuple(command)
-
-
-def _build_mkrf_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-build-managed-au-curves",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-            "--run-id",
-            _parameter(node, "run_id"),
-        )
-    )
-    _append_option(command, node, "bootstrap_csv", "--bootstrap-csv")
-    _append_option(command, node, "msyt_csv", "--msyt-csv")
-    _append_option(command, node, "output_dir", "--output-dir")
-    _append_option(command, node, "log_dir", "--log-dir")
-    _append_option(command, node, "btc_executable", "--btc-executable")
-    return tuple(command)
-
-
-def _build_mkrf_init_runtime_package_command(
-    node: Any, _context: Any
-) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-init-runtime-package",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-        )
-    )
-    _append_option(command, node, "package_root", "--package-root")
-    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
-    _append_option(
-        command,
-        node,
-        "stand_origin_assignment_csv",
-        "--stand-origin-assignment-csv",
-    )
-    _append_option(
-        command, node, "stand_au_assignment_csv", "--stand-au-assignment-csv"
-    )
-    _append_option(command, node, "managed_bootstrap_csv", "--managed-bootstrap-csv")
-    _append_option(
-        command, node, "first_growth_curves_csv", "--first-growth-curves-csv"
-    )
-    _append_option(
-        command,
-        node,
-        "first_growth_diagnostics_csv",
-        "--first-growth-diagnostics-csv",
-    )
-    _append_option(command, node, "managed_curves_csv", "--managed-curves-csv")
-    _append_option(
-        command, node, "managed_run_manifest_json", "--managed-run-manifest-json"
-    )
-    _append_option(
-        command,
-        node,
-        "bad_curve_audit_summary_csv",
-        "--bad-curve-audit-summary-csv",
-    )
     return tuple(command)
 
 

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -10,10 +10,7 @@ import yaml
 
 from femic.freshforge import (
     FEMIC_PROVIDER_ID,
-    FEMIC_MKRF_PROVIDER_ID,
     FemicFreshForgeProvider,
-    FemicMkrfFreshForgeProvider,
-    mkrf_provider_factory,
     provider_factory,
 )
 
@@ -21,26 +18,12 @@ freshforge = pytest.importorskip("freshforge")
 
 
 EXAMPLE_PATH = Path("examples/freshforge/model_build_workflow.yaml")
-MKRF_WORKFLOW_PATH = Path(
-    "external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml"
-)
 EXPECTED_GENERIC_MODEL_BUILD_ORDER = [
     "validate_case",
     "geospatial_preflight",
     "compile_upstream",
     "btc_post_tipsy",
     "export_patchworks",
-    "patchworks_preflight",
-    "matrix_build",
-]
-EXPECTED_MKRF_MODEL_BUILD_ORDER = [
-    "validate_case",
-    "geospatial_preflight",
-    "build_au_inputs",
-    "select_aus",
-    "build_managed_au_inputs",
-    "build_managed_au_curves",
-    "init_runtime_package",
     "patchworks_preflight",
     "matrix_build",
 ]
@@ -51,7 +34,6 @@ def _registry_with_femic_provider():
 
     registry = ProviderRegistry()
     registry.register(provider_factory())
-    registry.register(mkrf_provider_factory())
     return registry
 
 
@@ -163,23 +145,6 @@ def test_provider_factory_returns_femic_provider() -> None:
     assert provider_factory().metadata().id == FEMIC_PROVIDER_ID
 
 
-def test_mkrf_provider_metadata_serializes_deterministically() -> None:
-    metadata = mkrf_provider_factory().metadata()
-
-    assert metadata.id == FEMIC_MKRF_PROVIDER_ID
-    assert [node_type.id for node_type in metadata.node_types] == [
-        "build_au_inputs",
-        "select_aus",
-        "build_managed_au_inputs",
-        "build_managed_au_curves",
-        "init_runtime_package",
-    ]
-    assert metadata.to_dict()["node_types"][0]["parameters"] == [
-        "instance_root",
-        "resultant_gdb",
-    ]
-
-
 def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
@@ -188,7 +153,7 @@ def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     assert any("freshforge" in item for item in optional["dev"])
     entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
     assert entry_points["femic"] == "femic.freshforge:provider_factory"
-    assert entry_points["femic_mkrf"] == "femic.freshforge:mkrf_provider_factory"
+    assert "femic_mkrf" not in entry_points
 
 
 def test_femic_import_does_not_import_freshforge_eagerly() -> None:
@@ -285,7 +250,7 @@ def test_default_freshforge_registry_discovers_installed_femic_provider() -> Non
 
     assert not diagnostics
     assert registry.get("femic") is not None
-    assert registry.get("femic.mkrf") is not None
+    assert registry.get("femic.mkrf") is None
 
 
 def test_generic_provider_execution_constructs_femic_command() -> None:
@@ -327,45 +292,6 @@ def test_generic_provider_execution_constructs_femic_command() -> None:
     ]
 
 
-def test_mkrf_provider_execution_constructs_mkrf_command() -> None:
-    from freshforge.records import ExecutionContext, WorkflowNode
-
-    commands: list[tuple[str, ...]] = []
-    provider = FemicMkrfFreshForgeProvider(command_runner=_successful_runner(commands))
-    node_type = next(
-        item for item in provider.metadata().node_types if item.id == "build_au_inputs"
-    )
-    node = WorkflowNode(
-        id="build_au_inputs",
-        provider="femic.mkrf.build_au_inputs",
-        parameters={
-            "instance_root": ".",
-            "resultant_gdb": "data/source/03_MappingAnalysisData/Resultant.gdb",
-        },
-    )
-
-    result = provider.execute_node(
-        node,
-        node_type,
-        context=ExecutionContext(workflow_id="wf", run_id="run"),
-    )
-
-    assert result.diagnostics == ()
-    assert commands == [
-        (
-            sys.executable,
-            "-m",
-            "femic",
-            "instance",
-            "mkrf-build-au-inputs",
-            "--instance-root",
-            ".",
-            "--resultant-gdb",
-            "data/source/03_MappingAnalysisData/Resultant.gdb",
-        )
-    ]
-
-
 def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
     from freshforge.records import ExecutionContext, WorkflowNode
 
@@ -401,56 +327,3 @@ def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
     assert {diagnostic.code for diagnostic in result.diagnostics} == {
         "femic.execution.command.failed"
     }
-
-
-def test_mkrf_instance_workflow_validates_and_plans_when_available() -> None:
-    if not MKRF_WORKFLOW_PATH.exists():
-        pytest.skip("MKRF instance FreshForge workflow is not available")
-
-    from freshforge.loading import load_workflow
-    from freshforge.planning import create_run_plan
-    from freshforge.validation import validate_workflow_with_providers
-
-    spec, load_diagnostics = load_workflow(MKRF_WORKFLOW_PATH)
-    assert spec is not None
-    assert load_diagnostics == []
-    assert spec.id == "mkrf_model_build"
-
-    diagnostics = validate_workflow_with_providers(
-        spec,
-        registry=_registry_with_femic_provider(),
-        structural_diagnostics=load_diagnostics,
-    )
-    assert diagnostics == []
-
-    plan = create_run_plan(
-        spec,
-        diagnostics=diagnostics,
-        registry=_registry_with_femic_provider(),
-    )
-    assert not plan.has_errors
-    assert [node.id for node in plan.nodes] == EXPECTED_MKRF_MODEL_BUILD_ORDER
-    assert {node.provider_id for node in plan.nodes} == {"femic", "femic.mkrf"}
-
-
-def test_mkrf_instance_workflow_dry_run_when_available() -> None:
-    if not MKRF_WORKFLOW_PATH.exists():
-        pytest.skip("MKRF instance FreshForge workflow is not available")
-
-    from freshforge.execution import execute_workflow
-    from freshforge.loading import load_workflow
-
-    spec, load_diagnostics = load_workflow(MKRF_WORKFLOW_PATH)
-    assert spec is not None
-
-    report = execute_workflow(
-        spec,
-        run_id="mkrf_freshforge_exec",
-        diagnostics=load_diagnostics,
-        registry=_registry_with_femic_provider(),
-        dry_run=True,
-    )
-
-    assert not report.failed
-    assert report.dry_run
-    assert report.planned_order == tuple(EXPECTED_MKRF_MODEL_BUILD_ORDER)

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -10,6 +10,10 @@ import yaml
 
 from femic.freshforge import (
     FEMIC_PROVIDER_ID,
+    FEMIC_MKRF_PROVIDER_ID,
+    FemicFreshForgeProvider,
+    FemicMkrfFreshForgeProvider,
+    mkrf_provider_factory,
     provider_factory,
 )
 
@@ -20,12 +24,23 @@ EXAMPLE_PATH = Path("examples/freshforge/model_build_workflow.yaml")
 MKRF_WORKFLOW_PATH = Path(
     "external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml"
 )
-EXPECTED_MODEL_BUILD_ORDER = [
+EXPECTED_GENERIC_MODEL_BUILD_ORDER = [
     "validate_case",
     "geospatial_preflight",
     "compile_upstream",
     "btc_post_tipsy",
     "export_patchworks",
+    "patchworks_preflight",
+    "matrix_build",
+]
+EXPECTED_MKRF_MODEL_BUILD_ORDER = [
+    "validate_case",
+    "geospatial_preflight",
+    "build_au_inputs",
+    "select_aus",
+    "build_managed_au_inputs",
+    "build_managed_au_curves",
+    "init_runtime_package",
     "patchworks_preflight",
     "matrix_build",
 ]
@@ -36,7 +51,21 @@ def _registry_with_femic_provider():
 
     registry = ProviderRegistry()
     registry.register(provider_factory())
+    registry.register(mkrf_provider_factory())
     return registry
+
+
+def _successful_runner(commands: list[tuple[str, ...]]):
+    def _run(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+    return _run
 
 
 def _example_document() -> dict[str, object]:
@@ -124,14 +153,31 @@ def test_provider_metadata_serializes_deterministically() -> None:
         ],
         "name": "FEMIC model-build provider",
         "description": (
-            "Non-executing provider for FEMIC model-build workflow "
-            "validation, inspection, and planning."
+            "Provider for FEMIC model-build workflow validation, planning, "
+            "and explicit execution."
         ),
     }
 
 
 def test_provider_factory_returns_femic_provider() -> None:
     assert provider_factory().metadata().id == FEMIC_PROVIDER_ID
+
+
+def test_mkrf_provider_metadata_serializes_deterministically() -> None:
+    metadata = mkrf_provider_factory().metadata()
+
+    assert metadata.id == FEMIC_MKRF_PROVIDER_ID
+    assert [node_type.id for node_type in metadata.node_types] == [
+        "build_au_inputs",
+        "select_aus",
+        "build_managed_au_inputs",
+        "build_managed_au_curves",
+        "init_runtime_package",
+    ]
+    assert metadata.to_dict()["node_types"][0]["parameters"] == [
+        "instance_root",
+        "resultant_gdb",
+    ]
 
 
 def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
@@ -142,6 +188,7 @@ def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     assert any("freshforge" in item for item in optional["dev"])
     entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
     assert entry_points["femic"] == "femic.freshforge:provider_factory"
+    assert entry_points["femic_mkrf"] == "femic.freshforge:mkrf_provider_factory"
 
 
 def test_femic_import_does_not_import_freshforge_eagerly() -> None:
@@ -185,9 +232,9 @@ def test_example_workflow_validates_and_plans() -> None:
         registry=_registry_with_femic_provider(),
     )
     assert not plan.has_errors
-    assert [node.id for node in plan.nodes] == EXPECTED_MODEL_BUILD_ORDER
+    assert [node.id for node in plan.nodes] == EXPECTED_GENERIC_MODEL_BUILD_ORDER
     assert {node.provider_id for node in plan.nodes} == {"femic"}
-    assert [node.node_type for node in plan.nodes] == EXPECTED_MODEL_BUILD_ORDER
+    assert [node.node_type for node in plan.nodes] == EXPECTED_GENERIC_MODEL_BUILD_ORDER
 
 
 def test_missing_required_parameter_returns_provider_diagnostic() -> None:
@@ -238,6 +285,122 @@ def test_default_freshforge_registry_discovers_installed_femic_provider() -> Non
 
     assert not diagnostics
     assert registry.get("femic") is not None
+    assert registry.get("femic.mkrf") is not None
+
+
+def test_generic_provider_execution_constructs_femic_command() -> None:
+    from freshforge.records import ExecutionContext, WorkflowNode
+
+    commands: list[tuple[str, ...]] = []
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner(commands))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "validate_case"
+    )
+    node = WorkflowNode(
+        id="validate_case",
+        provider="femic.validate_case",
+        parameters={
+            "instance_root": ".",
+            "run_config": "config/run_profile.mkrf.yaml",
+        },
+    )
+
+    result = provider.execute_node(
+        node,
+        node_type,
+        context=ExecutionContext(workflow_id="wf", run_id="run"),
+    )
+
+    assert result.diagnostics == ()
+    assert commands == [
+        (
+            sys.executable,
+            "-m",
+            "femic",
+            "prep",
+            "validate-case",
+            "--instance-root",
+            ".",
+            "--run-config",
+            "config/run_profile.mkrf.yaml",
+        )
+    ]
+
+
+def test_mkrf_provider_execution_constructs_mkrf_command() -> None:
+    from freshforge.records import ExecutionContext, WorkflowNode
+
+    commands: list[tuple[str, ...]] = []
+    provider = FemicMkrfFreshForgeProvider(command_runner=_successful_runner(commands))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "build_au_inputs"
+    )
+    node = WorkflowNode(
+        id="build_au_inputs",
+        provider="femic.mkrf.build_au_inputs",
+        parameters={
+            "instance_root": ".",
+            "resultant_gdb": "data/source/03_MappingAnalysisData/Resultant.gdb",
+        },
+    )
+
+    result = provider.execute_node(
+        node,
+        node_type,
+        context=ExecutionContext(workflow_id="wf", run_id="run"),
+    )
+
+    assert result.diagnostics == ()
+    assert commands == [
+        (
+            sys.executable,
+            "-m",
+            "femic",
+            "instance",
+            "mkrf-build-au-inputs",
+            "--instance-root",
+            ".",
+            "--resultant-gdb",
+            "data/source/03_MappingAnalysisData/Resultant.gdb",
+        )
+    ]
+
+
+def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
+    from freshforge.records import ExecutionContext, WorkflowNode
+
+    def _failing_runner(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=9,
+            stdout="",
+            stderr="failed",
+        )
+
+    provider = FemicFreshForgeProvider(command_runner=_failing_runner)
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "matrix_build"
+    )
+    node = WorkflowNode(
+        id="matrix_build",
+        provider="femic.matrix_build",
+        parameters={
+            "instance_root": ".",
+            "patchworks_config": "config/patchworks.runtime.mkrf_rebuild.windows.yaml",
+            "run_id": "mkrf_freshforge_exec",
+        },
+    )
+
+    result = provider.execute_node(
+        node,
+        node_type,
+        context=ExecutionContext(workflow_id="wf", run_id="run"),
+    )
+
+    assert result.metadata["returncode"] == 9
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {
+        "femic.execution.command.failed"
+    }
 
 
 def test_mkrf_instance_workflow_validates_and_plans_when_available() -> None:
@@ -266,5 +429,28 @@ def test_mkrf_instance_workflow_validates_and_plans_when_available() -> None:
         registry=_registry_with_femic_provider(),
     )
     assert not plan.has_errors
-    assert [node.id for node in plan.nodes] == EXPECTED_MODEL_BUILD_ORDER
-    assert {node.provider_id for node in plan.nodes} == {"femic"}
+    assert [node.id for node in plan.nodes] == EXPECTED_MKRF_MODEL_BUILD_ORDER
+    assert {node.provider_id for node in plan.nodes} == {"femic", "femic.mkrf"}
+
+
+def test_mkrf_instance_workflow_dry_run_when_available() -> None:
+    if not MKRF_WORKFLOW_PATH.exists():
+        pytest.skip("MKRF instance FreshForge workflow is not available")
+
+    from freshforge.execution import execute_workflow
+    from freshforge.loading import load_workflow
+
+    spec, load_diagnostics = load_workflow(MKRF_WORKFLOW_PATH)
+    assert spec is not None
+
+    report = execute_workflow(
+        spec,
+        run_id="mkrf_freshforge_exec",
+        diagnostics=load_diagnostics,
+        registry=_registry_with_femic_provider(),
+        dry_run=True,
+    )
+
+    assert not report.failed
+    assert report.dry_run
+    assert report.planned_order == tuple(EXPECTED_MKRF_MODEL_BUILD_ORDER)


### PR DESCRIPTION
﻿## Summary

Implements Phase 84 FreshForge execution integration for FEMIC and MKRF:

- extends `femic.freshforge` with lazy provider execution hooks backed by `sys.executable -m femic`;
- preserves non-mutating validation, inspection, and planning behavior;
- adds the `femic.mkrf` provider namespace and `freshforge.providers` entry point;
- updates package metadata to consume the FreshForge Phase 6 execution branch;
- updates FEMIC docs/API docs/README and tests;
- updates the MKRF submodule pointer to UBC-FRESH/femic-mkrf-instance#38.

The MKRF executable graph is instance-owned and source-aware. It intentionally uses the MKRF `femic.mkrf.*` runtime-package regeneration commands after geospatial preflight rather than forcing the older TSA-style `femic run` and BTC/post-TIPSY lane, which still requires legacy checkpoint files outside the accepted MKRF source contract.

## Verification

FEMIC parent:

- `python -m ruff check src tests`
- `python -m pytest tests/test_freshforge_integration.py`
- `python -m mypy src/femic/freshforge.py`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`

MKRF instance:

- `freshforge providers --json`
- `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --dry-run --json --report runtime/freshforge/runs/mkrf_freshforge_exec.dry_run.json`
- `sphinx-build -b html docs docs/_build/html -W`

Full local execution was attempted. The workflow regenerated MKRF model-input/runtime package surfaces and reached Patchworks Matrix Builder, but Matrix Builder did not complete because local Patchworks stderr reported `No matching license`. That remains the explicit acceptance blocker for P84.4.

## Links

- FreshForge execution dependency: UBC-FRESH/freshforge#47
- MKRF instance workflow PR: UBC-FRESH/femic-mkrf-instance#38
- Parent issue: #234
