### PR TITLE
Restore FEMIC/MKRF FreshForge provider boundary

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18736,4 +18736,7 @@
   reviewed; and
 - verified focused parent and MKRF adapter Ruff, pytest, targeted mypy, parent
   and MKRF Sphinx builds, FreshForge CLI provider discovery/validate/inspect/
-  plan/dry-run, package builds, `twine check`, and wheel entry-point metadata.
+  plan/dry-run, package builds, `twine check`, and wheel entry-point metadata;
+  and
+- opened MKRF PR `UBC-FRESH/femic-mkrf-instance#40` and parent FEMIC PR `#242`
+  for review.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18716,3 +18716,24 @@
   model-input/runtime package surfaces and reached Patchworks Matrix Builder,
   but Matrix Builder did not complete because local Patchworks stderr reported
   `No matching license`.
+
+## 2026-07-01 - Restored FEMIC/MKRF FreshForge provider boundary
+
+- opened FEMIC issue `#241` and MKRF issue
+  `UBC-FRESH/femic-mkrf-instance#39` for the P85 namespace repair;
+- removed the MKRF-specific FreshForge provider id, factory, metadata, command
+  builders, and entry point from `femic.freshforge`, leaving FEMIC core with the
+  reusable executable `femic` provider only;
+- added an instance-owned MKRF adapter package in the MKRF repository that
+  exposes provider id `mkrf` through `freshforge.providers` and delegates
+  execution to existing `python -m femic instance mkrf-*` compatibility
+  commands;
+- updated the MKRF FreshForge workflow from `femic.mkrf.*` provider references
+  to `mkrf.*` and documented the adapter installation/ownership boundary in
+  parent and MKRF docs;
+- recorded Phase 86 as the follow-on lane for moving mature MKRF-specific
+  workflow and pipeline code out of FEMIC core after the adapter boundary is
+  reviewed; and
+- verified focused parent and MKRF adapter Ruff, pytest, targeted mypy, parent
+  and MKRF Sphinx builds, FreshForge CLI provider discovery/validate/inspect/
+  plan/dry-run, package builds, `twine check`, and wheel entry-point metadata.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2476,11 +2476,11 @@ id `mkrf`.
         commands.
   - [x] Add a follow-on phase for moving mature MKRF-specific workflow and
         pipeline code out of FEMIC core after the adapter path is proven.
-- [ ] P85.5 Verify, commit, push, and open PRs
+- [x] P85.5 Verify, commit, push, and open PRs
   - [x] Run focused parent and MKRF adapter tests.
   - [x] Verify provider metadata no longer advertises `femic.mkrf` from FEMIC
         and advertises `mkrf` only from the MKRF adapter.
-  - [ ] Open linked parent and MKRF PRs.
+  - [x] Open linked parent and MKRF PRs.
 
 Phase 85 intentionally does not remove the existing `femic instance mkrf-*`
 compatibility commands. Those commands remain the execution target for the
@@ -2531,7 +2531,8 @@ and `femic instance mkrf-*` CLI commands.
     metadata and command construction into the MKRF instance as provider id
     `mkrf`. Local verification has passed for focused Ruff, pytest, mypy,
     Sphinx, FreshForge CLI validate/inspect/plan/dry-run, package builds,
-    `twine check`, and wheel entry-point inspection. PR closeout remains.
+    `twine check`, wheel entry-point inspection, MKRF PR
+    `UBC-FRESH/femic-mkrf-instance#40`, and parent PR `#242`.
   - `P86` is planned: broader extraction of existing MKRF-specific FEMIC
     workflow and pipeline code should happen after the P85 adapter boundary is
     reviewed, rather than being bundled into the namespace repair.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2438,6 +2438,83 @@ workflow semantics are proven because it solves the separate user problem of
 bootstrapping Git, Python, DataLad, git-annex, special remotes, virtual
 environments, and required payload materialization before model workflows run.
 
