### PR TITLE
Close P84 MKRF FreshForge execution acceptance

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18750,3 +18750,22 @@
   `No matching license` on this machine; and
 - kept P84/P84.5 open until Matrix Builder completes and the resulting
   manifest/output inspection is recorded.
+
+## 2026-07-01 - Completed P84 MKRF FreshForge execution acceptance
+
+- fixed the MKRF runtime-package metadata writer so tracked manifests and XML
+  source-contract records use portable repo-relative paths instead of
+  machine-specific absolute paths;
+- reran `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml
+  --run-id mkrf_freshforge_exec --report
+  runtime/freshforge/runs/mkrf_freshforge_exec.json --json` from the MKRF
+  instance after connecting through the UBC VPN;
+- verified the full nine-node FreshForge plan completed through Patchworks
+  Matrix Builder with `returncode=0`, `Done Matrix Builder.` in stderr, and
+  `accounts_sync.status=synced`;
+- inspected rebuilt track-table row counts: `features.csv` 98,413 rows,
+  `protoaccounts.csv` 62 rows, `accounts.csv` 62 rows, `curves.csv` 2,684,869
+  rows, and `products.csv` 140,196 rows; and
+- updated P84.4/#238 as complete while keeping P84.5 open until this
+  portable-artifact closeout branch lands and the final GitHub issue comments
+  are posted.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2417,23 +2417,23 @@ runtime-package regeneration and Patchworks Matrix Builder.
         model package paths.
   - [x] Update MKRF README/docs/runbook language from plan-only to explicit
         `freshforge run` execution.
