### PR TITLE
P88: Define instance extension boundaries

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18860,3 +18860,25 @@
   synchronized; and
 - left the broader K3Z/TSA29/TFL6 instance-reference cleanup and packaged
   Patchworks variant registry cleanup as follow-on lanes.
+
+## 2026-07-01 - Opened P88-P94 instance boundary decoupling sequence
+
+- opened parent FEMIC issues `#248` through `#254` for the full arms-length
+  separation of FEMIC core from example instance repositories;
+- added the P88-P94 roadmap sequence, starting with an instance-extension
+  boundary phase before the K3Z, TSA29, Patchworks registry, catalog, and final
+  closeout extraction phases;
+- documented the core-vs-instance ownership contract in the technical docs; and
+- added a source audit guard that freezes the current named-instance reference
+  baseline under `src/femic` so later phases can reduce the coupling without
+  allowing new instance-specific references to enter core.
+
+## 2026-07-01 - Completed P88 instance extension boundary guard
+
+- linked the new instance-extension boundary contract into the technical docs;
+- verified the named-instance source guard with
+  `pytest tests/test_instance_extension_boundaries.py`;
+- verified the docs surface with `sphinx-build -b html docs _build/html -W`;
+  and
+- marked P88 complete in `ROADMAP.md`, leaving P89 as the next implementation
+  lane for extracting K3Z bindings and pipeline policies.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2579,6 +2579,100 @@ merged to MKRF `main`, the parent submodule pointer was reconciled to merged
 MKRF commit `c769e4c`, and parent PR `#247` passed package and docs checks
 before merge.
 
+## Phase 88: Define Instance Extension Boundaries for Arms-Length Example Repos
+
+Parent issue: #248
+
+Branch: `feature/p88-instance-extension-boundaries`
+
+Status: complete
+
+Goal: define and begin enforcing the boundary that FEMIC core must not depend
+on named example instances linked under `external/`. FEMIC core owns generic
+engines, schemas, runners, validators, registry loading, and CLI plumbing.
+Instance repositories own instance-specific data, policies, registries,
+workflows, adapters, and scientific interpretation.
+
+- [x] P88.1 Record lifecycle and roadmap surfaces
+  - [x] Open parent FEMIC issue `#248`.
+  - [x] Open follow-on phase issues `#249` through `#254`.
+  - [x] Update `ROADMAP.md` and `CHANGE_LOG.md` with the P88-P94 sequence.
+- [x] P88.2 Document the boundary contract
+  - [x] Add an instance-extension boundary contract to the technical docs.
+  - [x] State that example submodules are deployments, not core package
+        dependencies.
+- [x] P88.3 Add a source audit guard
+  - [x] Capture the current named-instance reference baseline from `src/femic`.
+  - [x] Add a regression test that rejects new or increased named-instance
+        references unless deliberately allowlisted during migration.
+- [x] P88.4 Verify and close out P88
+  - [x] Run focused tests for the new source audit guard.
+  - [x] Run Sphinx warning-clean docs build.
+  - [x] Post progress comments on issue `#248`.
+
+## Phase 89: Extract K3Z Bindings and Pipeline Policies From FEMIC Core
+
+Parent issue: #249
+
+Status: planned
+
+Goal: create a K3Z-owned package/config surface and move K3Z-specific FMG
+adapter bindings, source filenames, run defaults, plot limits, target-stratum
+defaults, and VDYP fit-policy decisions out of `src/femic`.
+
+## Phase 90: Extract TSA29 Strict Locked-Chain Workflow From FEMIC Core
+
+Parent issue: #250
+
+Status: planned
+
+Goal: define a generic locked-chain validation interface, then move TSA29
+locked-chain row ordering, ledger interpretation, checkpoint restrictions,
+strict-chain preflight, and strict-sequence execution into a TSA29-owned
+package or adapter.
+
+## Phase 91: Split TSR Engine From TSA29 Adjudication Overlays
+
+Parent issue: #251
+
+Status: planned
+
+Goal: keep generic TSR discovery, extraction, recipe execution, schemas, and
+report primitives in FEMIC core while moving TSA29 interpretation text, no-op
+decisions, gap overrides, and comparison-report special cases into
+instance-owned overlays.
+
+## Phase 92: Externalize Patchworks Variant Registries
+
+Parent issue: #252
+
+Status: planned
+
+Goal: extend Patchworks variant loading so instance packages and explicit
+registry files can provide variants, then move K3Z and MKRF variant definitions
+out of FEMIC core packaged resources.
+
+## Phase 93: Remove Built-In Example Instance Catalog From FEMIC Core
+
+Parent issue: #253
+
+Status: planned
+
+Goal: replace the packaged K3Z/TSA29 built-in instance catalog with external
+catalog discovery or explicit user catalog files. FEMIC core should not ship
+named example instance metadata by default.
+
+## Phase 94: Complete Core Decoupling From Example Instances
+
+Parent issue: #254
+
+Status: planned
+
+Goal: scrub remaining named-instance references from `src/femic`, packaged
+resources, generic templates, and generic CLI help. Close the umbrella only
+after tests prove FEMIC core imports, builds, and passes generic checks without
+example submodules present.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2591,6 +2685,13 @@ before merge.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P89` / `#249` is the next boundary-cleanup lane: create a K3Z-owned
+    package/config surface and move K3Z-specific FMG bindings and pipeline
+    policies out of `src/femic`.
+  - `P88` / `#248` is complete locally: the arms-length extension boundary is
+    documented, P89-P94 issues are open, and a source guard now prevents new
+    named-instance references from entering `src/femic` without an explicit
+    roadmap-linked allowlist update.
   - `P87` / `#246` is complete: the remaining MKRF-specific legacy ForestModel
     XML builder moved from parent `femic.fmg` into the MKRF instance package
     under `mkrf_femic.legacy_xml`; MKRF PR