+## Phase 85: FreshForge Instance Provider Boundary Repair
+
+Parent issue: #241
+
+Branch: `feature/p85-freshforge-instance-provider-boundary`
+
+Status: active
+
+Goal: restore the provider namespace boundary after the Phase 84 executable
+prototype put MKRF-specific FreshForge provider logic under `femic.mkrf` in
+FEMIC core. FEMIC core should expose reusable FEMIC stages through provider id
+`femic`; MKRF-specific orchestration belongs to the MKRF instance as provider
+id `mkrf`.
+
+- [x] P85.1 Remove MKRF FreshForge provider ownership from FEMIC core
+  - [x] Remove the `femic.mkrf` provider id, factory, metadata, command
+        builders, and entry point from `femic.freshforge`.
+  - [x] Keep generic executable `femic.*` stages and lazy FreshForge imports.
+  - [x] Update parent tests and docs so FEMIC core is instance-neutral.
+- [x] P85.2 Add the MKRF-owned FreshForge adapter package
+      (MKRF issue UBC-FRESH/femic-mkrf-instance#39)
+  - [x] Add a lightweight installable `mkrf_freshforge` package in the MKRF
+        instance repository.
+  - [x] Register provider id `mkrf` through the `freshforge.providers` entry
+        point.
+  - [x] Move MKRF provider metadata and command construction into the instance
+        adapter while continuing to call existing `python -m femic ...`
+        compatibility commands.
+- [x] P85.3 Update MKRF workflow and docs for `mkrf.*`
+  - [x] Rewrite MKRF workflow provider references from `femic.mkrf.*` to
+        `mkrf.*`.
+  - [x] Document adapter installation and the boundary between FEMIC core,
+        FreshForge, and instance-owned orchestration.
+- [x] P85.4 Record the broader MKRF core extraction follow-up
+  - [x] Inventory MKRF-specific core modules and `femic instance mkrf-*`
+        commands.
+  - [x] Add a follow-on phase for moving mature MKRF-specific workflow and
+        pipeline code out of FEMIC core after the adapter path is proven.
+- [ ] P85.5 Verify, commit, push, and open PRs
+  - [x] Run focused parent and MKRF adapter tests.
+  - [x] Verify provider metadata no longer advertises `femic.mkrf` from FEMIC
+        and advertises `mkrf` only from the MKRF adapter.
+  - [ ] Open linked parent and MKRF PRs.
+
+Phase 85 intentionally does not remove the existing `femic instance mkrf-*`
+compatibility commands. Those commands remain the execution target for the
+MKRF adapter until a separate extraction phase moves mature MKRF-specific
+scientific and workflow code into an instance-owned or companion package.
+
+## Phase 86: Extract MKRF-Specific Workflow Code From FEMIC Core
+
+Parent issue: pending
+
+Branch: pending
+
+Status: planned
+
+Goal: move mature MKRF-specific pipeline and workflow implementation out of
+FEMIC core after the P85 adapter package boundary is proven. The current
+inventory found MKRF-specific implementation surfaces in
+`src/femic/workflows/mkrf.py`, `src/femic/pipeline/mkrf_au.py`,
+`src/femic/pipeline/mkrf_first_growth.py`, `src/femic/pipeline/mkrf_managed.py`,
+and `femic instance mkrf-*` CLI commands.
+
+- [ ] P86.1 Define the extraction target and compatibility policy
+  - [ ] Decide whether mature MKRF code moves into the MKRF instance package or
+        a separately named companion package.
+  - [ ] Define temporary compatibility wrappers for existing
+        `femic instance mkrf-*` commands.
+- [ ] P86.2 Move MKRF implementation behind the chosen package boundary
+  - [ ] Preserve current tests and command behavior during the move.
+  - [ ] Keep generic FEMIC package APIs instance-neutral.
+- [ ] P86.3 Update docs, tests, packaging, and FreshForge adapter commands
+  - [ ] Point the MKRF FreshForge adapter at the extracted implementation or
+        retained compatibility commands according to the P86 policy.
+  - [ ] Remove stale FEMIC-core MKRF ownership language.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2449,6 +2526,15 @@ environments, and required payload materialization before model workflows run.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P85` / `#241` is active: restore the FreshForge provider boundary by
+    removing `femic.mkrf` from FEMIC core and moving MKRF executable provider
+    metadata and command construction into the MKRF instance as provider id
+    `mkrf`. Local verification has passed for focused Ruff, pytest, mypy,
+    Sphinx, FreshForge CLI validate/inspect/plan/dry-run, package builds,
+    `twine check`, and wheel entry-point inspection. PR closeout remains.
+  - `P86` is planned: broader extraction of existing MKRF-specific FEMIC
+    workflow and pipeline code should happen after the P85 adapter boundary is
+    reviewed, rather than being bundled into the namespace repair.
   - `P84` / `#234` is active: FEMIC will consume FreshForge Phase 6 execution
     support and MKRF owns the first executable instance workflow. Provider
     hooks, the MKRF provider namespace, docs, validation, planning, dry-run, and

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -31,7 +31,7 @@ Provider Discovery
 
 FEMIC registers provider entry points in the ``freshforge.providers`` group.
 When FEMIC is installed with the optional FreshForge dependency, FreshForge can
-discover provider IDs ``femic`` and ``femic.mkrf``:
+discover provider ID ``femic``:
 
 .. code-block:: bash
 
@@ -47,14 +47,10 @@ The generic provider references currently exposed for model-build workflows are:
 - ``femic.patchworks_preflight``
 - ``femic.matrix_build``
 
-The MKRF-specific provider references exposed for the first executable MKRF
-workflow are:
-
-- ``femic.mkrf.build_au_inputs``
-- ``femic.mkrf.select_aus``
-- ``femic.mkrf.build_managed_au_inputs``
-- ``femic.mkrf.build_managed_au_curves``
-- ``femic.mkrf.init_runtime_package``
+Instance-specific provider references are not shipped by FEMIC core. For
+example, the MKRF instance owns its executable adapter package and exposes
+provider references such as ``mkrf.build_au_inputs`` only when that instance
+adapter is installed.
 
 Generic Workflow Example
 ------------------------
@@ -106,7 +102,8 @@ workflow builders. Instance-specific FreshForge documents should live in the
 instance repository that owns the model-build contract. For example, the MKRF
 workflow document lives in the MKRF instance repository, while FEMIC core
 supplies reusable provider references such as ``femic.validate_case`` and
-``femic.matrix_build`` plus the MKRF command namespace ``femic.mkrf``.
+``femic.matrix_build``. The MKRF instance supplies its own provider namespace
+``mkrf`` through its adapter package.
 
 Boundaries
 ----------
@@ -125,7 +122,6 @@ API
 ---
 
 Use :func:`femic.freshforge.provider_factory` when a caller needs explicit
-registry control for the generic FEMIC provider. Use
-:func:`femic.freshforge.mkrf_provider_factory` for the MKRF-specific provider.
-Concrete workflow assembly is intentionally left to instance repositories or
+registry control for the generic FEMIC provider. Concrete workflow assembly and
+instance-specific providers are intentionally left to instance repositories or
 caller-owned workflow documents.

--- a/docs/reference/api/femic-freshforge.rst
+++ b/docs/reference/api/femic-freshforge.rst
@@ -10,12 +10,13 @@ dependency boundary. Normal FEMIC imports do not import FreshForge eagerly.
 Responsibilities
 ----------------
 
-- expose provider IDs ``femic`` and ``femic.mkrf`` through
-  ``freshforge.providers`` entry-point discovery;
+- expose provider ID ``femic`` through ``freshforge.providers`` entry-point
+  discovery;
 - describe reusable FEMIC model-build stages as FreshForge node types;
 - validate broad node parameters, inputs, outputs, and artifact declarations;
 - execute existing FEMIC CLI commands only when ``freshforge run`` is called;
-- leave instance-specific workflow composition to instance repositories; and
+- leave instance-specific workflow composition and provider namespaces to
+  instance repositories; and
 - preserve the boundary that FreshForge validation, inspection, and planning do
   not execute FEMIC.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ femic = "femic.cli.main:app"
 
 [project.entry-points."freshforge.providers"]
 femic = "femic.freshforge:provider_factory"
-femic_mkrf = "femic.freshforge:mkrf_provider_factory"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/femic/freshforge.py
+++ b/src/femic/freshforge.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import Any
 
 FEMIC_PROVIDER_ID = "femic"
-FEMIC_MKRF_PROVIDER_ID = "femic.mkrf"
 FEMIC_PROVIDER_VERSION = "0.1.0a1"
 
 CommandRunner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
@@ -92,53 +91,6 @@ _NODE_CONTRACTS: tuple[_NodeContract, ...] = (
     ),
 )
 