-- [ ] P84.4 Validate MKRF FreshForge execution cycle (#238)
+- [x] P84.4 Validate MKRF FreshForge execution cycle (#238)
   - [x] Verify providers, validate, inspect, plan, and dry-run output.
   - [x] Attempt full local execution through Matrix Builder.
-  - [ ] Rerun after this machine has a usable Patchworks license; the previous
+  - [x] Rerun after this machine has a usable Patchworks license; the previous
         FreshForge run reached `femic patchworks matrix-build`, then Patchworks
         exited with `No matching license`.
   - [x] Inspect produced run reports, FEMIC logs, regenerated model-input
-        bundle files, and ForestModel XML.
-  - [ ] Inspect Matrix Builder manifest after the Patchworks license blocker is
+  bundle files, and ForestModel XML.
+  - [x] Inspect Matrix Builder manifest after the Patchworks license blocker is
         resolved.
 - [ ] P84.5 Close out execution integration (#239)
   - [x] Update roadmap and changelog closeout notes.
   - [x] Open PRs, merge implementation PRs, and verify checks.
   - [x] Record model-instance materialization as the next separate FreshForge
         workflow family.
-  - [ ] Close parent P84 only after P84.4/#238 Matrix Builder acceptance is
-        complete.
+  - [ ] Close parent P84 after the portable-artifact closeout branch lands and
+        the final issue comments are posted.
 
 Phase 84 deliberately does not add model-instance materialization workflow
 support. That is the next FreshForge deployment family after executable
@@ -2441,12 +2441,14 @@ workflow semantics are proven because it solves the separate user problem of
 bootstrapping Git, Python, DataLad, git-annex, special remotes, virtual
 environments, and required payload materialization before model workflows run.
 
-P84.5 remains open even though the implementation PRs have landed because
-P84.4/#238 has not yet proven a completed Matrix Builder run. The previous
-FreshForge run reached `femic patchworks matrix-build`, but Patchworks exited
-with `No matching license` on this machine. Do not close P84.5 or the P84
-parent issue until Matrix Builder completes and the resulting manifest/output
-inspection is recorded.
+P84.4/#238 is now validated. After connecting this machine through the UBC VPN,
+the MKRF FreshForge run completed all nine planned nodes through Patchworks
+Matrix Builder with `run_id=mkrf_freshforge_exec`; the Matrix Builder manifest
+reported `returncode=0`, stderr reported `Done Matrix Builder.`, and the tracks
+surface contained `features.csv` 98,413 rows, `protoaccounts.csv` 62 rows,
+`accounts.csv` 62 rows, `curves.csv` 2,684,869 rows, and `products.csv`
+140,196 rows. The remaining P84.5 closeout task is to land the portable tracked
+artifact fix, post the final GitHub comments, and close the parent issue.
 
 ## Phase 85: FreshForge Instance Provider Boundary Repair
 

--- a/src/femic/pipeline/mkrf_managed.py
+++ b/src/femic/pipeline/mkrf_managed.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
+import json
 from pathlib import Path
 from typing import Any, Mapping
-import json
 
 import numpy as np
 import pandas as pd
@@ -18,6 +19,18 @@ from femic.pipeline.tipsy import (
 
 _MANAGED_TIPSY_SPECIES_COLUMNS = ("BA", "CW", "DR", "FD", "HW", "PW", "SS", "YC")
 _DEFAULT_MANAGED_RULE_KEY = "families"
+
+
+def _portable_path_value(path: Path | str | None) -> str | None:
+    if path is None:
+        return None
+    candidate = Path(path)
+    try:
+        return os.path.relpath(candidate.resolve(), Path.cwd().resolve()).replace(
+            "\\", "/"
+        )
+    except Exception:
+        return candidate.name
 
 
 @dataclass(frozen=True)
@@ -328,7 +341,7 @@ def build_mkrf_managed_au_bootstrap_table(
             "leading_species_1": str(selected_row["leading_species_1"]),
             "leading_species_2": str(selected_row["leading_species_2"]),
             "managed_curve_id": 60000 + int(selected_row["selected_rank"]),
-            "managed_rule_source": str(rule_config.path.as_posix()),
+            "managed_rule_source": _portable_path_value(rule_config.path),
             "origin_fire_min_age": float(rule_config.fire_origin_min_age),
             "origin_classification": "AGE_2020 threshold",
             "logging_origin_stand_count": int(

--- a/src/femic/workflows/mkrf.py
+++ b/src/femic/workflows/mkrf.py
@@ -2879,7 +2879,7 @@ def initialize_mkrf_runtime_package(
         ("speciesShareAuditCsv", species_share_audit_path),
     ):
         child = et.SubElement(source_node, tag)
-        child.text = str(path.resolve())
+        child.text = _manifest_path_value(path)
     aus_node = et.SubElement(root, "analysisUnits")
     for row in runtime_curve_status.itertuples(index=False):
         au_node = et.SubElement(aus_node, "au")
@@ -4200,40 +4200,56 @@ def initialize_mkrf_runtime_package(
 
     manifest_payload = {
         "schema_version": 1,
-        "package_root": str(package_root),
+        "package_root": _manifest_path_value(package_root),
         "runtime_generation_status": "initialized_only",
         "source_contracts": {
-            "selected_au_csv": str(selected_au_csv.resolve()),
-            "stand_origin_assignment_csv": str(stand_origin_assignment_csv.resolve()),
-            "stand_au_assignment_csv": str(stand_au_assignment_csv.resolve()),
-            "managed_bootstrap_csv": str(managed_bootstrap_csv.resolve()),
-            "first_growth_curves_csv": str(first_growth_curves_csv.resolve()),
-            "first_growth_diagnostics_csv": str(first_growth_diagnostics_csv.resolve()),
-            "managed_curves_csv": str(managed_curves_csv.resolve()),
-            "managed_run_manifest_json": str(managed_run_manifest_json.resolve()),
-            "bad_curve_audit_summary_csv": str(bad_curve_audit_summary_csv.resolve()),
-            "runtime_curve_status_csv": str(curve_status_path.resolve()),
-            "analysis_au_runtime_status_csv": str(
-                analysis_au_runtime_status_path.resolve()
+            "selected_au_csv": _manifest_path_value(selected_au_csv),
+            "stand_origin_assignment_csv": _manifest_path_value(
+                stand_origin_assignment_csv
             ),
-            "analysis_au_curve_refs_csv": str(analysis_au_curve_refs_path.resolve()),
-            "runtime_au_remap_audit_csv": str(runtime_au_remap_audit_path.resolve()),
-            "runtime_species_share_audit_csv": str(species_share_audit_path.resolve()),
-            "ct_eligibility_audit_csv": str(ct_eligibility_audit_path.resolve()),
-            "ct_intensity_audit_csv": str(ct_intensity_audit_path.resolve()),
-            "ct_intensity_summary_csv": str(ct_intensity_summary_path.resolve()),
-            "hw_ingrowth_overlay_audit_csv": str(
-                hw_ingrowth_overlay_audit_path.resolve()
+            "stand_au_assignment_csv": _manifest_path_value(stand_au_assignment_csv),
+            "managed_bootstrap_csv": _manifest_path_value(managed_bootstrap_csv),
+            "first_growth_curves_csv": _manifest_path_value(first_growth_curves_csv),
+            "first_growth_diagnostics_csv": _manifest_path_value(
+                first_growth_diagnostics_csv
             ),
-            "hw_ingrowth_overlay_summary_csv": str(
-                hw_ingrowth_overlay_summary_path.resolve()
+            "managed_curves_csv": _manifest_path_value(managed_curves_csv),
+            "managed_run_manifest_json": _manifest_path_value(
+                managed_run_manifest_json
             ),
-            "runtime_curve_contract_xml": str(xml_contract_path.resolve()),
-            "runtime_curve_bank_xml": str(xml_curve_bank_path.resolve()),
-            "forestmodel_xml": str(forestmodel_xml_path.resolve()),
-            "analysis_pin": str(analysis_pin_path.resolve()),
-            "headless_runtime_common_bsh": str(headless_runtime_common_path.resolve()),
-            "flow_targets_bsh": str(flow_targets_script_path.resolve()),
+            "bad_curve_audit_summary_csv": _manifest_path_value(
+                bad_curve_audit_summary_csv
+            ),
+            "runtime_curve_status_csv": _manifest_path_value(curve_status_path),
+            "analysis_au_runtime_status_csv": _manifest_path_value(
+                analysis_au_runtime_status_path
+            ),
+            "analysis_au_curve_refs_csv": _manifest_path_value(
+                analysis_au_curve_refs_path
+            ),
+            "runtime_au_remap_audit_csv": _manifest_path_value(
+                runtime_au_remap_audit_path
+            ),
+            "runtime_species_share_audit_csv": _manifest_path_value(
+                species_share_audit_path
+            ),
+            "ct_eligibility_audit_csv": _manifest_path_value(ct_eligibility_audit_path),
+            "ct_intensity_audit_csv": _manifest_path_value(ct_intensity_audit_path),
+            "ct_intensity_summary_csv": _manifest_path_value(ct_intensity_summary_path),
+            "hw_ingrowth_overlay_audit_csv": _manifest_path_value(
+                hw_ingrowth_overlay_audit_path
+            ),
+            "hw_ingrowth_overlay_summary_csv": _manifest_path_value(
+                hw_ingrowth_overlay_summary_path
+            ),
+            "runtime_curve_contract_xml": _manifest_path_value(xml_contract_path),
+            "runtime_curve_bank_xml": _manifest_path_value(xml_curve_bank_path),
+            "forestmodel_xml": _manifest_path_value(forestmodel_xml_path),
+            "analysis_pin": _manifest_path_value(analysis_pin_path),
+            "headless_runtime_common_bsh": _manifest_path_value(
+                headless_runtime_common_path
+            ),
+            "flow_targets_bsh": _manifest_path_value(flow_targets_script_path),
         },
         "counts": {
             "selected_au_count": selected_au_count,

--- a/tests/test_mkrf_managed.py
+++ b/tests/test_mkrf_managed.py
@@ -338,6 +338,8 @@ def test_build_mkrf_managed_au_bootstrap_table_uses_expert_rules_and_si_fallback
     assert vm1["managed_species_3"] == "PW"
     assert vm1["density_total"] == 1500
     assert bool(vm1["ct_eligible"]) is True
+    assert vm1["managed_rule_source"].endswith("tsamkrf.yaml")
+    assert ":" not in vm1["managed_rule_source"]
 
     vm2 = out.loc[out["au_id"] == "cwh_vm_2_cw_hw"].iloc[0]
     assert vm2["bootstrap_status"] == "expert_rule"

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from xml.etree import ElementTree as et
 
 import pandas as pd
 import pytest
 
 from femic.workflows.mkrf import (
-    audit_mkrf_runtime_sanity,
     _build_unmanaged_species_share_table,
+    _manifest_path_value,
+    audit_mkrf_runtime_sanity,
     initialize_mkrf_runtime_package,
 )
 
@@ -272,35 +274,50 @@ def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None
     assert payload["counts"]["first_growth_missing_au_count"] == 1
     assert payload["counts"]["managed_only_runtime_au_count"] == 1
     assert payload["curve_policy"]["first_growth_borrowing_allowed"] is False
-    assert payload["source_contracts"]["stand_origin_assignment_csv"] == str(
-        stand_origin_assignment_csv.resolve()
+    assert payload["package_root"] == _manifest_path_value(package_root)
+    assert payload["source_contracts"]["stand_origin_assignment_csv"] == (
+        _manifest_path_value(stand_origin_assignment_csv)
     )
-    assert payload["source_contracts"]["stand_au_assignment_csv"] == str(
-        stand_au_assignment_csv.resolve()
+    assert payload["source_contracts"]["stand_au_assignment_csv"] == (
+        _manifest_path_value(stand_au_assignment_csv)
     )
-    assert payload["source_contracts"]["managed_bootstrap_csv"] == str(
-        managed_bootstrap_csv.resolve()
+    assert payload["source_contracts"]["managed_bootstrap_csv"] == (
+        _manifest_path_value(managed_bootstrap_csv)
     )
-    assert payload["source_contracts"]["runtime_au_remap_audit_csv"] == str(
-        result.runtime_au_remap_audit_path.resolve()
+    assert payload["source_contracts"]["runtime_au_remap_audit_csv"] == (
+        _manifest_path_value(result.runtime_au_remap_audit_path)
     )
-    assert payload["source_contracts"]["runtime_species_share_audit_csv"] == str(
-        result.species_share_audit_path.resolve()
+    assert payload["source_contracts"]["runtime_species_share_audit_csv"] == (
+        _manifest_path_value(result.species_share_audit_path)
     )
-    assert payload["source_contracts"]["analysis_pin"] == str(
-        result.analysis_pin_path.resolve()
+    assert payload["source_contracts"]["analysis_pin"] == _manifest_path_value(
+        result.analysis_pin_path
     )
-    assert payload["source_contracts"]["headless_runtime_common_bsh"] == str(
-        result.headless_runtime_common_path.resolve()
+    assert payload["source_contracts"]["headless_runtime_common_bsh"] == (
+        _manifest_path_value(result.headless_runtime_common_path)
     )
-    assert payload["source_contracts"]["flow_targets_bsh"] == str(
-        result.flow_targets_script_path.resolve()
+    assert payload["source_contracts"]["flow_targets_bsh"] == _manifest_path_value(
+        result.flow_targets_script_path
     )
     assert (
         payload["managed_only_runtime_policy"]["insufficient_support_borrowing"]
         == "forbidden"
     )
     assert payload["runtime_au_normalization"]["remapped_source_au_count"] == 1
+
+    xml_root = et.parse(result.xml_contract_path).getroot()
+    source_contracts_node = xml_root.find("sourceContracts")
+    assert source_contracts_node is not None
+    xml_source_contracts = {child.tag: child.text for child in source_contracts_node}
+    assert xml_source_contracts["standOriginAssignmentCsv"] == _manifest_path_value(
+        stand_origin_assignment_csv
+    )
+    assert xml_source_contracts["managedBootstrapCsv"] == _manifest_path_value(
+        managed_bootstrap_csv
+    )
+    assert xml_source_contracts["runtimeCurveStatusCsv"] == _manifest_path_value(
+        result.curve_status_path
+    )
 
     curve_status = pd.read_csv(result.curve_status_path)
     assert curve_status["au_id"].tolist() == ["cwh_vm_1_dr_hw", "cwh_vm_1_hw_cw"]


### PR DESCRIPTION
﻿## Summary

This PR closes the P84 Matrix Builder acceptance gap after the successful MKRF FreshForge execution run and fixes the portability issue found in tracked MKRF runtime metadata.

## Changes

- serializes MKRF runtime-package manifest and XML source-contract paths as portable cwd-relative paths instead of machine-specific absolute paths;
- serializes MKRF managed-rule source paths as portable relative paths;
- adds regression tests for the portable path behavior;
- updates `ROADMAP.md` to mark P84.4 complete and leave only final P84.5 issue closeout pending;
- appends the P84 Matrix Builder success evidence to `CHANGE_LOG.md`;
- updates the MKRF submodule pointer to `UBC-FRESH/femic-mkrf-instance#41` content.

## Validation

- `python -m ruff check src tests`
- `python -m pytest tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py tests/test_freshforge_integration.py -q`
- `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json --json`
- tracked-artifact scan for `C:\Users`, old `F:\projects`, and parent-prefixed `external/femic-mkrf-instance` paths returned no matches
- `python -m build`
- `python -m twine check dist/*`

Matrix Builder evidence from the full run:

- full nine-node FreshForge plan completed with `ok: true`;
- Matrix Builder node returned `returncode=0`;
- Matrix Builder stderr reported `Done Matrix Builder.`;
- managed/passive area lines were present: total 4,810.850281521678 ha, managed 3,653.2659247091565 ha, passive 1,157.5843568125133 ha, exclude 0.0 ha;
- rebuilt track row counts were `features.csv` 98,413, `protoaccounts.csv` 62, `accounts.csv` 62, `curves.csv` 2,684,869, and `products.csv` 140,196.

## Known Validation Caveat

Targeted `mypy` against `src/femic/pipeline/mkrf_managed.py` and `src/femic/workflows/mkrf.py` still fails on existing missing stubs for pandas/geopandas/seaborn and older type issues in `mkrf.py`. This PR does not add new mypy suppressions or attempt the broader typing cleanup.

## Merge Order

Merge `UBC-FRESH/femic-mkrf-instance#41` first, then update/reconcile this submodule pointer if GitHub rewrites the MKRF commit on merge.