--- a/docs/reference/contracts/index.rst
+++ b/docs/reference/contracts/index.rst
@@ -30,5 +30,6 @@ Contract Pages
    patchworks-model-semantics
    repo-runtime-invariants
    instance-and-data-roots
+   instance-extension-boundaries
    stage-boundaries-and-canonical-artifacts
    recovery-and-external-runtime-boundaries

--- a/docs/reference/contracts/instance-extension-boundaries.rst
+++ b/docs/reference/contracts/instance-extension-boundaries.rst
@@ -1,0 +1,56 @@
+Instance Extension Boundaries
+=============================
+
+FEMIC core must be usable without any particular example model instance checked
+out under ``external/``.
+
+Ownership Contract
+------------------
+
+FEMIC core owns reusable modelling infrastructure:
+
+- schemas, validators, loaders, and report primitives;
+- generic pipeline stages and stage runners;
+- generic Patchworks, BTC, VDYP, TSR, DataLad, and FreshForge integration
+  surfaces;
+- extension discovery and registry merge logic; and
+- CLI plumbing that delegates to generic engines or explicitly discovered
+  extensions.
+
+Instance repositories own instance-specific modelling content:
+
+- source-data bindings, accepted filenames, and reviewed overlays;
+- model-specific run profiles, policy decisions, and workflow graphs;
+- Patchworks variant/scenario registry entries;
+- FreshForge providers or nodes whose semantics only make sense for one
+  instance;
+- TSR/THLB adjudication choices and locked-chain ledgers; and
+- package entry points or registry files that advertise the instance to FEMIC
+  or FreshForge.
+
+The parent repository may link example instances as Git submodules for
+developer convenience, but the installable FEMIC package must not assume those
+submodules exist, keep their current names, or are materialized.
+
+Allowed Coupling During Migration
+----------------------------------
+
+The current source tree still contains named-instance references that predate
+this contract. They are migration debt, not precedent.
+
+Until the decoupling phases are complete, new named-instance references under
+``src/femic`` must be rejected unless they are deliberately added to the
+temporary migration allowlist and tied to an active roadmap phase. Existing
+allowlisted references should only decrease over time.
+
+Target Extension Shape
+----------------------
+
+Instance-owned packages should expose metadata through explicit registries or
+Python entry points. FEMIC core should merge those registrations with
+user-supplied registry files and should report missing extensions as clear
+configuration errors rather than import failures or broken default paths.
+
+Curated examples such as K3Z, TSA29, MKRF, and TFL6 may remain in the source
+checkout as submodules, but they are deployments of FEMIC, not dependencies of
+FEMIC core.