-_MKRF_NODE_CONTRACTS: tuple[_NodeContract, ...] = (
-    _NodeContract(
-        id="build_au_inputs",
-        name="Build MKRF AU inputs",
-        description="Build MKRF AU and stand-assignment inputs from Resultant.gdb.",
-        outputs=("au_inputs",),
-        parameters=("instance_root", "resultant_gdb"),
-        artifacts=("au_table", "stand_assignment"),
-    ),
-    _NodeContract(
-        id="select_aus",
-        name="Select MKRF analysis units",
-        description="Publish the canonical MKRF selected AU subset.",
-        inputs=("au_inputs",),
-        outputs=("selected_aus",),
-        parameters=("instance_root",),
-        artifacts=("selected_au_table",),
-    ),
-    _NodeContract(
-        id="build_managed_au_inputs",
-        name="Build MKRF managed AU inputs",
-        description="Build managed AU bootstrap and MSYT input surfaces.",
-        inputs=("selected_aus",),
-        outputs=("managed_au_inputs",),
-        parameters=("instance_root", "resultant_gdb"),
-        artifacts=("stand_origin_assignment", "managed_au_msyt"),
-    ),
-    _NodeContract(
-        id="build_managed_au_curves",
-        name="Build MKRF managed AU curves",
-        description="Run the managed AU BTC curve-building seam.",
-        inputs=("managed_au_inputs",),
-        outputs=("managed_au_curves",),
-        parameters=("instance_root", "run_id"),
-        artifacts=("managed_au_curves", "managed_run_manifest"),
-    ),
-    _NodeContract(
-        id="init_runtime_package",
-        name="Initialize MKRF runtime package",
-        description="Initialize the canonical MKRF Patchworks runtime package.",
-        inputs=("managed_au_curves",),
-        outputs=("patchworks_package",),
-        parameters=("instance_root",),
-        artifacts=("forestmodel_xml", "runtime_manifest"),
-    ),
-)
-
 
 class FemicFreshForgeProvider:
     """FreshForge provider for generic FEMIC workflow stages."""
@@ -162,59 +114,7 @@ class FemicFreshForgeProvider:
         self, node: Any, node_type: Any, *, location: str
     ) -> tuple[Any, ...]:
         """Validate broad FEMIC node shape without executing FEMIC."""
-        diagnostic, severity = _freshforge_diagnostic_types()
-        diagnostics: list[Any] = []
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.inputs),
-                actual=node.inputs,
-                field_name="inputs",
-                location=location,
-            )
-        )
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.outputs),
-                actual=node.outputs,
-                field_name="outputs",
-                location=location,
-            )
-        )
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.parameters),
-                actual=node.parameters,
-                field_name="parameters",
-                location=location,
-            )
-        )
-        artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
-        diagnostics.extend(
-            _missing_key_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                required=tuple(node_type.artifacts),
-                actual=artifacts,
-                field_name="artifacts",
-                location=location,
-            )
-        )
-        diagnostics.extend(
-            _empty_parameter_diagnostics(
-                diagnostic=diagnostic,
-                severity=severity,
-                parameters=node.parameters,
-                required=tuple(node_type.parameters),
-                location=location,
-            )
-        )
-        return tuple(diagnostics)
+        return _validate_contract_node(node, node_type, location=location)
 
     def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
         """Execute one generic FEMIC node through the installed FEMIC CLI."""
@@ -229,51 +129,9 @@ class FemicFreshForgeProvider:
         )
 
 
-class FemicMkrfFreshForgeProvider:
-    """FreshForge provider for MKRF-specific runtime-package regeneration."""
-
-    def __init__(self, command_runner: CommandRunner | None = None) -> None:
-        self._command_runner = command_runner or _default_command_runner
-
-    def metadata(self) -> Any:
-        """Return FreshForge provider metadata."""
-        return _provider_metadata(
-            provider_id=FEMIC_MKRF_PROVIDER_ID,
-            name="FEMIC MKRF model-build provider",
-            description=(
-                "Provider for MKRF-specific FEMIC runtime-package regeneration "
-                "validation, planning, and explicit execution."
-            ),
-            contracts=_MKRF_NODE_CONTRACTS,
-        )
-
-    def validate_node(
-        self, node: Any, node_type: Any, *, location: str
-    ) -> tuple[Any, ...]:
-        """Validate broad MKRF node shape without executing FEMIC."""
-        return _validate_contract_node(node, node_type, location=location)
-
-    def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
-        """Execute one MKRF node through the installed FEMIC CLI."""
-        builders = _mkrf_command_builders()
-        return _execute_with_builder(
-            node=node,
-            node_type=node_type,
-            context=context,
-            provider_id=FEMIC_MKRF_PROVIDER_ID,
-            builders=builders,
-            runner=self._command_runner,
-        )
-
-
 def provider_factory() -> FemicFreshForgeProvider:
     """Return the FEMIC FreshForge provider for entry-point discovery."""
     return FemicFreshForgeProvider()