--- a/tests/test_instance_extension_boundaries.py
+++ b/tests/test_instance_extension_boundaries.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+INSTANCE_REFERENCE_TERMS = (
+    "mkrf",
+    "k3z",
+    "tsa29",
+    "tsa_29",
+    "tfl6",
+    "femic-mkrf-instance",
+    "femic-k3z-instance",
+    "femic-tsa29-instance",
+    "femic-tfl6-instance",
+)
+
+
+# P88 migration baseline. These counts are maximums, not required counts: later
+# extraction phases are expected to drive them down to zero.
+ALLOWED_INSTANCE_REFERENCE_COUNTS = {
+    "src/femic/named_pipelines.py": {"tsa29": 21},
+    "src/femic/patchworks_runtime.py": {"k3z": 2},
+    "src/femic/cli/main.py": {"k3z": 3, "tsa29": 2},
+    "src/femic/fmg/adapters.py": {"k3z": 10},
+    "src/femic/pipeline/plots.py": {"k3z": 1},
+    "src/femic/pipeline/tsa.py": {"k3z": 3},
+    "src/femic/pipeline/vdyp_overrides.py": {"tsa29": 1},
+    "src/femic/pipeline/vdyp_stage.py": {"k3z": 8},
+    "src/femic/tsr_catalog/recipes.py": {
+        "tsa29": 61,
+        "tsa_29": 1,
+        "femic-tsa29-instance": 4,
+    },
+    "src/femic/resources/builtins/instances.builtin.yaml": {
+        "k3z": 4,
+        "tsa29": 5,
+        "femic-k3z-instance": 2,
+        "femic-tsa29-instance": 2,
+    },
+    "src/femic/resources/patchworks/btc_indicator_bank_compile_recipes.yaml": {"k3z": 2},
+    "src/femic/resources/patchworks/variants.builtin.yaml": {
+        "mkrf": 19,
+        "k3z": 117,
+        "femic-mkrf-instance": 6,
+        "femic-k3z-instance": 45,
+    },
+    "src/femic/resources/instance/config/patchworks.runtime.windows.yaml": {"k3z": 3},
+    "src/femic/resources/instance/config/tipsy/template.case.yaml": {"k3z": 1},
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _count_instance_references(path: Path) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    return {
+        term: len(re.findall(re.escape(term), text, flags=re.IGNORECASE))
+        for term in INSTANCE_REFERENCE_TERMS
+        if re.search(re.escape(term), text, flags=re.IGNORECASE)
+    }
+
+
+def test_no_new_named_instance_references_enter_femic_core() -> None:
+    root = _repo_root()
+    actual: dict[str, dict[str, int]] = {}
+    for path in (root / "src" / "femic").rglob("*"):
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        counts = _count_instance_references(path)
+        if counts:
+            actual[path.relative_to(root).as_posix()] = counts
+
+    violations: list[str] = []
+    for path, counts in sorted(actual.items()):
+        allowed_for_path = ALLOWED_INSTANCE_REFERENCE_COUNTS.get(path, {})
+        for term, count in sorted(counts.items()):
+            allowed = allowed_for_path.get(term, 0)
+            if count > allowed:
+                violations.append(f"{path}: {term} count {count} exceeds allowed {allowed}")
+
+    assert not violations, (
+        "Named example-instance references in src/femic are migration debt. "
+        "Move new instance-specific behavior into an instance package or update "
+        "the P88 migration allowlist with a roadmap-linked rationale.\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

Implements P88 as the enabling boundary phase for the P88-P94 arms-length decoupling sequence.

- records P88-P94 in `ROADMAP.md` with linked issues #248 through #254;
- adds the technical contract page `docs/reference/contracts/instance-extension-boundaries.rst`;
- links the new contract into the technical contracts docs index;
- adds `tests/test_instance_extension_boundaries.py`, which freezes the current named-instance references under `src/femic` as maximum allowed migration counts; and
- updates `CHANGE_LOG.md` and Detailed Next Steps so P89 is the next implementation lane.

## Validation

- `python -m pytest tests/test_instance_extension_boundaries.py`
- `python -m ruff check tests/test_instance_extension_boundaries.py`
- `sphinx-build -b html docs _build/html -W`

## Notes

The local `external/femic-public-data` submodule state is unrelated and intentionally left untouched.