-
-
-def mkrf_provider_factory() -> FemicMkrfFreshForgeProvider:
-    """Return the MKRF FreshForge provider for entry-point discovery."""
-    return FemicMkrfFreshForgeProvider()
 
 
 def _provider_metadata(
@@ -526,16 +384,6 @@ def _generic_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...
     }
 
 
-def _mkrf_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...]]]:
-    return {
-        "build_au_inputs": _build_mkrf_au_inputs_command,
-        "select_aus": _build_mkrf_select_aus_command,
-        "build_managed_au_inputs": _build_mkrf_managed_au_inputs_command,
-        "build_managed_au_curves": _build_mkrf_managed_au_curves_command,
-        "init_runtime_package": _build_mkrf_init_runtime_package_command,
-    }
-
-
 def _build_validate_case_command(node: Any, _context: Any) -> tuple[str, ...]:
     rebuild_spec = _optional_parameter(node, "rebuild_spec")
     if rebuild_spec is not None:
@@ -645,119 +493,6 @@ def _build_matrix_build_command(node: Any, _context: Any) -> tuple[str, ...]:
         )
     )
     _append_option(command, node, "log_dir", "--log-dir")
-    return tuple(command)
-
-
-def _build_mkrf_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-build-au-inputs",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-            "--resultant-gdb",
-            _parameter(node, "resultant_gdb"),
-        )
-    )
-    _append_option(command, node, "output_dir", "--output-dir")
-    return tuple(command)
-
-
-def _build_mkrf_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-select-aus",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-        )
-    )
-    _append_option(command, node, "au_table_csv", "--au-table-csv")
-    _append_option(command, node, "assignment_csv", "--assignment-csv")
-    _append_option(command, node, "output_csv", "--output-csv")
-    _append_option(command, node, "target_coverage", "--target-coverage")
-    return tuple(command)
-
-
-def _build_mkrf_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-build-managed-au-inputs",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-            "--resultant-gdb",
-            _parameter(node, "resultant_gdb"),
-        )
-    )
-    _append_option(command, node, "tipsy_rules_yaml", "--tipsy-rules-yaml")
-    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
-    _append_option(command, node, "assignment_csv", "--assignment-csv")
-    _append_option(command, node, "output_dir", "--output-dir")
-    return tuple(command)
-
-
-def _build_mkrf_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-build-managed-au-curves",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-            "--run-id",
-            _parameter(node, "run_id"),
-        )
-    )
-    _append_option(command, node, "bootstrap_csv", "--bootstrap-csv")
-    _append_option(command, node, "msyt_csv", "--msyt-csv")
-    _append_option(command, node, "output_dir", "--output-dir")
-    _append_option(command, node, "log_dir", "--log-dir")
-    _append_option(command, node, "btc_executable", "--btc-executable")
-    return tuple(command)
-
-
-def _build_mkrf_init_runtime_package_command(
-    node: Any, _context: Any
-) -> tuple[str, ...]:
-    command = list(
-        _python_m_femic(
-            "instance",
-            "mkrf-init-runtime-package",
-            "--instance-root",
-            _parameter(node, "instance_root"),
-        )
-    )
-    _append_option(command, node, "package_root", "--package-root")
-    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
-    _append_option(
-        command,
-        node,
-        "stand_origin_assignment_csv",
-        "--stand-origin-assignment-csv",
-    )
-    _append_option(
-        command, node, "stand_au_assignment_csv", "--stand-au-assignment-csv"
-    )
-    _append_option(command, node, "managed_bootstrap_csv", "--managed-bootstrap-csv")
-    _append_option(
-        command, node, "first_growth_curves_csv", "--first-growth-curves-csv"
-    )
-    _append_option(
-        command,
-        node,
-        "first_growth_diagnostics_csv",
-        "--first-growth-diagnostics-csv",
-    )
-    _append_option(command, node, "managed_curves_csv", "--managed-curves-csv")
-    _append_option(
-        command, node, "managed_run_manifest_json", "--managed-run-manifest-json"
-    )
-    _append_option(
-        command,
-        node,
-        "bad_curve_audit_summary_csv",
-        "--bad-curve-audit-summary-csv",
-    )
     return tuple(command)
 
 

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -10,10 +10,7 @@ import yaml
 
 from femic.freshforge import (
     FEMIC_PROVIDER_ID,
-    FEMIC_MKRF_PROVIDER_ID,
     FemicFreshForgeProvider,
-    FemicMkrfFreshForgeProvider,
-    mkrf_provider_factory,
     provider_factory,
 )
 
@@ -21,26 +18,12 @@ freshforge = pytest.importorskip("freshforge")
 
 
 EXAMPLE_PATH = Path("examples/freshforge/model_build_workflow.yaml")
-MKRF_WORKFLOW_PATH = Path(
-    "external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml"
-)
 EXPECTED_GENERIC_MODEL_BUILD_ORDER = [
     "validate_case",
     "geospatial_preflight",
     "compile_upstream",
     "btc_post_tipsy",
     "export_patchworks",
-    "patchworks_preflight",
-    "matrix_build",
-]
-EXPECTED_MKRF_MODEL_BUILD_ORDER = [
-    "validate_case",
-    "geospatial_preflight",
-    "build_au_inputs",
-    "select_aus",
-    "build_managed_au_inputs",
-    "build_managed_au_curves",
-    "init_runtime_package",
     "patchworks_preflight",
     "matrix_build",
 ]
@@ -51,7 +34,6 @@ def _registry_with_femic_provider():
 
     registry = ProviderRegistry()
     registry.register(provider_factory())
-    registry.register(mkrf_provider_factory())
     return registry
 
 
@@ -163,23 +145,6 @@ def test_provider_factory_returns_femic_provider() -> None:
     assert provider_factory().metadata().id == FEMIC_PROVIDER_ID
 
 
-def test_mkrf_provider_metadata_serializes_deterministically() -> None:
-    metadata = mkrf_provider_factory().metadata()
-
-    assert metadata.id == FEMIC_MKRF_PROVIDER_ID
-    assert [node_type.id for node_type in metadata.node_types] == [
-        "build_au_inputs",
-        "select_aus",
-        "build_managed_au_inputs",
-        "build_managed_au_curves",
-        "init_runtime_package",
-    ]
-    assert metadata.to_dict()["node_types"][0]["parameters"] == [
-        "instance_root",
-        "resultant_gdb",
-    ]
-
-
 def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
@@ -188,7 +153,7 @@ def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     assert any("freshforge" in item for item in optional["dev"])
     entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
     assert entry_points["femic"] == "femic.freshforge:provider_factory"
-    assert entry_points["femic_mkrf"] == "femic.freshforge:mkrf_provider_factory"
+    assert "femic_mkrf" not in entry_points
 
 
 def test_femic_import_does_not_import_freshforge_eagerly() -> None:
@@ -285,7 +250,7 @@ def test_default_freshforge_registry_discovers_installed_femic_provider() -> Non
 
     assert not diagnostics
     assert registry.get("femic") is not None
-    assert registry.get("femic.mkrf") is not None
+    assert registry.get("femic.mkrf") is None
 
 
 def test_generic_provider_execution_constructs_femic_command() -> None:
@@ -327,45 +292,6 @@ def test_generic_provider_execution_constructs_femic_command() -> None:
     ]
 
 
-def test_mkrf_provider_execution_constructs_mkrf_command() -> None:
-    from freshforge.records import ExecutionContext, WorkflowNode
-
-    commands: list[tuple[str, ...]] = []
-    provider = FemicMkrfFreshForgeProvider(command_runner=_successful_runner(commands))
-    node_type = next(
-        item for item in provider.metadata().node_types if item.id == "build_au_inputs"
-    )
-    node = WorkflowNode(
-        id="build_au_inputs",
-        provider="femic.mkrf.build_au_inputs",
-        parameters={
-            "instance_root": ".",
-            "resultant_gdb": "data/source/03_MappingAnalysisData/Resultant.gdb",
-        },
-    )
-
-    result = provider.execute_node(
-        node,
-        node_type,
-        context=ExecutionContext(workflow_id="wf", run_id="run"),
-    )
-
-    assert result.diagnostics == ()
-    assert commands == [
-        (
-            sys.executable,
-            "-m",
-            "femic",
-            "instance",
-            "mkrf-build-au-inputs",
-            "--instance-root",
-            ".",
-            "--resultant-gdb",
-            "data/source/03_MappingAnalysisData/Resultant.gdb",
-        )
-    ]
-
-
 def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
     from freshforge.records import ExecutionContext, WorkflowNode
 
@@ -401,56 +327,3 @@ def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
     assert {diagnostic.code for diagnostic in result.diagnostics} == {
         "femic.execution.command.failed"
     }
-
-
-def test_mkrf_instance_workflow_validates_and_plans_when_available() -> None:
-    if not MKRF_WORKFLOW_PATH.exists():
-        pytest.skip("MKRF instance FreshForge workflow is not available")
-
-    from freshforge.loading import load_workflow
-    from freshforge.planning import create_run_plan
-    from freshforge.validation import validate_workflow_with_providers
-
-    spec, load_diagnostics = load_workflow(MKRF_WORKFLOW_PATH)
-    assert spec is not None
-    assert load_diagnostics == []
-    assert spec.id == "mkrf_model_build"
-
-    diagnostics = validate_workflow_with_providers(
-        spec,
-        registry=_registry_with_femic_provider(),
-        structural_diagnostics=load_diagnostics,
-    )
-    assert diagnostics == []
-
-    plan = create_run_plan(
-        spec,
-        diagnostics=diagnostics,
-        registry=_registry_with_femic_provider(),
-    )
-    assert not plan.has_errors
-    assert [node.id for node in plan.nodes] == EXPECTED_MKRF_MODEL_BUILD_ORDER
-    assert {node.provider_id for node in plan.nodes} == {"femic", "femic.mkrf"}
-
-
-def test_mkrf_instance_workflow_dry_run_when_available() -> None:
-    if not MKRF_WORKFLOW_PATH.exists():
-        pytest.skip("MKRF instance FreshForge workflow is not available")
-
-    from freshforge.execution import execute_workflow
-    from freshforge.loading import load_workflow
-
-    spec, load_diagnostics = load_workflow(MKRF_WORKFLOW_PATH)
-    assert spec is not None
-
-    report = execute_workflow(
-        spec,
-        run_id="mkrf_freshforge_exec",
-        diagnostics=load_diagnostics,
-        registry=_registry_with_femic_provider(),
-        dry_run=True,
-    )
-
-    assert not report.failed
-    assert report.dry_run
-    assert report.planned_order == tuple(EXPECTED_MKRF_MODEL_BUILD_ORDER)


### PR DESCRIPTION
﻿## Summary
- removes `femic.mkrf` provider ownership from FEMIC core
- keeps the generic executable `femic` FreshForge provider intact
- updates docs/tests/package metadata so FEMIC advertises only `femic`
- records P86 as the follow-on for extracting broader MKRF-specific core code
- updates the MKRF submodule pointer to the instance-owned `mkrf` adapter branch

## Verification
- `.\.venv\Scripts\python.exe -m pip install -e .[freshforge]`
- `.\.venv\Scripts\python.exe -m ruff check src tests`
- `.\.venv\Scripts\python.exe -m pytest tests/test_freshforge_integration.py`
- `.\.venv\Scripts\python.exe -m mypy src\femic\freshforge.py`
- `.\.venv\Scripts\sphinx-build.exe -b html docs _build\html -W`
- `.\.venv\Scripts\python.exe -m build`
- `.\.venv\Scripts\python.exe -m twine check dist\*`
- inspected parent wheel entry points: `[freshforge.providers] femic = femic.freshforge:provider_factory`
- inspected MKRF adapter wheel entry points: `[freshforge.providers] mkrf = mkrf_freshforge:provider_factory`

Depends on UBC-FRESH/femic-mkrf-instance#40.
Closes #241.
