### PR TITLE
P90: extract TSA29 strict-chain named-pipeline contract

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18933,3 +18933,15 @@
   `acd87a1`; and
 - marked P89 complete in `ROADMAP.md`, leaving P90 as the next named-instance
   boundary extraction lane.
+
+## 2026-07-01 - Opened P90 TSA29 strict-chain extraction
+
+- created parent branch `feature/p90-extract-tsa29-strict-chain`;
+- created TSA29 branch `feature/tsa29-femic-strict-chain`;
+- linked parent issue `#250` with TSA29 instance issue
+  `UBC-FRESH/femic-tsa29-instance#15`;
+- recorded the P90 task breakdown in `ROADMAP.md`; and
+- locked the boundary: P90 moves only the TSA29 strict locked-chain
+  named-pipeline contract into the TSA29 instance package while leaving TSR
+  adjudication overlays, Patchworks variants, and instance catalogs to later
+  phases.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18983,3 +18983,11 @@
   `2817710`; and
 - left parent P90 merge as the only remaining P90.4 closeout item pending
   parent PR checks.
+
+## 2026-07-01 - Closed P90 TSA29 strict-chain extraction
+
+- parent PR `#257` passed GitHub docs and package-release checks after the
+  TSA29 submodule pointer update;
+- marked P90 complete in `ROADMAP.md`; and
+- P90 closes with FEMIC core owning generic named-pipeline contract dispatch
+  while TSA29 owns the `tsa29_locked_chain_strict` implementation.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18945,3 +18945,15 @@
   named-pipeline contract into the TSA29 instance package while leaving TSR
   adjudication overlays, Patchworks variants, and instance catalogs to later
   phases.
+
+## 2026-07-01 - Implemented P90 named-pipeline contract handler seam
+
+- added `femic.named_pipelines.NamedPipelineContractHandler` with explicit
+  registration and `femic.named_pipeline_contracts` entry-point discovery;
+- replaced the embedded TSA29 strict-chain branches in `run_named_pipeline_runbook`
+  with contract-handler dispatch and clear missing-handler errors;
+- moved TSA29 strict-chain behavior into the TSA29 instance package
+  `tsa29_femic`; and
+- updated focused parent tests so FEMIC core covers generic contract-handler
+  registration, discovery, duplicate handling, pre-default dispatch, and
+  post-default validation without carrying TSA29 contract implementation tests.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18975,3 +18975,11 @@
   - `python -m build` plus `twine check dist/*`.
 - Editable entry-point discovery resolved
   `tsa29_locked_chain_strict = tsa29_femic.locked_chain:provider_factory`.
+
+## 2026-07-01 - Reconciled P90 TSA29 submodule pointer
+
+- merged TSA29 PR `UBC-FRESH/femic-tsa29-instance#16`;
+- updated the parent FEMIC submodule pointer to TSA29 main commit
+  `2817710`; and
+- left parent P90 merge as the only remaining P90.4 closeout item pending
+  parent PR checks.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18957,3 +18957,21 @@
 - updated focused parent tests so FEMIC core covers generic contract-handler
   registration, discovery, duplicate handling, pre-default dispatch, and
   post-default validation without carrying TSA29 contract implementation tests.
+
+## 2026-07-01 - Verified P90 focused checks before PR
+
+- Parent FEMIC checks passed:
+  - `ruff check src tests`;
+  - `mypy src/femic/named_pipelines.py`;
+  - focused pytest for named pipelines, pipeline CLI output, and the
+    instance-extension boundary guard;
+  - `sphinx-build -b html docs _build/html -W`; and
+  - `python -m build` plus `twine check dist/*`.
+- TSA29 instance checks passed:
+  - `python -m pip install -e .[dev]`;
+  - `ruff check src tests`;
+  - `pytest`;
+  - `sphinx-build -b html docs docs/_build/html -W`; and
+  - `python -m build` plus `twine check dist/*`.
+- Editable entry-point discovery resolved
+  `tsa29_locked_chain_strict = tsa29_femic.locked_chain:provider_factory`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2651,7 +2651,7 @@ defaults, and VDYP fit-policy decisions out of `src/femic`.
 Parent issue: #250
 Instance issue: UBC-FRESH/femic-tsa29-instance#15
 
-Status: active
+Status: complete
 
 Goal: define a generic locked-chain validation interface, then move TSA29
 locked-chain row ordering, ledger interpretation, checkpoint restrictions,
@@ -2677,13 +2677,13 @@ package or adapter.
   - [x] Move TSA29 row-order, ledger, preflight, GLB materialization, strict
         sequence, and ledger-validation logic into `tsa29_femic`.
   - [x] Migrate TSA29-specific strict-chain tests into the TSA29 package.
-- [ ] P90.4 Verify and close out
+- [x] P90.4 Verify and close out
   - [x] Run focused parent checks for named pipelines, boundary guard, typing,
         docs, and package artifacts.
   - [x] Run focused TSA29 package checks.
   - [x] Merge TSA29 first and update the parent submodule pointer to the
         merged TSA29 main commit.
-  - [ ] Merge parent P90 after PR checks pass.
+  - [x] Merge parent P90 after PR checks pass.
 
 ## Phase 91: Split TSR Engine From TSA29 Adjudication Overlays
 
@@ -2739,9 +2739,13 @@ example submodules present.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P90` / `#250` is active: add the generic named-pipeline contract-handler
-    seam and move the TSA29 strict locked-chain contract into the TSA29
-    instance package under issue `UBC-FRESH/femic-tsa29-instance#15`.
+  - `P91` / `#251` is next: keep generic TSR machinery in FEMIC core while
+    moving TSA29 adjudication overlays and interpretation text into
+    instance-owned surfaces.
+  - `P90` / `#250` is complete: generic named-pipeline contract-handler
+    dispatch now lives in FEMIC core, and the TSA29 strict locked-chain
+    contract implementation lives in the TSA29 instance package under issue
+    `UBC-FRESH/femic-tsa29-instance#15`.
   - `P89` / `#249` is complete: K3Z-owned package/config surfaces now own the
     K3Z FMG auxiliary support and pipeline policy defaults.
   - `P88` / `#248` is complete locally: the arms-length extension boundary is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2681,8 +2681,9 @@ package or adapter.
   - [x] Run focused parent checks for named pipelines, boundary guard, typing,
         docs, and package artifacts.
   - [x] Run focused TSA29 package checks.
-  - [ ] Merge TSA29 first, update the parent submodule pointer, then merge
-        parent P90.
+  - [x] Merge TSA29 first and update the parent submodule pointer to the
+        merged TSA29 main commit.
+  - [ ] Merge parent P90 after PR checks pass.
 
 ## Phase 91: Split TSR Engine From TSA29 Adjudication Overlays
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2649,13 +2649,40 @@ defaults, and VDYP fit-policy decisions out of `src/femic`.
 ## Phase 90: Extract TSA29 Strict Locked-Chain Workflow From FEMIC Core
 
 Parent issue: #250
+Instance issue: UBC-FRESH/femic-tsa29-instance#15
 
-Status: planned
+Status: active
 
 Goal: define a generic locked-chain validation interface, then move TSA29
 locked-chain row ordering, ledger interpretation, checkpoint restrictions,
 strict-chain preflight, and strict-sequence execution into a TSA29-owned
 package or adapter.
+
+- [ ] P90.1 Record lifecycle and planning surfaces
+  - [x] Create parent branch `feature/p90-extract-tsa29-strict-chain`.
+  - [x] Create TSA29 branch `feature/tsa29-femic-strict-chain`.
+  - [x] Link parent issue `#250` and TSA29 issue
+        `UBC-FRESH/femic-tsa29-instance#15`.
+  - [ ] Record matching starting notes in parent and TSA29 changelogs.
+- [ ] P90.2 Add generic named-pipeline contract-handler seam
+  - [ ] Define the contract handler protocol and registration/discovery API.
+  - [ ] Replace TSA29-specific branches in `femic.named_pipelines` with
+        handler dispatch and clear missing-handler errors.
+  - [ ] Add fixture-handler tests for explicit registration, discovery,
+        duplicate handling, and generic dispatch.
+- [ ] P90.3 Move TSA29 strict-chain contract into instance ownership
+  - [ ] Add installable `tsa29_femic` package in the TSA29 instance repo.
+  - [ ] Register `tsa29_locked_chain_strict` through
+        `femic.named_pipeline_contracts`.
+  - [ ] Move TSA29 row-order, ledger, preflight, GLB materialization, strict
+        sequence, and ledger-validation logic into `tsa29_femic`.
+  - [ ] Migrate TSA29-specific strict-chain tests into the TSA29 package.
+- [ ] P90.4 Verify and close out
+  - [ ] Run focused parent checks for named pipelines, boundary guard, typing,
+        docs, and package artifacts.
+  - [ ] Run focused TSA29 package checks.
+  - [ ] Merge TSA29 first, update the parent submodule pointer, then merge
+        parent P90.
 
 ## Phase 91: Split TSR Engine From TSA29 Adjudication Overlays
 
@@ -2711,8 +2738,11 @@ example submodules present.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P89` / `#249` is active: create a K3Z-owned package/config surface and
-    move K3Z-specific FMG bindings and pipeline policies out of `src/femic`.
+  - `P90` / `#250` is active: add the generic named-pipeline contract-handler
+    seam and move the TSA29 strict locked-chain contract into the TSA29
+    instance package under issue `UBC-FRESH/femic-tsa29-instance#15`.
+  - `P89` / `#249` is complete: K3Z-owned package/config surfaces now own the
+    K3Z FMG auxiliary support and pipeline policy defaults.
   - `P88` / `#248` is complete locally: the arms-length extension boundary is
     documented, P89-P94 issues are open, and a source guard now prevents new
     named-instance references from entering `src/femic` without an explicit

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2678,9 +2678,9 @@ package or adapter.
         sequence, and ledger-validation logic into `tsa29_femic`.
   - [x] Migrate TSA29-specific strict-chain tests into the TSA29 package.
 - [ ] P90.4 Verify and close out
-  - [ ] Run focused parent checks for named pipelines, boundary guard, typing,
+  - [x] Run focused parent checks for named pipelines, boundary guard, typing,
         docs, and package artifacts.
-  - [ ] Run focused TSA29 package checks.
+  - [x] Run focused TSA29 package checks.
   - [ ] Merge TSA29 first, update the parent submodule pointer, then merge
         parent P90.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2663,20 +2663,20 @@ package or adapter.
   - [x] Create TSA29 branch `feature/tsa29-femic-strict-chain`.
   - [x] Link parent issue `#250` and TSA29 issue
         `UBC-FRESH/femic-tsa29-instance#15`.
-  - [ ] Record matching starting notes in parent and TSA29 changelogs.
-- [ ] P90.2 Add generic named-pipeline contract-handler seam
-  - [ ] Define the contract handler protocol and registration/discovery API.
-  - [ ] Replace TSA29-specific branches in `femic.named_pipelines` with
+  - [x] Record matching starting notes in parent and TSA29 changelogs.
+- [x] P90.2 Add generic named-pipeline contract-handler seam
+  - [x] Define the contract handler protocol and registration/discovery API.
+  - [x] Replace TSA29-specific branches in `femic.named_pipelines` with
         handler dispatch and clear missing-handler errors.
-  - [ ] Add fixture-handler tests for explicit registration, discovery,
+  - [x] Add fixture-handler tests for explicit registration, discovery,
         duplicate handling, and generic dispatch.
-- [ ] P90.3 Move TSA29 strict-chain contract into instance ownership
-  - [ ] Add installable `tsa29_femic` package in the TSA29 instance repo.
-  - [ ] Register `tsa29_locked_chain_strict` through
+- [x] P90.3 Move TSA29 strict-chain contract into instance ownership
+  - [x] Add installable `tsa29_femic` package in the TSA29 instance repo.
+  - [x] Register `tsa29_locked_chain_strict` through
         `femic.named_pipeline_contracts`.
-  - [ ] Move TSA29 row-order, ledger, preflight, GLB materialization, strict
+  - [x] Move TSA29 row-order, ledger, preflight, GLB materialization, strict
         sequence, and ledger-validation logic into `tsa29_femic`.
-  - [ ] Migrate TSA29-specific strict-chain tests into the TSA29 package.
+  - [x] Migrate TSA29-specific strict-chain tests into the TSA29 package.
 - [ ] P90.4 Verify and close out
   - [ ] Run focused parent checks for named pipelines, boundary guard, typing,
         docs, and package artifacts.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -116,6 +116,11 @@ Subcommands
 ``pipelines run`` resolves one machine-readable runbook, loads the built-in +
 optional user + optional instance-local named-pipeline registries, and runs
 the first proof-oriented named pipeline surface.
+Validation contracts are extension-owned: FEMIC core dispatches contract kinds
+through installed ``femic.named_pipeline_contracts`` handlers rather than
+hardcoding example-instance semantics. For example, TSA29's
+``tsa29_locked_chain_strict`` contract is available only when the TSA29
+instance package is installed in the active environment.
 
 Current proof-runner scope:
 

--- a/src/femic/named_pipelines.py
+++ b/src/femic/named_pipelines.py
@@ -4,21 +4,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from importlib import import_module, resources
+from importlib.metadata import EntryPoint, entry_points
+from importlib import resources
 import json
 from pathlib import Path
-from typing import Any, Callable, Mapping, cast
+from typing import Any, Callable, Mapping, Protocol, cast
 
 import yaml
 
-from femic.glb import build_tsa_raw_glb
 from femic.tsr_catalog import (
     TSR_THLB_EXECUTION_MODE_RECONSTRUCTED,
     TsrThlbParentStepRunResult,
     TsrThlbNetdownRecipeRunResult,
     default_tsr_thlb_netdown_recipe_path,
     load_tsr_thlb_netdown_recipe,
-    run_tsr_thlb_locked_parent_step,
     run_tsr_thlb_netdown_recipe,
 )
 from femic.user_config import DEFAULT_FEMIC_CONFIG_HOME
@@ -26,6 +25,7 @@ from femic.user_config import DEFAULT_FEMIC_CONFIG_HOME
 
 PIPELINE_REGISTRY_RESOURCE_PACKAGE = "femic.resources.pipelines"
 PIPELINE_REGISTRY_RESOURCE_NAME = "registry.yaml"
+NAMED_PIPELINE_CONTRACT_ENTRY_POINT_GROUP = "femic.named_pipeline_contracts"
 _SUPPORTED_TSR_THLB_PIPELINE_IDS = {"tsr.thlb_strict", "tsr.thlb_reviewed"}
 DEFAULT_NAMED_PIPELINE_USER_REGISTRY_PATH = DEFAULT_FEMIC_CONFIG_HOME / "pipelines.yaml"
 DEFAULT_NAMED_PIPELINE_INSTANCE_REGISTRY_RELATIVE_PATH = Path("config/pipelines.yaml")
@@ -210,6 +210,35 @@ class NamedPipelineExecutionResult:
     tsr_parent_step_result: TsrThlbParentStepRunResult | None = None
     validation_result: NamedPipelineValidationResult | None = None
     runtime_event_log_path: Path | None = None
+
+
+class NamedPipelineContractHandler(Protocol):
+    """Provider hook for contract-kind-specific named-pipeline behavior."""
+
+    contract_kind: str
+
+    def run_before_default(
+        self,
+        *,
+        plan: NamedPipelineExecutionPlan,
+        runtime_logger: Any,
+        runtime_event_log_path: Path,
+    ) -> NamedPipelineExecutionResult | None:
+        """Optionally execute a contract-specific run path before default TSR."""
+        ...
+
+    def validate_after_default(
+        self,
+        *,
+        plan: NamedPipelineExecutionPlan,
+        tsr_result: TsrThlbNetdownRecipeRunResult,
+    ) -> NamedPipelineValidationResult | None:
+        """Optionally validate the default TSR result."""
+        ...
+
+
+_NAMED_PIPELINE_CONTRACT_HANDLERS: dict[str, NamedPipelineContractHandler] = {}
+_DISCOVERED_NAMED_PIPELINE_CONTRACTS = False
 
 
 _RUNTIME_EVENT_CORE_FIELDS = (
@@ -676,6 +705,71 @@ def load_named_pipeline_registry(
     )
 
 
+def register_named_pipeline_contract_handler(
+    handler: NamedPipelineContractHandler,
+) -> None:
+    """Register one named-pipeline contract handler in-process."""
+
+    contract_kind = str(getattr(handler, "contract_kind", "")).strip()
+    if not contract_kind:
+        raise NamedPipelineError(
+            "Named-pipeline contract handler is missing `contract_kind`."
+        )
+    if contract_kind in _NAMED_PIPELINE_CONTRACT_HANDLERS:
+        raise NamedPipelineError(
+            f"Named-pipeline contract handler already registered: {contract_kind}"
+        )
+    _NAMED_PIPELINE_CONTRACT_HANDLERS[contract_kind] = handler
+
+
+def _load_contract_entry_point(entry_point: EntryPoint) -> NamedPipelineContractHandler:
+    loaded = entry_point.load()
+    candidate = loaded() if callable(loaded) else loaded
+    contract_kind = str(getattr(candidate, "contract_kind", "")).strip()
+    if not contract_kind:
+        raise NamedPipelineError(
+            "Named-pipeline contract entry point "
+            f"`{entry_point.name}` did not provide an object with `contract_kind`."
+        )
+    return cast(NamedPipelineContractHandler, candidate)
+
+
+def discover_named_pipeline_contract_handlers() -> tuple[str, ...]:
+    """Discover installed named-pipeline contract handlers from entry points."""
+
+    discovered: list[str] = []
+    selected = entry_points(group=NAMED_PIPELINE_CONTRACT_ENTRY_POINT_GROUP)
+    for entry_point in selected:
+        handler = _load_contract_entry_point(entry_point)
+        register_named_pipeline_contract_handler(handler)
+        discovered.append(handler.contract_kind)
+    return tuple(discovered)
+
+
+def _ensure_named_pipeline_contract_handlers_discovered() -> None:
+    global _DISCOVERED_NAMED_PIPELINE_CONTRACTS
+    if _DISCOVERED_NAMED_PIPELINE_CONTRACTS:
+        return
+    discover_named_pipeline_contract_handlers()
+    _DISCOVERED_NAMED_PIPELINE_CONTRACTS = True
+
+
+def get_named_pipeline_contract_handler(
+    contract_kind: str,
+) -> NamedPipelineContractHandler:
+    """Return the registered handler for one named-pipeline contract kind."""
+
+    _ensure_named_pipeline_contract_handlers_discovered()
+    normalized = contract_kind.strip()
+    handler = _NAMED_PIPELINE_CONTRACT_HANDLERS.get(normalized)
+    if handler is None:
+        raise NamedPipelineError(
+            "Named-pipeline validation contract handler is not installed or "
+            f"registered: {normalized}"
+        )
+    return handler
+
+
 def _infer_runbook_instance_root(runbook_path: Path) -> Path:
     resolved = runbook_path.expanduser().resolve()
     for candidate in (resolved.parent,) + tuple(resolved.parents):
@@ -985,650 +1079,6 @@ def build_named_pipeline_execution_plan(
     )
 
 
-def _validate_tsa29_locked_chain_strict_result(
-    *,
-    plan: NamedPipelineExecutionPlan,
-    tsr_result: TsrThlbNetdownRecipeRunResult,
-    tolerance_ha: float = 1e-3,
-) -> NamedPipelineValidationResult:
-    validation_contract = plan.validation_contract
-    if validation_contract is None:
-        raise NamedPipelineError(
-            "Strict validation contract is required for this validator."
-        )
-    if validation_contract.locked_chain_ledger_path is None:
-        raise NamedPipelineError(
-            "Strict validation contract requires `locked_chain_ledger_path`."
-        )
-    ledger_payload = _load_json_mapping(
-        path=validation_contract.locked_chain_ledger_path,
-        source_label=str(validation_contract.locked_chain_ledger_path),
-    )
-    audit_path = getattr(tsr_result, "audit_path", None)
-    if audit_path in (None, ""):
-        raise NamedPipelineError(
-            "Strict validation contract requires a THLB run result with an `audit_path`."
-        )
-    resolved_audit_path = Path(str(audit_path)).expanduser().resolve()
-    if not resolved_audit_path.exists():
-        raise NamedPipelineError(
-            f"Resolved strict validation audit path not found: {resolved_audit_path}"
-        )
-    audit_payload = _load_json_mapping(
-        path=resolved_audit_path,
-        source_label=str(resolved_audit_path),
-    )
-    ledger_entries = ledger_payload.get("entries")
-    if not isinstance(ledger_entries, list):
-        raise NamedPipelineError(
-            f"{validation_contract.locked_chain_ledger_path} field `entries` must be a list."
-        )
-    audit_steps = audit_payload.get("steps")
-    if not isinstance(audit_steps, list):
-        raise NamedPipelineError(f"{resolved_audit_path} field `steps` must be a list.")
-
-    parent_step_totals: dict[str, dict[str, float | int | str | None]] = {}
-    for step in audit_steps:
-        if not isinstance(step, dict):
-            raise NamedPipelineError(
-                f"{resolved_audit_path} field `steps` must contain mappings."
-            )
-        parent_step_id = str(step.get("parent_step_id", "")).strip()
-        if not parent_step_id:
-            continue
-        entry = parent_step_totals.setdefault(
-            parent_step_id,
-            {
-                "row_order": _normalize_int_or_none(step.get("order_index")),
-                "parent_label": str(step.get("parent_label", "")).strip() or None,
-                "net_removed_area_ha": 0.0,
-                "remaining_area_ha": None,
-            },
-        )
-        net_removed_area_ha = _normalize_float_or_none(
-            step.get("net_removed_area_ha", step.get("removed_area_ha"))
-        )
-        if net_removed_area_ha is not None:
-            entry["net_removed_area_ha"] = float(
-                entry["net_removed_area_ha"] or 0.0
-            ) + float(net_removed_area_ha)
-        remaining_area_ha = _normalize_float_or_none(step.get("remaining_area_ha"))
-        if remaining_area_ha is not None:
-            entry["remaining_area_ha"] = remaining_area_ha
-
-    validated_parent_step_count = 0
-    max_abs_marginal_delta_ha = 0.0
-    max_abs_cumulative_delta_ha = 0.0
-    latest_locked_row_order: int | None = None
-    latest_locked_parent_step_id: str | None = None
-    expected_final_managed_area_ha: float | None = None
-
-    for ledger_entry in ledger_entries:
-        if not isinstance(ledger_entry, dict):
-            raise NamedPipelineError(
-                f"{validation_contract.locked_chain_ledger_path} field `entries` must contain mappings."
-            )
-        parent_step_id = str(ledger_entry.get("parent_step_id", "")).strip()
-        row_order = _normalize_int_or_none(ledger_entry.get("row_order"))
-        if not parent_step_id or row_order is None:
-            raise NamedPipelineError(
-                f"{validation_contract.locked_chain_ledger_path} contains an invalid ledger entry."
-            )
-        parent_audit = parent_step_totals.get(parent_step_id)
-        if parent_audit is None:
-            raise NamedPipelineError(
-                "Strict validation contract mismatch: missing audited parent step "
-                f"`{parent_step_id}` for locked ledger row `{row_order}`."
-            )
-        expected_net_removed_area_ha = _normalize_float_or_none(
-            ledger_entry.get("locked_net_removed_area_ha")
-        )
-        actual_net_removed_area_ha = _normalize_float_or_none(
-            parent_audit.get("net_removed_area_ha")
-        )
-        expected_marginal_compare = (
-            0.0
-            if expected_net_removed_area_ha is None
-            else expected_net_removed_area_ha
-        )
-        actual_marginal_compare = (
-            0.0 if actual_net_removed_area_ha is None else actual_net_removed_area_ha
-        )
-        marginal_delta_ha = abs(actual_marginal_compare - expected_marginal_compare)
-        max_abs_marginal_delta_ha = max(max_abs_marginal_delta_ha, marginal_delta_ha)
-        if marginal_delta_ha > tolerance_ha:
-            raise NamedPipelineError(
-                "Strict validation contract mismatch at row "
-                f"`{row_order}` (`{parent_step_id}`): expected locked marginal "
-                f"`{expected_marginal_compare:.3f} ha`, got "
-                f"`{actual_marginal_compare:.3f} ha`."
-            )
-        expected_cumulative_remaining_area_ha = _normalize_float_or_none(
-            ledger_entry.get("locked_cumulative_remaining_area_ha")
-        )
-        actual_cumulative_remaining_area_ha = _normalize_float_or_none(
-            parent_audit.get("remaining_area_ha")
-        )
-        if expected_cumulative_remaining_area_ha is None:
-            raise NamedPipelineError(
-                "Strict validation contract ledger entry is missing "
-                f"`locked_cumulative_remaining_area_ha` for `{parent_step_id}`."
-            )
-        if actual_cumulative_remaining_area_ha is None:
-            raise NamedPipelineError(
-                "Strict validation contract mismatch: audited parent step "
-                f"`{parent_step_id}` is missing `remaining_area_ha`."
-            )
-        cumulative_delta_ha = abs(
-            actual_cumulative_remaining_area_ha - expected_cumulative_remaining_area_ha
-        )
-        max_abs_cumulative_delta_ha = max(
-            max_abs_cumulative_delta_ha, cumulative_delta_ha
-        )
-        if cumulative_delta_ha > tolerance_ha:
-            raise NamedPipelineError(
-                "Strict validation contract mismatch at row "
-                f"`{row_order}` (`{parent_step_id}`): expected locked cumulative "
-                f"`{expected_cumulative_remaining_area_ha:.3f} ha`, got "
-                f"`{actual_cumulative_remaining_area_ha:.3f} ha`."
-            )
-        latest_locked_row_order = row_order
-        latest_locked_parent_step_id = parent_step_id
-        expected_final_managed_area_ha = expected_cumulative_remaining_area_ha
-        validated_parent_step_count += 1
-
-    actual_final_managed_area_ha = _normalize_float_or_none(
-        getattr(tsr_result, "final_managed_area_ha", None)
-    )
-    if expected_final_managed_area_ha is None or actual_final_managed_area_ha is None:
-        raise NamedPipelineError(
-            "Strict validation contract requires both expected and actual final managed area."
-        )
-    final_delta_ha = abs(actual_final_managed_area_ha - expected_final_managed_area_ha)
-    max_abs_cumulative_delta_ha = max(max_abs_cumulative_delta_ha, final_delta_ha)
-    if final_delta_ha > tolerance_ha:
-        raise NamedPipelineError(
-            "Strict validation contract mismatch at final managed area: expected "
-            f"`{expected_final_managed_area_ha:.3f} ha`, got "
-            f"`{actual_final_managed_area_ha:.3f} ha`."
-        )
-
-    return NamedPipelineValidationResult(
-        contract_kind=validation_contract.contract_kind,
-        validated_parent_step_count=validated_parent_step_count,
-        latest_locked_row_order=latest_locked_row_order,
-        latest_locked_parent_step_id=latest_locked_parent_step_id,
-        expected_final_managed_area_ha=expected_final_managed_area_ha,
-        actual_final_managed_area_ha=actual_final_managed_area_ha,
-        max_abs_marginal_delta_ha=max_abs_marginal_delta_ha,
-        max_abs_cumulative_delta_ha=max_abs_cumulative_delta_ha,
-    )
-
-
-def _load_locked_chain_entries(
-    validation_contract: NamedPipelineValidationContract,
-) -> list[Mapping[str, Any]]:
-    if validation_contract.locked_chain_ledger_path is None:
-        raise NamedPipelineError(
-            "Strict validation contract requires `locked_chain_ledger_path`."
-        )
-    ledger_payload = _load_json_mapping(
-        path=validation_contract.locked_chain_ledger_path,
-        source_label=str(validation_contract.locked_chain_ledger_path),
-    )
-    ledger_entries = ledger_payload.get("entries")
-    if not isinstance(ledger_entries, list):
-        raise NamedPipelineError(
-            f"{validation_contract.locked_chain_ledger_path} field `entries` must be a list."
-        )
-    normalized_entries: list[Mapping[str, Any]] = []
-    for entry in ledger_entries:
-        if not isinstance(entry, dict):
-            raise NamedPipelineError(
-                f"{validation_contract.locked_chain_ledger_path} field `entries` must contain mappings."
-            )
-        normalized_entries.append(entry)
-    return normalized_entries
-
-
-def _resolve_tsa29_locked_chain_strict_row_order(*, seam_id: str) -> int:
-    if seam_id in {"scratch", "glb"}:
-        return 1
-    if seam_id in {"aflb", "aflb_yield_ready"}:
-        return 5
-    raise NamedPipelineError(
-        "Strict validation preflight does not yet support seam "
-        f"`{seam_id}` for `tsa29_locked_chain_strict`."
-    )
-
-
-def _resolve_tsa29_locked_chain_entry(
-    *,
-    validation_contract: NamedPipelineValidationContract,
-    row_order: int,
-) -> Mapping[str, Any]:
-    for entry in _load_locked_chain_entries(validation_contract):
-        if _normalize_int_or_none(entry.get("row_order")) == row_order:
-            return entry
-    raise NamedPipelineError(
-        "Strict validation contract is missing locked-chain row "
-        f"`{row_order}` in {validation_contract.locked_chain_ledger_path}."
-    )
-
-
-def _resolve_tsa29_locked_chain_entry_by_parent_step_id(
-    *,
-    validation_contract: NamedPipelineValidationContract,
-    parent_step_id: str,
-) -> Mapping[str, Any]:
-    normalized_parent_step_id = parent_step_id.strip()
-    for entry in _load_locked_chain_entries(validation_contract):
-        if str(entry.get("parent_step_id", "")).strip() == normalized_parent_step_id:
-            return entry
-    raise NamedPipelineError(
-        "Strict validation contract is missing parent step "
-        f"`{normalized_parent_step_id}` in {validation_contract.locked_chain_ledger_path}."
-    )
-
-
-def _is_reference_only_parent_step(parent_step: Mapping[str, Any]) -> bool:
-    parent_kind = str(parent_step.get("parent_kind", "")).strip().casefold()
-    execution_class = str(parent_step.get("execution_class", "")).strip().casefold()
-    return parent_kind == "milestone" or execution_class == "reference_only"
-
-
-def _resolve_locked_parent_step_sequence(
-    *,
-    recipe_path: Path,
-    start_after_row_order: int = 1,
-    stop_after_parent_step_id: str | None = None,
-) -> tuple[Mapping[str, Any], ...]:
-    recipe = load_tsr_thlb_netdown_recipe(recipe_path)
-    sequence: list[Mapping[str, Any]] = []
-    normalized_stop_after = (
-        stop_after_parent_step_id.strip()
-        if stop_after_parent_step_id is not None
-        else None
-    )
-    found_stop_after = normalized_stop_after is None
-    for parent_step in recipe.parent_steps:
-        parent_step_id = str(parent_step.get("parent_step_id", "")).strip()
-        row_order = _normalize_int_or_none(parent_step.get("row_order"))
-        if not parent_step_id or row_order is None:
-            raise NamedPipelineError(
-                f"Locked THLB recipe contains an invalid parent-step entry: {parent_step!r}"
-            )
-        if row_order <= start_after_row_order:
-            continue
-        sequence.append(parent_step)
-        if (
-            normalized_stop_after is not None
-            and parent_step_id == normalized_stop_after
-        ):
-            found_stop_after = True
-            break
-    if not found_stop_after:
-        raise NamedPipelineError(
-            "Strict pipeline stop target is not present in the locked recipe: "
-            f"`{normalized_stop_after}`."
-        )
-    return tuple(sequence)
-
-
-def _validate_locked_strict_parent_step_execution_contract(
-    parent_step: Mapping[str, Any],
-) -> Mapping[str, Any]:
-    parent_step_id = str(parent_step.get("parent_step_id", "")).strip()
-    ratchet_state = str(parent_step.get("ratchet_state", "")).strip().casefold()
-    approved = bool(parent_step.get("approved", False)) or ratchet_state in {
-        "approved",
-        "benchmarked",
-    }
-    compiled_logic = [
-        item for item in parent_step.get("compiled_logic", ()) if isinstance(item, dict)
-    ]
-    if not approved:
-        raise NamedPipelineError(
-            "Strict pipeline step is not approved on the locked recipe surface: "
-            f"`{parent_step_id}`."
-        )
-    if not compiled_logic:
-        raise NamedPipelineError(
-            "Strict pipeline step is missing locked compiled logic: "
-            f"`{parent_step_id}`."
-        )
-    return parent_step
-
-
-def _source_tree_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def _managed_area_ha_from_checkpoint(checkpoint_path: Path) -> float:
-    if not checkpoint_path.exists():
-        raise NamedPipelineError(
-            f"Strict validation checkpoint not found: {checkpoint_path}"
-        )
-    gpd = import_module("geopandas")
-    checkpoint = gpd.read_feather(checkpoint_path)
-    if "thlb_fact" in checkpoint.columns:
-        thlb_fact = checkpoint["thlb_fact"].astype(float)
-        for area_column in ("_stand_area_sqm", "FEATURE_AREA_SQM", "Shape_Area"):
-            if area_column in checkpoint.columns:
-                return float(
-                    (checkpoint[area_column].astype(float) * thlb_fact).sum() / 10000.0
-                )
-        for area_column in ("POLYGON_AREA", "GEOMETRY_AREA"):
-            if area_column in checkpoint.columns:
-                return float((checkpoint[area_column].astype(float) * thlb_fact).sum())
-        if "geometry" in checkpoint.columns:
-            return float(
-                (checkpoint.geometry.area.astype(float) * thlb_fact).sum() / 10000.0
-            )
-    if "geometry" in checkpoint.columns:
-        return float(checkpoint.geometry.area.sum() / 10000.0)
-    raise NamedPipelineError(
-        "Strict validation checkpoint is missing both managed-area columns and geometry: "
-        f"{checkpoint_path}"
-    )
-
-
-def _materialize_tsa29_glb_checkpoint_from_result(
-    *,
-    instance_root: Path,
-    clipped_glb_gdb_path: Path,
-    clipped_glb_feature_class: str,
-) -> Path:
-    gpd = import_module("geopandas")
-    checkpoint = gpd.read_file(
-        clipped_glb_gdb_path,
-        layer=clipped_glb_feature_class,
-    )
-    if len(checkpoint) == 0:
-        raise NamedPipelineError(
-            "Raw-source GLB build produced no features for TSA29; cannot materialize "
-            "step-001 checkpoint."
-        )
-    area_sqm = checkpoint.geometry.area.astype(float)
-    if "FEATURE_AREA_SQM" in checkpoint.columns:
-        checkpoint["FEATURE_AREA_SQM"] = area_sqm
-    if "POLYGON_AREA" in checkpoint.columns:
-        checkpoint["POLYGON_AREA"] = area_sqm / 10000.0
-    if "Shape_Area" in checkpoint.columns:
-        checkpoint["Shape_Area"] = area_sqm
-    if "GEOMETRY_AREA" in checkpoint.columns:
-        checkpoint["GEOMETRY_AREA"] = area_sqm / 10000.0
-    checkpoint_path = instance_root / "data" / "tsr" / "glb_checkpoint.feather"
-    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-    checkpoint.to_feather(checkpoint_path)
-    return checkpoint_path
-
-
-def _validate_tsa29_locked_chain_strict_preflight(
-    *,
-    plan: NamedPipelineExecutionPlan,
-    tolerance_ha: float = 1e-3,
-) -> Mapping[str, Any]:
-    validation_contract = plan.validation_contract
-    if validation_contract is None:
-        raise NamedPipelineError(
-            "Strict validation contract is required for this preflight."
-        )
-    locked_row_order = _resolve_tsa29_locked_chain_strict_row_order(
-        seam_id=plan.seam_id
-    )
-    locked_entry = _resolve_tsa29_locked_chain_entry(
-        validation_contract=validation_contract,
-        row_order=locked_row_order,
-    )
-    locked_parent_step_id = str(locked_entry.get("parent_step_id", "")).strip()
-    expected_benchmark_area_ha = _normalize_float_or_none(
-        locked_entry.get("locked_cumulative_remaining_area_ha")
-    )
-    if expected_benchmark_area_ha is None:
-        raise NamedPipelineError(
-            "Strict validation contract ledger entry is missing "
-            f"`locked_cumulative_remaining_area_ha` for row `{locked_row_order}`."
-        )
-
-    if plan.seam_id == "scratch":
-        glb_result = build_tsa_raw_glb(
-            source_root=_source_tree_root(),
-            instance_root=plan.instance_root,
-            tsa="29",
-            stash_public_data_glb=False,
-        )
-        actual_start_area_ha = float(glb_result.clipped_area_ha)
-        area_delta_ha = actual_start_area_ha - expected_benchmark_area_ha
-        if abs(area_delta_ha) > tolerance_ha:
-            raise NamedPipelineError(
-                "Strict validation preflight mismatch for seam "
-                f"`{plan.seam_id}` at locked row `{locked_row_order}` "
-                f"(`{locked_parent_step_id}`): expected `{expected_benchmark_area_ha:.3f} ha`, "
-                f"got `{actual_start_area_ha:.3f} ha`, delta `{area_delta_ha:.3f} ha`."
-            )
-        return {
-            "locked_row_order": locked_row_order,
-            "locked_parent_step_id": locked_parent_step_id,
-            "expected_benchmark_area_ha": expected_benchmark_area_ha,
-            "actual_start_area_ha": actual_start_area_ha,
-            "area_delta_ha": area_delta_ha,
-            "clipped_glb_gdb_path": glb_result.clipped_glb_gdb_path,
-            "clipped_glb_feature_class": glb_result.clipped_glb_feature_class,
-            "summary_json_path": glb_result.summary_json_path,
-            "summary_markdown_path": glb_result.summary_markdown_path,
-        }
-
-    if plan.checkpoint_path is None:
-        raise NamedPipelineError(
-            "Strict validation preflight requires an explicit checkpoint path for seam "
-            f"`{plan.seam_id}`."
-        )
-    actual_start_area_ha = _managed_area_ha_from_checkpoint(plan.checkpoint_path)
-
-    if plan.seam_id == "aflb_yield_ready":
-        aflb_checkpoint_path = (
-            plan.instance_root / "data" / "tsr" / "aflb_checkpoint.feather"
-        )
-        aflb_area_ha = _managed_area_ha_from_checkpoint(aflb_checkpoint_path)
-        aflb_delta_ha = actual_start_area_ha - aflb_area_ha
-        if abs(aflb_delta_ha) > tolerance_ha:
-            raise NamedPipelineError(
-                "Strict validation preflight mismatch for seam `aflb_yield_ready`: expected "
-                "yield-ready area to preserve AFLB area from "
-                f"`{aflb_checkpoint_path}`; AFLB `{aflb_area_ha:.3f} ha`, "
-                f"yield-ready `{actual_start_area_ha:.3f} ha`, "
-                f"delta `{aflb_delta_ha:.3f} ha`."
-            )
-
-    area_delta_ha = actual_start_area_ha - expected_benchmark_area_ha
-    if abs(area_delta_ha) > tolerance_ha:
-        raise NamedPipelineError(
-            "Strict validation preflight mismatch for seam "
-            f"`{plan.seam_id}` at locked row `{locked_row_order}` "
-            f"(`{locked_parent_step_id}`): expected `{expected_benchmark_area_ha:.3f} ha`, "
-            f"got `{actual_start_area_ha:.3f} ha`, delta `{area_delta_ha:.3f} ha`."
-        )
-
-    return {
-        "locked_row_order": locked_row_order,
-        "locked_parent_step_id": locked_parent_step_id,
-        "expected_benchmark_area_ha": expected_benchmark_area_ha,
-        "actual_start_area_ha": actual_start_area_ha,
-        "area_delta_ha": area_delta_ha,
-    }
-
-
-def _validate_tsa29_locked_chain_parent_step(
-    *,
-    validation_contract: NamedPipelineValidationContract,
-    parent_step_id: str,
-    removed_area_ha: float | None,
-    remaining_area_ha: float,
-    tolerance_ha: float = 1e-3,
-) -> NamedPipelineValidationResult:
-    locked_entry = _resolve_tsa29_locked_chain_entry_by_parent_step_id(
-        validation_contract=validation_contract,
-        parent_step_id=parent_step_id,
-    )
-    row_order = _normalize_int_or_none(locked_entry.get("row_order"))
-    if row_order is None:
-        raise NamedPipelineError(
-            "Strict validation contract ledger entry is missing row order for "
-            f"`{parent_step_id}`."
-        )
-    expected_removed_ha = _normalize_float_or_none(
-        locked_entry.get("locked_net_removed_area_ha")
-    )
-    expected_remaining_ha = _normalize_float_or_none(
-        locked_entry.get("locked_cumulative_remaining_area_ha")
-    )
-    locked_parent_step_id = str(locked_entry.get("parent_step_id", "")).strip() or None
-    if expected_removed_ha is None or expected_remaining_ha is None:
-        if expected_remaining_ha is None:
-            raise NamedPipelineError(
-                "Strict validation contract ledger entry is missing locked cumulative "
-                f"value for row `{row_order}`."
-            )
-        expected_removed_ha = 0.0
-    actual_removed_ha = 0.0 if removed_area_ha is None else removed_area_ha
-    marginal_delta_ha = actual_removed_ha - expected_removed_ha
-    cumulative_delta_ha = remaining_area_ha - expected_remaining_ha
-    if abs(marginal_delta_ha) > tolerance_ha or abs(cumulative_delta_ha) > tolerance_ha:
-        raise NamedPipelineError(
-            "Strict validation mismatch at row "
-            f"`{row_order}` (`{locked_parent_step_id}`): expected marginal "
-            f"`{expected_removed_ha:.3f} ha`, got `{actual_removed_ha:.3f} ha`, "
-            f"delta `{marginal_delta_ha:.3f} ha`; expected cumulative "
-            f"`{expected_remaining_ha:.3f} ha`, got `{remaining_area_ha:.3f} ha`, "
-            f"delta `{cumulative_delta_ha:.3f} ha`."
-        )
-    return NamedPipelineValidationResult(
-        contract_kind=validation_contract.contract_kind,
-        validated_parent_step_count=row_order,
-        latest_locked_row_order=row_order,
-        latest_locked_parent_step_id=locked_parent_step_id,
-        expected_final_managed_area_ha=expected_remaining_ha,
-        actual_final_managed_area_ha=remaining_area_ha,
-        max_abs_marginal_delta_ha=abs(marginal_delta_ha),
-        max_abs_cumulative_delta_ha=abs(cumulative_delta_ha),
-    )
-
-
-def _run_tsa29_strict_sequence_from_checkpoint(
-    *,
-    plan: NamedPipelineExecutionPlan,
-    start_checkpoint_path: Path,
-    start_validated_row_order: int,
-    start_validated_parent_step_id: str,
-    start_remaining_area_ha: float,
-    runtime_logger: "_NamedPipelineRuntimeEventLogger",
-) -> tuple[TsrThlbParentStepRunResult | None, NamedPipelineValidationResult]:
-    validation_contract = plan.validation_contract
-    if validation_contract is None:
-        raise NamedPipelineError(
-            "Strict pipeline sequencing requires a validation contract."
-        )
-    current_checkpoint_path = start_checkpoint_path
-    sequence = _resolve_locked_parent_step_sequence(
-        recipe_path=plan.thlb_netdown_recipe_path,
-        start_after_row_order=start_validated_row_order,
-        stop_after_parent_step_id=plan.target_parent_step_id,
-    )
-    latest_validation = NamedPipelineValidationResult(
-        contract_kind=validation_contract.contract_kind,
-        validated_parent_step_count=start_validated_row_order,
-        latest_locked_row_order=start_validated_row_order,
-        latest_locked_parent_step_id=start_validated_parent_step_id,
-        expected_final_managed_area_ha=start_remaining_area_ha,
-        actual_final_managed_area_ha=start_remaining_area_ha,
-        max_abs_marginal_delta_ha=0.0,
-        max_abs_cumulative_delta_ha=0.0,
-    )
-    last_parent_step_result: TsrThlbParentStepRunResult | None = None
-    for parent_step in sequence:
-        parent_step_id = str(parent_step.get("parent_step_id", "")).strip()
-        parent_label = str(parent_step.get("parent_label", "")).strip() or None
-        row_order = _normalize_int_or_none(parent_step.get("row_order"))
-        land_base_stage = str(parent_step.get("land_base_stage", "")).strip() or None
-        runtime_logger.emit(
-            {
-                "event_kind": "parent_step_started",
-                "parent_step_id": parent_step_id,
-                "parent_label": parent_label,
-                "row_order": row_order,
-                "land_base_stage": land_base_stage,
-                "locked_execution_class": str(
-                    parent_step.get("execution_class", "")
-                ).strip()
-                or None,
-                "checkpoint_path": current_checkpoint_path,
-            }
-        )
-        if _is_reference_only_parent_step(parent_step):
-            remaining_area_ha = _managed_area_ha_from_checkpoint(
-                current_checkpoint_path
-            )
-            latest_validation = _validate_tsa29_locked_chain_parent_step(
-                validation_contract=validation_contract,
-                parent_step_id=parent_step_id,
-                removed_area_ha=None,
-                remaining_area_ha=remaining_area_ha,
-            )
-            runtime_logger.emit(
-                {
-                    "event_kind": "parent_step_finished",
-                    "parent_step_id": parent_step_id,
-                    "parent_label": parent_label,
-                    "row_order": row_order,
-                    "land_base_stage": land_base_stage,
-                    "run_status": "reference_validated",
-                    "remaining_area_ha": remaining_area_ha,
-                    "checkpoint_path": current_checkpoint_path,
-                    "locked_execution_class": str(
-                        parent_step.get("execution_class", "")
-                    ).strip()
-                    or None,
-                }
-            )
-            continue
-        locked_parent_step = _validate_locked_strict_parent_step_execution_contract(
-            parent_step
-        )
-        parent_step_result = run_tsr_thlb_locked_parent_step(
-            recipe_path=plan.thlb_netdown_recipe_path,
-            parent_step_id=parent_step_id,
-            checkpoint_path=current_checkpoint_path,
-            runtime_event_sink=runtime_logger.emit,
-        )
-        last_parent_step_result = parent_step_result
-        current_checkpoint_path = parent_step_result.output_path
-        latest_validation = _validate_tsa29_locked_chain_parent_step(
-            validation_contract=validation_contract,
-            parent_step_id=parent_step_id,
-            removed_area_ha=parent_step_result.removed_area_ha,
-            remaining_area_ha=parent_step_result.remaining_area_ha,
-        )
-        runtime_logger.emit(
-            {
-                "event_kind": "parent_step_finished",
-                "parent_step_id": parent_step_result.parent_step_id,
-                "parent_label": parent_step_result.parent_label,
-                "row_order": row_order,
-                "land_base_stage": land_base_stage,
-                "run_status": parent_step_result.status,
-                "remaining_area_ha": parent_step_result.remaining_area_ha,
-                "checkpoint_path": current_checkpoint_path,
-                "output_checkpoint_path": parent_step_result.output_path,
-                "locked_execution_class": str(
-                    locked_parent_step.get("execution_class", "")
-                ).strip()
-                or None,
-            }
-        )
-    return last_parent_step_result, latest_validation
-
-
 def run_named_pipeline_runbook(
     *,
     runbook_path: Path,
@@ -1695,144 +1145,19 @@ def run_named_pipeline_runbook(
         }
     )
     validation_result: NamedPipelineValidationResult | None = None
+    contract_handler: NamedPipelineContractHandler | None = None
     try:
-        if (
-            plan.validation_contract is not None
-            and plan.validation_contract.contract_kind == "tsa29_locked_chain_strict"
-        ):
-            runtime_logger.emit(
-                {
-                    "event_kind": "pipeline_validation_preflight_started",
-                    "validation_contract_kind": plan.validation_contract.contract_kind,
-                }
+        if plan.validation_contract is not None:
+            contract_handler = get_named_pipeline_contract_handler(
+                plan.validation_contract.contract_kind
             )
-            preflight_result = _validate_tsa29_locked_chain_strict_preflight(plan=plan)
-            runtime_logger.emit(
-                {
-                    "event_kind": "pipeline_validation_preflight_finished",
-                    "validation_contract_kind": plan.validation_contract.contract_kind,
-                    **preflight_result,
-                }
+            pre_default_result = contract_handler.run_before_default(
+                plan=plan,
+                runtime_logger=runtime_logger,
+                runtime_event_log_path=runtime_event_log_path,
             )
-            if plan.seam_id in {"scratch", "glb", "aflb", "aflb_yield_ready"}:
-                start_checkpoint_path = plan.checkpoint_path
-                if plan.seam_id == "scratch":
-                    glb_checkpoint_path = _materialize_tsa29_glb_checkpoint_from_result(
-                        instance_root=plan.instance_root,
-                        clipped_glb_gdb_path=cast(
-                            Path, preflight_result["clipped_glb_gdb_path"]
-                        ),
-                        clipped_glb_feature_class=cast(
-                            str, preflight_result["clipped_glb_feature_class"]
-                        ),
-                    )
-                    start_checkpoint_path = glb_checkpoint_path
-                    runtime_logger.emit(
-                        {
-                            "event_kind": "pipeline_preflight_resolved",
-                            "notes": f"glb_checkpoint_path={glb_checkpoint_path}",
-                        }
-                    )
-                if plan.target_parent_step_id is not None:
-                    parent_step_result, validation_result = (
-                        _run_tsa29_strict_sequence_from_checkpoint(
-                            plan=plan,
-                            start_checkpoint_path=cast(Path, start_checkpoint_path),
-                            start_validated_row_order=cast(
-                                int, preflight_result["locked_row_order"]
-                            ),
-                            start_validated_parent_step_id=cast(
-                                str, preflight_result["locked_parent_step_id"]
-                            ),
-                            start_remaining_area_ha=cast(
-                                float, preflight_result["actual_start_area_ha"]
-                            ),
-                            runtime_logger=runtime_logger,
-                        )
-                    )
-                    runtime_logger.emit(
-                        {
-                            "event_kind": "pipeline_run_finished",
-                            "validated_parent_step_count": (
-                                validation_result.validated_parent_step_count
-                            ),
-                            "latest_locked_row_order": (
-                                validation_result.latest_locked_row_order
-                            ),
-                            "latest_locked_parent_step_id": (
-                                validation_result.latest_locked_parent_step_id
-                            ),
-                            "expected_final_managed_area_ha": (
-                                validation_result.expected_final_managed_area_ha
-                            ),
-                            "actual_final_managed_area_ha": (
-                                validation_result.actual_final_managed_area_ha
-                            ),
-                            "notes": (
-                                "strict seam executed the locked parent-step sequence "
-                                "through the requested stop target"
-                            ),
-                        }
-                    )
-                    return NamedPipelineExecutionResult(
-                        plan=plan,
-                        tsr_thlb_result=None,
-                        tsr_parent_step_result=parent_step_result,
-                        validation_result=validation_result,
-                        runtime_event_log_path=runtime_event_log_path,
-                    )
-                validation_result = NamedPipelineValidationResult(
-                    contract_kind=plan.validation_contract.contract_kind,
-                    validated_parent_step_count=cast(
-                        int, preflight_result["locked_row_order"]
-                    ),
-                    latest_locked_row_order=cast(
-                        int | None, preflight_result.get("locked_row_order")
-                    ),
-                    latest_locked_parent_step_id=cast(
-                        str | None, preflight_result.get("locked_parent_step_id")
-                    ),
-                    expected_final_managed_area_ha=cast(
-                        float | None, preflight_result.get("expected_benchmark_area_ha")
-                    ),
-                    actual_final_managed_area_ha=cast(
-                        float | None, preflight_result.get("actual_start_area_ha")
-                    ),
-                    max_abs_marginal_delta_ha=0.0,
-                    max_abs_cumulative_delta_ha=abs(
-                        cast(float, preflight_result.get("area_delta_ha", 0.0))
-                    ),
-                )
-                runtime_logger.emit(
-                    {
-                        "event_kind": "pipeline_run_finished",
-                        "validated_parent_step_count": (
-                            validation_result.validated_parent_step_count
-                        ),
-                        "latest_locked_row_order": (
-                            validation_result.latest_locked_row_order
-                        ),
-                        "latest_locked_parent_step_id": (
-                            validation_result.latest_locked_parent_step_id
-                        ),
-                        "expected_final_managed_area_ha": (
-                            validation_result.expected_final_managed_area_ha
-                        ),
-                        "actual_final_managed_area_ha": (
-                            validation_result.actual_final_managed_area_ha
-                        ),
-                        "notes": (
-                            "strict seam validated the locked-chain restart row and "
-                            "stopped before the next parent step"
-                        ),
-                    }
-                )
-                return NamedPipelineExecutionResult(
-                    plan=plan,
-                    tsr_thlb_result=None,
-                    validation_result=validation_result,
-                    runtime_event_log_path=runtime_event_log_path,
-                )
+            if pre_default_result is not None:
+                return pre_default_result
         tsr_result = run_tsr_thlb_netdown_recipe(
             recipe_path=plan.thlb_netdown_recipe_path,
             checkpoint_path=plan.checkpoint_path,
@@ -1848,41 +1173,39 @@ def run_named_pipeline_runbook(
         )
         raise
     try:
-        if (
-            plan.validation_contract is not None
-            and plan.validation_contract.contract_kind == "tsa29_locked_chain_strict"
-        ):
+        if contract_handler is not None and plan.validation_contract is not None:
             runtime_logger.emit(
                 {
                     "event_kind": "pipeline_validation_started",
                     "validation_contract_kind": plan.validation_contract.contract_kind,
                 }
             )
-            validation_result = _validate_tsa29_locked_chain_strict_result(
+            validation_result = contract_handler.validate_after_default(
                 plan=plan,
                 tsr_result=tsr_result,
             )
-            runtime_logger.emit(
-                {
-                    "event_kind": "pipeline_validation_finished",
-                    "validation_contract_kind": validation_result.contract_kind,
-                    "validated_parent_step_count": (
-                        validation_result.validated_parent_step_count
-                    ),
-                    "latest_locked_row_order": (
-                        validation_result.latest_locked_row_order
-                    ),
-                    "latest_locked_parent_step_id": (
-                        validation_result.latest_locked_parent_step_id
-                    ),
-                    "expected_final_managed_area_ha": (
-                        validation_result.expected_final_managed_area_ha
-                    ),
-                    "actual_final_managed_area_ha": (
-                        validation_result.actual_final_managed_area_ha
-                    ),
-                }
-            )
+            if validation_result is not None:
+                runtime_logger.emit(
+                    {
+                        "event_kind": "pipeline_validation_finished",
+                        "validation_contract_kind": validation_result.contract_kind,
+                        "validated_parent_step_count": (
+                            validation_result.validated_parent_step_count
+                        ),
+                        "latest_locked_row_order": (
+                            validation_result.latest_locked_row_order
+                        ),
+                        "latest_locked_parent_step_id": (
+                            validation_result.latest_locked_parent_step_id
+                        ),
+                        "expected_final_managed_area_ha": (
+                            validation_result.expected_final_managed_area_ha
+                        ),
+                        "actual_final_managed_area_ha": (
+                            validation_result.actual_final_managed_area_ha
+                        ),
+                    }
+                )
     except Exception as exc:
         runtime_logger.emit(
             {

--- a/tests/test_named_pipelines.py
+++ b/tests/test_named_pipelines.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from types import SimpleNamespace
 
-import geopandas as gpd
 import pytest
-from shapely.geometry import box
 
 from femic import named_pipelines
 
@@ -489,75 +486,43 @@ def test_run_named_pipeline_runbook_dispatches_to_tsr_thlb_runner(
     assert any("event_kind=pipeline_run_finished" in line for line in runtime_lines)
 
 
-def _write_checkpoint_with_area(path: Path, *, area_ha: float) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    gpd.GeoDataFrame(
-        {
-            "_stand_area_sqm": [area_ha * 10000.0],
-            "thlb_fact": [1.0],
-        },
-        geometry=[box(0.0, 0.0, 1.0, 1.0)],
-        crs="EPSG:3005",
-    ).to_feather(path)
+class _FixtureContractHandler:
+    contract_kind = "fixture_contract"
+
+    def __init__(self, *, pre_default_result=None) -> None:
+        self.pre_default_result = pre_default_result
+        self.pre_default_called = False
+        self.validate_called = False
+
+    def run_before_default(self, *, plan, runtime_logger, runtime_event_log_path):
+        self.pre_default_called = True
+        runtime_logger.emit({"event_kind": "fixture_contract_pre_default"})
+        return self.pre_default_result
+
+    def validate_after_default(self, *, plan, tsr_result):
+        self.validate_called = True
+        return named_pipelines.NamedPipelineValidationResult(
+            contract_kind=plan.validation_contract.contract_kind,
+            validated_parent_step_count=1,
+            latest_locked_row_order=1,
+            latest_locked_parent_step_id="fixture_parent_step",
+            expected_final_managed_area_ha=1000.0,
+            actual_final_managed_area_ha=tsr_result.final_managed_area_ha,
+            max_abs_marginal_delta_ha=0.0,
+            max_abs_cumulative_delta_ha=0.0,
+        )
 
 
-def test_run_named_pipeline_runbook_validates_tsa29_locked_chain_contract(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    audit_path = instance_root / "config" / "tsr" / "thlb_reconstructed.audit.json"
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    _write_checkpoint_with_area(
-        instance_root / "data" / "tsr" / "aflb_checkpoint.feather",
-        area_ha=800.0,
-    )
-    _write_checkpoint_with_area(
-        instance_root / "data" / "tsr" / "aflb_yield_ready_checkpoint.feather",
-        area_ha=800.0,
-    )
-    audit_path.write_text(
-        json.dumps(
-            {
-                "steps": [
-                    {
-                        "parent_step_id": "thlb_parent_005_analysis_forest_land_base",
-                        "order_index": 5,
-                        "parent_label": "Analysis forest land base",
-                        "net_removed_area_ha": 0.0,
-                        "remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 5,
-                        "parent_step_id": "thlb_parent_005_analysis_forest_land_base",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+def _reset_contract_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(named_pipelines, "_NAMED_PIPELINE_CONTRACT_HANDLERS", {})
+    monkeypatch.setattr(named_pipelines, "_DISCOVERED_NAMED_PIPELINE_CONTRACTS", True)
 
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
+
+def _fixture_contract_plan(
+    instance_root: Path,
+) -> named_pipelines.NamedPipelineExecutionPlan:
+    return named_pipelines.NamedPipelineExecutionPlan(
+        runbook_path=instance_root / "runbooks" / "pipelines" / "fixture.yaml",
         instance_root=instance_root,
         pipeline_id="tsr.thlb_strict",
         pipeline_label="TSR strict THLB product lane",
@@ -570,13 +535,10 @@ def test_run_named_pipeline_runbook_validates_tsa29_locked_chain_contract(
         overlay_paths=(),
         parameter_files=(),
         validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
+            contract_kind="fixture_contract",
+            locked_chain_ledger_path=None,
+            comparison_report_path=None,
+            required_recipe_path=None,
         ),
         user_registry_path=None,
         instance_registry_path=None,
@@ -592,6 +554,30 @@ def test_run_named_pipeline_runbook_validates_tsa29_locked_chain_contract(
         execution_mode="reconstructed",
     )
 
+
+def test_register_named_pipeline_contract_handler_rejects_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_contract_handlers(monkeypatch)
+    named_pipelines.register_named_pipeline_contract_handler(_FixtureContractHandler())
+
+    with pytest.raises(named_pipelines.NamedPipelineError, match="already registered"):
+        named_pipelines.register_named_pipeline_contract_handler(
+            _FixtureContractHandler()
+        )
+
+
+def test_named_pipeline_contract_handler_dispatches_default_run_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_contract_handlers(monkeypatch)
+    instance_root = tmp_path / "instance"
+    plan = _fixture_contract_plan(instance_root)
+    handler = _FixtureContractHandler()
+    named_pipelines.register_named_pipeline_contract_handler(handler)
+    captured_lines: list[str] = []
+
     monkeypatch.setattr(
         named_pipelines,
         "build_named_pipeline_execution_plan",
@@ -601,231 +587,49 @@ def test_run_named_pipeline_runbook_validates_tsa29_locked_chain_contract(
         named_pipelines,
         "run_tsr_thlb_netdown_recipe",
         lambda **kwargs: SimpleNamespace(
-            audit_path=audit_path,
-            final_managed_area_ha=800.0,
-            step_count=2,
-            runtime_status_report_path=instance_root
-            / "runtime"
-            / "logs"
-            / "tsr"
-            / "thlb_reconstructed_status_report-20260419T000000Z.md",
+            audit_path=instance_root / "runtime" / "audit.json",
+            final_managed_area_ha=1000.0,
+            step_count=1,
+            runtime_status_report_path=instance_root / "runtime" / "status.md",
         ),
     )
 
     result = named_pipelines.run_named_pipeline_runbook(
         runbook_path=plan.runbook_path,
         instance_root=instance_root,
+        runtime_event_sink=captured_lines.append,
     )
 
+    assert handler.pre_default_called is True
+    assert handler.validate_called is True
     assert result.validation_result is not None
-    assert result.validation_result.contract_kind == "tsa29_locked_chain_strict"
-    assert result.validation_result.validated_parent_step_count == 1
-    assert result.validation_result.latest_locked_row_order == 5
-    assert (
-        result.validation_result.latest_locked_parent_step_id
-        == "thlb_parent_005_analysis_forest_land_base"
+    assert result.validation_result.contract_kind == "fixture_contract"
+    assert any(
+        "event_kind=fixture_contract_pre_default" in line for line in captured_lines
     )
-    assert result.validation_result.expected_final_managed_area_ha == pytest.approx(
-        800.0
+    assert any(
+        "event_kind=pipeline_validation_finished" in line for line in captured_lines
     )
-    assert result.validation_result.actual_final_managed_area_ha == pytest.approx(800.0)
-    assert result.validation_result.max_abs_marginal_delta_ha == pytest.approx(0.0)
-    assert result.validation_result.max_abs_cumulative_delta_ha == pytest.approx(0.0)
 
 
-def test_run_named_pipeline_runbook_rejects_tsa29_locked_chain_mismatch(
+def test_named_pipeline_contract_handler_can_return_pre_default_result(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _reset_contract_handlers(monkeypatch)
     instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    audit_path = instance_root / "config" / "tsr" / "thlb_reconstructed.audit.json"
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    _write_checkpoint_with_area(
-        instance_root / "data" / "tsr" / "aflb_checkpoint.feather",
-        area_ha=800.0,
-    )
-    _write_checkpoint_with_area(
-        instance_root / "data" / "tsr" / "aflb_yield_ready_checkpoint.feather",
-        area_ha=800.0,
-    )
-    audit_path.write_text(
-        json.dumps(
-            {
-                "steps": [
-                    {
-                        "parent_step_id": "thlb_parent_005_analysis_forest_land_base",
-                        "order_index": 5,
-                        "parent_label": "Analysis forest land base",
-                        "net_removed_area_ha": 10.0,
-                        "remaining_area_ha": 790.0,
-                    },
-                ]
-            },
-            indent=2,
+    plan = _fixture_contract_plan(instance_root)
+    expected = named_pipelines.NamedPipelineExecutionResult(
+        plan=plan,
+        tsr_thlb_result=None,
+        validation_result=named_pipelines.NamedPipelineValidationResult(
+            contract_kind="fixture_contract",
+            validated_parent_step_count=1,
         ),
-        encoding="utf-8",
+        runtime_event_log_path=instance_root / "runtime" / "fixture.log",
     )
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 5,
-                        "parent_step_id": "thlb_parent_005_analysis_forest_land_base",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="aflb_yield_ready",
-        checkpoint_path=instance_root
-        / "data"
-        / "tsr"
-        / "aflb_yield_ready_checkpoint.feather",
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_named_pipeline_execution_plan",
-        lambda **kwargs: plan,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_netdown_recipe",
-        lambda **kwargs: SimpleNamespace(
-            audit_path=audit_path,
-            final_managed_area_ha=790.0,
-            step_count=2,
-            runtime_status_report_path=instance_root
-            / "runtime"
-            / "logs"
-            / "tsr"
-            / "thlb_reconstructed_status_report-20260419T000000Z.md",
-        ),
-    )
-
-    with pytest.raises(named_pipelines.NamedPipelineError) as excinfo:
-        named_pipelines.run_named_pipeline_runbook(
-            runbook_path=plan.runbook_path,
-            instance_root=instance_root,
-        )
-
-    assert "Strict validation contract mismatch at row `5`" in str(excinfo.value)
-
-
-def test_run_named_pipeline_runbook_rejects_tsa29_preflight_mismatch_before_execution(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    _write_checkpoint_with_area(
-        instance_root / "data" / "tsr" / "aflb_checkpoint.feather",
-        area_ha=810.0,
-    )
-    _write_checkpoint_with_area(
-        instance_root / "data" / "tsr" / "aflb_yield_ready_checkpoint.feather",
-        area_ha=810.0,
-    )
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 5,
-                        "parent_step_id": "thlb_parent_005_analysis_forest_land_base",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="aflb_yield_ready",
-        checkpoint_path=instance_root
-        / "data"
-        / "tsr"
-        / "aflb_yield_ready_checkpoint.feather",
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-    captured_lines: list[str] = []
+    handler = _FixtureContractHandler(pre_default_result=expected)
+    named_pipelines.register_named_pipeline_contract_handler(handler)
     run_called = False
 
     monkeypatch.setattr(
@@ -837,99 +641,28 @@ def test_run_named_pipeline_runbook_rejects_tsa29_preflight_mismatch_before_exec
     def _fake_run(**kwargs: object) -> object:
         nonlocal run_called
         run_called = True
-        raise AssertionError("downstream runner should not be called")
+        raise AssertionError("default runner should not be called")
 
     monkeypatch.setattr(named_pipelines, "run_tsr_thlb_netdown_recipe", _fake_run)
 
-    with pytest.raises(named_pipelines.NamedPipelineError) as excinfo:
-        named_pipelines.run_named_pipeline_runbook(
-            runbook_path=plan.runbook_path,
-            instance_root=instance_root,
-            runtime_event_sink=captured_lines.append,
-        )
-
-    error_message = str(excinfo.value)
-    assert (
-        "Strict validation preflight mismatch for seam `aflb_yield_ready`"
-        in error_message
+    result = named_pipelines.run_named_pipeline_runbook(
+        runbook_path=plan.runbook_path,
+        instance_root=instance_root,
     )
-    assert "locked row `5`" in error_message
-    assert "expected `800.000 ha`" in error_message
-    assert "got `810.000 ha`" in error_message
-    assert "delta `10.000 ha`" in error_message
+
+    assert result is expected
+    assert handler.pre_default_called is True
     assert run_called is False
-    assert any(
-        "event_kind=pipeline_validation_preflight_started" in line
-        for line in captured_lines
-    )
-    assert any("event_kind=pipeline_run_failed" in line for line in captured_lines)
-    assert not any("event_kind=parent_step_started" in line for line in captured_lines)
 
 
-def test_run_named_pipeline_runbook_validates_tsa29_preflight_scratch_with_raw_glb_builder(
+def test_named_pipeline_contract_handler_missing_errors_before_execution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _reset_contract_handlers(monkeypatch)
     instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 1,
-                        "parent_step_id": "thlb_parent_001_total_tsa_area",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 1000.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="scratch",
-        checkpoint_path=None,
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
+    plan = _fixture_contract_plan(instance_root)
     run_called = False
-    captured_lines: list[str] = []
-
     monkeypatch.setattr(
         named_pipelines,
         "build_named_pipeline_execution_plan",
@@ -939,919 +672,39 @@ def test_run_named_pipeline_runbook_validates_tsa29_preflight_scratch_with_raw_g
     def _fake_run(**kwargs: object) -> object:
         nonlocal run_called
         run_called = True
-        raise AssertionError("downstream runner should not be called")
+        raise AssertionError("default runner should not be called")
 
     monkeypatch.setattr(named_pipelines, "run_tsr_thlb_netdown_recipe", _fake_run)
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_tsa_raw_glb",
-        lambda **kwargs: SimpleNamespace(
-            clipped_area_ha=1000.0,
-            clipped_glb_gdb_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "clipped.gdb",
-            clipped_glb_feature_class="tsa_glb_vri_2024",
-            summary_json_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "glb_summary.json",
-            summary_markdown_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "glb_summary.md",
-        ),
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "_materialize_tsa29_glb_checkpoint_from_result",
-        lambda **kwargs: instance_root / "data" / "tsr" / "glb_checkpoint.feather",
-    )
 
-    result = named_pipelines.run_named_pipeline_runbook(
-        runbook_path=plan.runbook_path,
-        instance_root=instance_root,
-        runtime_event_sink=captured_lines.append,
-    )
-
-    assert run_called is False
-    assert result.tsr_thlb_result is None
-    assert result.validation_result is not None
-    assert result.validation_result.validated_parent_step_count == 1
-    assert result.validation_result.latest_locked_row_order == 1
-    assert result.validation_result.expected_final_managed_area_ha == pytest.approx(
-        1000.0
-    )
-    assert result.validation_result.actual_final_managed_area_ha == pytest.approx(
-        1000.0
-    )
-    assert any(
-        "event_kind=pipeline_validation_preflight_started" in line
-        for line in captured_lines
-    )
-    assert any(
-        "event_kind=pipeline_validation_preflight_finished" in line
-        for line in captured_lines
-    )
-    assert any("event_kind=pipeline_run_finished" in line for line in captured_lines)
-    assert not any("event_kind=parent_step_started" in line for line in captured_lines)
-
-
-def test_run_named_pipeline_runbook_executes_target_parent_step_from_scratch(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 1,
-                        "parent_step_id": "thlb_parent_001_total_tsa_area",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 1000.0,
-                    },
-                    {
-                        "row_order": 2,
-                        "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                        "locked_net_removed_area_ha": 200.0,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="scratch",
-        checkpoint_path=None,
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        target_parent_step_id="thlb_parent_002_land_not_administered_by_the_province",
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-    captured_lines: list[str] = []
-
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_named_pipeline_execution_plan",
-        lambda **kwargs: plan,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_tsa_raw_glb",
-        lambda **kwargs: SimpleNamespace(
-            clipped_area_ha=1000.0,
-            clipped_glb_gdb_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "clipped.gdb",
-            clipped_glb_feature_class="tsa_glb_vri_2024",
-            summary_json_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "glb_summary.json",
-            summary_markdown_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "glb_summary.md",
-        ),
-    )
-    checkpoint_path = instance_root / "data" / "tsr" / "glb_checkpoint.feather"
-    monkeypatch.setattr(
-        named_pipelines,
-        "_materialize_tsa29_glb_checkpoint_from_result",
-        lambda **kwargs: checkpoint_path,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "_managed_area_ha_from_checkpoint",
-        lambda path: 1000.0 if path == checkpoint_path else 800.0,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "load_tsr_thlb_netdown_recipe",
-        lambda path: SimpleNamespace(
-            parent_steps=(
-                {
-                    "parent_step_id": "thlb_parent_001_total_tsa_area",
-                    "parent_label": "Total TSA area",
-                    "row_order": 1,
-                    "parent_kind": "milestone",
-                    "execution_class": "reference_only",
-                    "land_base_stage": "reference_target",
-                },
-                {
-                    "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                    "parent_label": "Land not administered by the Province",
-                    "row_order": 2,
-                    "parent_kind": "transformation",
-                    "execution_class": "bounded_step_run",
-                    "land_base_stage": "glb_to_aflb",
-                    "approved": True,
-                    "ratchet_state": "approved",
-                    "last_notebook_run_status": "applied",
-                    "compiled_logic": ({"step_id": "thlb_parent_002_compiled_01"},),
-                },
-            )
-        ),
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_parent_step",
-        lambda **kwargs: (_ for _ in ()).throw(
-            AssertionError("broad runner must stay dead")
-        ),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_locked_parent_step",
-        lambda **kwargs: SimpleNamespace(
-            parent_step_id="thlb_parent_002_land_not_administered_by_the_province",
-            parent_label="Land not administered by the Province",
-            recipe_path=plan.thlb_netdown_recipe_path,
-            tsa=SimpleNamespace(
-                tsa_id="tsa_29", tsa_code="29", tsa_name="Williams Lake"
-            ),
-            checkpoint_path=checkpoint_path,
-            selected_map_ids=(),
-            selected_landscape_units=(),
-            output_path=instance_root
-            / "data"
-            / "tsr"
-            / "strict_chain"
-            / "02_thlb_parent_002_land_not_administered_by_the_province.feather",
-            result_json_path=instance_root
-            / "runtime"
-            / "logs"
-            / "tsr"
-            / "strict_chain"
-            / "02_thlb_parent_002_land_not_administered_by_the_province.json",
-            status="applied",
-            executed_parent_step_ids=(
-                "thlb_parent_002_land_not_administered_by_the_province",
-            ),
-            input_area_ha=1000.0,
-            removed_area_ha=200.0,
-            remaining_area_ha=800.0,
-            benchmark_marginal_area_ha=200.0,
-            benchmark_cumulative_area_ha=800.0,
-            benchmark_marginal_delta_ha=0.0,
-            benchmark_cumulative_delta_ha=0.0,
-            smoke_benchmark_scale_factor=None,
-            scaled_benchmark_marginal_area_ha=None,
-            scaled_benchmark_cumulative_area_ha=None,
-            scaled_benchmark_marginal_delta_ha=None,
-            scaled_benchmark_cumulative_delta_ha=None,
-            notes=(),
-            execution_mode="serial",
-            worker_count=1,
-            lu_chunk_count=None,
-            lu_bundle_count=None,
-            progress_root=None,
-            profiling=None,
-        ),
-    )
-
-    result = named_pipelines.run_named_pipeline_runbook(
-        runbook_path=plan.runbook_path,
-        instance_root=instance_root,
-        runtime_event_sink=captured_lines.append,
-    )
-
-    assert result.tsr_thlb_result is None
-    assert result.tsr_parent_step_result is not None
-    assert result.tsr_parent_step_result.parent_step_id == (
-        "thlb_parent_002_land_not_administered_by_the_province"
-    )
-    assert result.validation_result is not None
-    assert result.validation_result.validated_parent_step_count == 2
-    assert result.validation_result.actual_final_managed_area_ha == pytest.approx(800.0)
-    assert any("event_kind=parent_step_started" in line for line in captured_lines)
-    assert any("event_kind=parent_step_finished" in line for line in captured_lines)
-
-
-def test_run_named_pipeline_runbook_sequences_locked_parent_steps_from_scratch(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 1,
-                        "parent_step_id": "thlb_parent_001_total_tsa_area",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 1000.0,
-                    },
-                    {
-                        "row_order": 2,
-                        "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                        "locked_net_removed_area_ha": 200.0,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                    {
-                        "row_order": 3,
-                        "parent_step_id": "thlb_parent_003_analysis_units",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="scratch",
-        checkpoint_path=None,
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        target_parent_step_id="thlb_parent_003_analysis_units",
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-    captured_lines: list[str] = []
-    run_calls: list[Path] = []
-
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_named_pipeline_execution_plan",
-        lambda **kwargs: plan,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_tsa_raw_glb",
-        lambda **kwargs: SimpleNamespace(
-            clipped_area_ha=1000.0,
-            clipped_glb_gdb_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "clipped.gdb",
-            clipped_glb_feature_class="tsa_glb_vri_2024",
-            summary_json_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "glb_summary.json",
-            summary_markdown_path=instance_root
-            / "runtime"
-            / "logs"
-            / "glb_build"
-            / "glb_summary.md",
-        ),
-    )
-    glb_checkpoint_path = instance_root / "data" / "tsr" / "glb_checkpoint.feather"
-    row2_checkpoint_path = instance_root / "data" / "tsr" / "row2_checkpoint.feather"
-    monkeypatch.setattr(
-        named_pipelines,
-        "_materialize_tsa29_glb_checkpoint_from_result",
-        lambda **kwargs: glb_checkpoint_path,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "_managed_area_ha_from_checkpoint",
-        lambda path: 1000.0 if path == glb_checkpoint_path else 800.0,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "load_tsr_thlb_netdown_recipe",
-        lambda path: SimpleNamespace(
-            parent_steps=(
-                {
-                    "parent_step_id": "thlb_parent_001_total_tsa_area",
-                    "parent_label": "Total TSA area",
-                    "row_order": 1,
-                    "parent_kind": "milestone",
-                    "execution_class": "reference_only",
-                    "land_base_stage": "reference_target",
-                },
-                {
-                    "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                    "parent_label": "Land not administered by the Province",
-                    "row_order": 2,
-                    "parent_kind": "transformation",
-                    "execution_class": "bounded_step_run",
-                    "land_base_stage": "glb_to_aflb",
-                    "approved": True,
-                    "ratchet_state": "approved",
-                    "last_notebook_run_status": "applied",
-                    "compiled_logic": ({"step_id": "thlb_parent_002_compiled_01"},),
-                },
-                {
-                    "parent_step_id": "thlb_parent_003_analysis_units",
-                    "parent_label": "Analysis units",
-                    "row_order": 3,
-                    "parent_kind": "milestone",
-                    "execution_class": "reference_only",
-                    "land_base_stage": "glb_to_aflb",
-                },
-            )
-        ),
-    )
-
-    def _fake_locked_parent_step_run(**kwargs: object) -> object:
-        run_calls.append(kwargs["checkpoint_path"])
-        return SimpleNamespace(
-            parent_step_id="thlb_parent_002_land_not_administered_by_the_province",
-            parent_label="Land not administered by the Province",
-            recipe_path=plan.thlb_netdown_recipe_path,
-            tsa=SimpleNamespace(
-                tsa_id="tsa_29", tsa_code="29", tsa_name="Williams Lake"
-            ),
-            checkpoint_path=glb_checkpoint_path,
-            selected_map_ids=(),
-            selected_landscape_units=(),
-            output_path=row2_checkpoint_path,
-            result_json_path=instance_root / "runtime" / "logs" / "tsr" / "step2.json",
-            status="applied",
-            executed_parent_step_ids=(
-                "thlb_parent_002_land_not_administered_by_the_province",
-            ),
-            input_area_ha=1000.0,
-            removed_area_ha=200.0,
-            remaining_area_ha=800.0,
-            benchmark_marginal_area_ha=200.0,
-            benchmark_cumulative_area_ha=800.0,
-            benchmark_marginal_delta_ha=0.0,
-            benchmark_cumulative_delta_ha=0.0,
-            smoke_benchmark_scale_factor=None,
-            scaled_benchmark_marginal_area_ha=None,
-            scaled_benchmark_cumulative_area_ha=None,
-            scaled_benchmark_marginal_delta_ha=None,
-            scaled_benchmark_cumulative_delta_ha=None,
-            notes=(),
-            execution_mode="serial",
-            worker_count=1,
-            lu_chunk_count=None,
-            lu_bundle_count=None,
-            progress_root=None,
-            profiling=None,
-        )
-
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_parent_step",
-        lambda **kwargs: (_ for _ in ()).throw(
-            AssertionError("broad runner must stay dead")
-        ),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_locked_parent_step",
-        _fake_locked_parent_step_run,
-    )
-
-    result = named_pipelines.run_named_pipeline_runbook(
-        runbook_path=plan.runbook_path,
-        instance_root=instance_root,
-        runtime_event_sink=captured_lines.append,
-    )
-
-    assert run_calls == [glb_checkpoint_path]
-    assert result.tsr_parent_step_result is not None
-    assert result.tsr_parent_step_result.output_path == row2_checkpoint_path
-    assert result.validation_result is not None
-    assert result.validation_result.validated_parent_step_count == 3
-    assert result.validation_result.latest_locked_parent_step_id == (
-        "thlb_parent_003_analysis_units"
-    )
-    assert result.validation_result.actual_final_managed_area_ha == pytest.approx(800.0)
-    assert any("run_status=reference_validated" in line for line in captured_lines)
-
-
-def test_materialize_tsa29_glb_checkpoint_normalizes_area_columns(
-    tmp_path: Path,
-) -> None:
-    instance_root = tmp_path / "instance"
-    clipped_glb_gdb_path = tmp_path / "glb.gpkg"
-    gdf = gpd.GeoDataFrame(
-        {
-            "FEATURE_AREA_SQM": [999.0],
-            "POLYGON_AREA": [999.0],
-            "Shape_Area": [999.0],
-            "GEOMETRY_AREA": [999.0],
-        },
-        geometry=[box(0, 0, 100, 100)],
-        crs="EPSG:3005",
-    )
-    gdf.to_file(clipped_glb_gdb_path, layer="tsa_glb_vri_2024", driver="GPKG")
-
-    checkpoint_path = named_pipelines._materialize_tsa29_glb_checkpoint_from_result(
-        instance_root=instance_root,
-        clipped_glb_gdb_path=clipped_glb_gdb_path,
-        clipped_glb_feature_class="tsa_glb_vri_2024",
-    )
-
-    checkpoint = gpd.read_feather(checkpoint_path)
-    assert checkpoint["FEATURE_AREA_SQM"].tolist() == pytest.approx([10000.0])
-    assert checkpoint["POLYGON_AREA"].tolist() == pytest.approx([1.0])
-    assert checkpoint["Shape_Area"].tolist() == pytest.approx([10000.0])
-    assert checkpoint["GEOMETRY_AREA"].tolist() == pytest.approx([1.0])
-
-
-def test_run_named_pipeline_runbook_rejects_unapproved_locked_step(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "data" / "tsr").mkdir(parents=True, exist_ok=True)
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 1,
-                        "parent_step_id": "thlb_parent_001_total_tsa_area",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 1000.0,
-                    },
-                    {
-                        "row_order": 2,
-                        "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                        "locked_net_removed_area_ha": 200.0,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    glb_checkpoint_path = instance_root / "data" / "tsr" / "glb_checkpoint.feather"
-    glb_checkpoint_path.write_text("stub\n", encoding="utf-8")
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="glb",
-        checkpoint_path=glb_checkpoint_path,
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        target_parent_step_id="thlb_parent_002_land_not_administered_by_the_province",
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_named_pipeline_execution_plan",
-        lambda **kwargs: plan,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "_managed_area_ha_from_checkpoint",
-        lambda path: 1000.0,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "load_tsr_thlb_netdown_recipe",
-        lambda path: SimpleNamespace(
-            parent_steps=(
-                {
-                    "parent_step_id": "thlb_parent_001_total_tsa_area",
-                    "parent_label": "Total TSA area",
-                    "row_order": 1,
-                    "parent_kind": "milestone",
-                    "execution_class": "reference_only",
-                    "land_base_stage": "reference_target",
-                },
-                {
-                    "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                    "parent_label": "Land not administered by the Province",
-                    "row_order": 2,
-                    "parent_kind": "transformation",
-                    "execution_class": "bounded_step_run",
-                    "land_base_stage": "glb_to_aflb",
-                    "approved": False,
-                    "ratchet_state": "draft",
-                    "compiled_logic": ({"step_id": "thlb_parent_002_compiled_01"},),
-                },
-            )
-        ),
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_locked_parent_step",
-        lambda **kwargs: (_ for _ in ()).throw(AssertionError("must not execute")),
-    )
-
-    with pytest.raises(
-        named_pipelines.NamedPipelineError,
-        match="not approved on the locked recipe surface",
-    ):
+    with pytest.raises(named_pipelines.NamedPipelineError, match="not installed"):
         named_pipelines.run_named_pipeline_runbook(
             runbook_path=plan.runbook_path,
             instance_root=instance_root,
         )
 
-
-def test_resolve_tsa29_locked_chain_strict_row_order() -> None:
-    assert (
-        named_pipelines._resolve_tsa29_locked_chain_strict_row_order(seam_id="scratch")
-        == 1
-    )
-    assert (
-        named_pipelines._resolve_tsa29_locked_chain_strict_row_order(seam_id="glb") == 1
-    )
-    assert (
-        named_pipelines._resolve_tsa29_locked_chain_strict_row_order(seam_id="aflb")
-        == 5
-    )
-    assert (
-        named_pipelines._resolve_tsa29_locked_chain_strict_row_order(
-            seam_id="aflb_yield_ready"
-        )
-        == 5
-    )
-    with pytest.raises(
-        named_pipelines.NamedPipelineError, match="does not yet support seam"
-    ):
-        named_pipelines._resolve_tsa29_locked_chain_strict_row_order(
-            seam_id="lhlb_curve_ready"
-        )
+    assert run_called is False
 
 
-def test_locked_strict_contract_allows_benchmarked_rows_with_compiled_logic() -> None:
-    parent_step = {
-        "parent_step_id": "thlb_parent_006_parks_protected_areas_area_base_tenures",
-        "ratchet_state": "benchmarked",
-        "compiled_logic": ({"step_id": "thlb_parent_006_compiled_01"},),
-    }
-
-    assert (
-        named_pipelines._validate_locked_strict_parent_step_execution_contract(
-            parent_step
-        )
-        is parent_step
-    )
-
-
-def test_run_named_pipeline_runbook_routes_aflb_strict_seam_to_locked_sequence(
-    tmp_path: Path,
+def test_discover_named_pipeline_contract_handlers_loads_entry_points(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    checkpoint_path = (
-        instance_root
-        / "data"
-        / "tsr"
-        / "strict_chain"
-        / "04_thlb_parent_004_roads_and_landings.feather"
-    )
-    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-    checkpoint_path.write_text("stub\n", encoding="utf-8")
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 5,
-                        "parent_step_id": "thlb_parent_005_analysis_forest_land_base",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 1000.0,
-                    },
-                    {
-                        "row_order": 6,
-                        "parent_step_id": "thlb_parent_006_parks_protected_areas_area_base_tenures",
-                        "locked_net_removed_area_ha": 200.0,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="aflb",
-        checkpoint_path=checkpoint_path,
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        target_parent_step_id="thlb_parent_006_parks_protected_areas_area_base_tenures",
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-    locked_calls: list[Path] = []
-
+    _reset_contract_handlers(monkeypatch)
+    monkeypatch.setattr(named_pipelines, "_DISCOVERED_NAMED_PIPELINE_CONTRACTS", False)
+    handler = _FixtureContractHandler()
+    entry_point = SimpleNamespace(name="fixture", load=lambda: lambda: handler)
     monkeypatch.setattr(
         named_pipelines,
-        "build_named_pipeline_execution_plan",
-        lambda **kwargs: plan,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "_managed_area_ha_from_checkpoint",
-        lambda path: 1000.0,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "load_tsr_thlb_netdown_recipe",
-        lambda path: SimpleNamespace(
-            parent_steps=(
-                {
-                    "parent_step_id": "thlb_parent_006_parks_protected_areas_area_base_tenures",
-                    "parent_label": "Parks, protected areas, area-base tenures",
-                    "row_order": 6,
-                    "parent_kind": "transformation",
-                    "execution_class": "legal_harvest_exclusion",
-                    "land_base_stage": "aflb_to_lhlb",
-                    "ratchet_state": "benchmarked",
-                    "compiled_logic": ({"step_id": "thlb_parent_006_compiled_01"},),
-                },
-                {
-                    "parent_step_id": "thlb_parent_007_old_growth_management_areas",
-                    "parent_label": "Old growth management areas",
-                    "row_order": 7,
-                    "parent_kind": "transformation",
-                    "execution_class": "legal_harvest_exclusion",
-                    "land_base_stage": "aflb_to_lhlb",
-                    "approved": True,
-                    "compiled_logic": ({"step_id": "thlb_parent_007_compiled_01"},),
-                },
-            )
-        ),
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_netdown_recipe",
-        lambda **kwargs: (_ for _ in ()).throw(
-            AssertionError("generic THLB runner must not execute strict aflb seam")
+        "entry_points",
+        lambda *, group: (
+            (entry_point,)
+            if group == named_pipelines.NAMED_PIPELINE_CONTRACT_ENTRY_POINT_GROUP
+            else ()
         ),
     )
 
-    def _fake_locked_parent_step_run(**kwargs: object) -> object:
-        assert (
-            kwargs["parent_step_id"]
-            == "thlb_parent_006_parks_protected_areas_area_base_tenures"
-        )
-        locked_calls.append(kwargs["checkpoint_path"])
-        return SimpleNamespace(
-            parent_step_id="thlb_parent_006_parks_protected_areas_area_base_tenures",
-            parent_label="Parks, protected areas, area-base tenures",
-            recipe_path=plan.thlb_netdown_recipe_path,
-            tsa=SimpleNamespace(
-                tsa_id="tsa_29", tsa_code="29", tsa_name="Williams Lake"
-            ),
-            checkpoint_path=checkpoint_path,
-            selected_map_ids=(),
-            selected_landscape_units=(),
-            output_path=instance_root
-            / "data"
-            / "tsr"
-            / "strict_chain"
-            / "06_thlb_parent_006_parks_protected_areas_area_base_tenures.feather",
-            result_json_path=instance_root
-            / "runtime"
-            / "logs"
-            / "tsr"
-            / "strict_chain"
-            / "06_thlb_parent_006_parks_protected_areas_area_base_tenures.json",
-            status="applied",
-            executed_parent_step_ids=(
-                "thlb_parent_006_parks_protected_areas_area_base_tenures",
-            ),
-            input_area_ha=1000.0,
-            removed_area_ha=200.0,
-            remaining_area_ha=800.0,
-            benchmark_marginal_area_ha=200.0,
-            benchmark_cumulative_area_ha=800.0,
-            benchmark_marginal_delta_ha=0.0,
-            benchmark_cumulative_delta_ha=0.0,
-            smoke_benchmark_scale_factor=None,
-            scaled_benchmark_marginal_area_ha=None,
-            scaled_benchmark_cumulative_area_ha=None,
-            scaled_benchmark_marginal_delta_ha=None,
-            scaled_benchmark_cumulative_delta_ha=None,
-            notes=(),
-            execution_mode="serial",
-            worker_count=1,
-            lu_chunk_count=None,
-            lu_bundle_count=None,
-            progress_root=None,
-            profiling=None,
-        )
+    resolved = named_pipelines.get_named_pipeline_contract_handler("fixture_contract")
 
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_locked_parent_step",
-        _fake_locked_parent_step_run,
-    )
-
-    result = named_pipelines.run_named_pipeline_runbook(
-        runbook_path=plan.runbook_path,
-        instance_root=instance_root,
-    )
-
-    assert locked_calls == [checkpoint_path]
-    assert result.validation_result is not None
-    assert result.validation_result.validated_parent_step_count == 6
-
-
-def test_managed_area_ha_from_checkpoint_uses_explicit_tsr_checkpoint(
-    tmp_path: Path,
-) -> None:
-    checkpoint_path = tmp_path / "data" / "tsr" / "aflb_yield_ready_checkpoint.feather"
-    _write_checkpoint_with_area(checkpoint_path, area_ha=812.5)
-
-    assert named_pipelines._managed_area_ha_from_checkpoint(
-        checkpoint_path
-    ) == pytest.approx(812.5)
-
-
-def test_managed_area_ha_from_checkpoint_uses_feature_area_with_thlb_fact(
-    tmp_path: Path,
-) -> None:
-    checkpoint_path = tmp_path / "data" / "tsr" / "strict_row4_checkpoint.feather"
-    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-    gpd.GeoDataFrame(
-        {
-            "FEATURE_AREA_SQM": [10000.0, 20000.0],
-            "thlb_fact": [0.25, 0.5],
-        },
-        geometry=[box(0.0, 0.0, 100.0, 100.0), box(100.0, 0.0, 300.0, 100.0)],
-        crs="EPSG:3005",
-    ).to_feather(checkpoint_path)
-
-    assert named_pipelines._managed_area_ha_from_checkpoint(
-        checkpoint_path
-    ) == pytest.approx(1.25)
+    assert resolved is handler
 
 
 def test_run_named_pipeline_runbook_emits_pipeline_run_failed_event(
@@ -1918,193 +771,3 @@ def test_run_named_pipeline_runbook_emits_pipeline_run_failed_event(
 
     assert any("event_kind=pipeline_run_failed" in line for line in captured_lines)
     assert any('error="synthetic failure"' in line for line in captured_lines)
-
-
-def test_run_named_pipeline_runbook_executes_from_glb_seam_without_rebuilding_scratch(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    instance_root = tmp_path / "instance"
-    (instance_root / "config" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "workbench" / "tsr").mkdir(parents=True, exist_ok=True)
-    (instance_root / "data" / "tsr").mkdir(parents=True, exist_ok=True)
-    ledger_path = instance_root / "config" / "tsr" / "thlb_locked_chain_ledger.json"
-    comparison_path = (
-        instance_root / "config" / "tsr" / "thlb_reconstruction_comparison.md"
-    )
-    comparison_path.write_text("# comparison\n", encoding="utf-8")
-    ledger_path.write_text(
-        json.dumps(
-            {
-                "entries": [
-                    {
-                        "row_order": 1,
-                        "parent_step_id": "thlb_parent_001_total_tsa_area",
-                        "locked_net_removed_area_ha": None,
-                        "locked_cumulative_remaining_area_ha": 1000.0,
-                    },
-                    {
-                        "row_order": 2,
-                        "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                        "locked_net_removed_area_ha": 200.0,
-                        "locked_cumulative_remaining_area_ha": 800.0,
-                    },
-                ]
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    glb_checkpoint_path = instance_root / "data" / "tsr" / "glb_checkpoint.feather"
-    glb_checkpoint_path.write_text("stub\n", encoding="utf-8")
-    plan = named_pipelines.NamedPipelineExecutionPlan(
-        runbook_path=instance_root / "runbooks" / "pipelines" / "tsa29.yaml",
-        instance_root=instance_root,
-        pipeline_id="tsr.thlb_strict",
-        pipeline_label="TSR strict THLB product lane",
-        seam_id="glb",
-        checkpoint_path=glb_checkpoint_path,
-        run_profile_path=None,
-        overlay_paths=(),
-        parameter_files=(),
-        validation_contract=named_pipelines.NamedPipelineValidationContract(
-            contract_kind="tsa29_locked_chain_strict",
-            locked_chain_ledger_path=ledger_path,
-            comparison_report_path=comparison_path,
-            required_recipe_path=instance_root
-            / "workbench"
-            / "tsr"
-            / "thlb_netdown.locked.recipe.yaml",
-        ),
-        target_parent_step_id="thlb_parent_002_land_not_administered_by_the_province",
-        user_registry_path=None,
-        instance_registry_path=None,
-        explicit_registry_paths=(),
-        thlb_netdown_recipe_path=instance_root
-        / "workbench"
-        / "tsr"
-        / "thlb_netdown.locked.recipe.yaml",
-        source_layers_recipe_path=instance_root
-        / "config"
-        / "tsr"
-        / "source_layers.recipe.yaml",
-        execution_mode="reconstructed",
-    )
-    captured_lines: list[str] = []
-    build_raw_glb_called = False
-
-    monkeypatch.setattr(
-        named_pipelines,
-        "build_named_pipeline_execution_plan",
-        lambda **kwargs: plan,
-    )
-
-    def _fail_build_raw_glb(**kwargs: object) -> object:
-        nonlocal build_raw_glb_called
-        build_raw_glb_called = True
-        raise AssertionError("glb seam must not rebuild scratch")
-
-    monkeypatch.setattr(named_pipelines, "build_tsa_raw_glb", _fail_build_raw_glb)
-    monkeypatch.setattr(
-        named_pipelines,
-        "_managed_area_ha_from_checkpoint",
-        lambda path: 1000.0 if path == glb_checkpoint_path else 800.0,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "load_tsr_thlb_netdown_recipe",
-        lambda path: SimpleNamespace(
-            parent_steps=(
-                {
-                    "parent_step_id": "thlb_parent_001_total_tsa_area",
-                    "parent_label": "Total TSA area",
-                    "row_order": 1,
-                    "parent_kind": "milestone",
-                    "execution_class": "reference_only",
-                    "land_base_stage": "reference_target",
-                },
-                {
-                    "parent_step_id": "thlb_parent_002_land_not_administered_by_the_province",
-                    "parent_label": "Land not administered by the Province",
-                    "row_order": 2,
-                    "parent_kind": "transformation",
-                    "execution_class": "bounded_step_run",
-                    "land_base_stage": "glb_to_aflb",
-                    "approved": True,
-                    "ratchet_state": "approved",
-                    "last_notebook_run_status": "applied",
-                    "compiled_logic": ({"step_id": "thlb_parent_002_compiled_01"},),
-                },
-            )
-        ),
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_parent_step",
-        lambda **kwargs: (_ for _ in ()).throw(
-            AssertionError("broad runner must stay dead")
-        ),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        named_pipelines,
-        "run_tsr_thlb_locked_parent_step",
-        lambda **kwargs: SimpleNamespace(
-            parent_step_id="thlb_parent_002_land_not_administered_by_the_province",
-            parent_label="Land not administered by the Province",
-            recipe_path=plan.thlb_netdown_recipe_path,
-            tsa=SimpleNamespace(
-                tsa_id="tsa_29", tsa_code="29", tsa_name="Williams Lake"
-            ),
-            checkpoint_path=glb_checkpoint_path,
-            selected_map_ids=(),
-            selected_landscape_units=(),
-            output_path=instance_root
-            / "data"
-            / "tsr"
-            / "strict_chain"
-            / "02_thlb_parent_002_land_not_administered_by_the_province.feather",
-            result_json_path=instance_root
-            / "runtime"
-            / "logs"
-            / "tsr"
-            / "strict_chain"
-            / "02_thlb_parent_002_land_not_administered_by_the_province.json",
-            status="applied",
-            executed_parent_step_ids=(
-                "thlb_parent_002_land_not_administered_by_the_province",
-            ),
-            input_area_ha=1000.0,
-            removed_area_ha=200.0,
-            remaining_area_ha=800.0,
-            benchmark_marginal_area_ha=200.0,
-            benchmark_cumulative_area_ha=800.0,
-            benchmark_marginal_delta_ha=0.0,
-            benchmark_cumulative_delta_ha=0.0,
-            smoke_benchmark_scale_factor=None,
-            scaled_benchmark_marginal_area_ha=None,
-            scaled_benchmark_cumulative_area_ha=None,
-            scaled_benchmark_marginal_delta_ha=None,
-            scaled_benchmark_cumulative_delta_ha=None,
-            notes=(),
-            execution_mode="serial",
-            worker_count=1,
-            lu_chunk_count=None,
-            lu_bundle_count=None,
-            progress_root=None,
-            profiling=None,
-        ),
-    )
-
-    result = named_pipelines.run_named_pipeline_runbook(
-        runbook_path=plan.runbook_path,
-        instance_root=instance_root,
-        runtime_event_sink=captured_lines.append,
-    )
-
-    assert build_raw_glb_called is False
-    assert result.validation_result is not None
-    assert result.validation_result.validated_parent_step_count == 2
-    assert any(
-        "checkpoint_path=" + str(glb_checkpoint_path) in line for line in captured_lines
-    )


### PR DESCRIPTION
## Summary
- add generic `NamedPipelineContractHandler` registration and entry-point discovery under `femic.named_pipeline_contracts`
- replace embedded TSA29 strict-chain branches in `femic.named_pipelines` with contract-handler dispatch
- update parent docs/tests so FEMIC core owns generic named-pipeline plumbing, not TSA29 strict-chain semantics

## Validation
- `ruff check src tests`
- `mypy src/femic/named_pipelines.py`
- focused pytest for named pipelines, pipeline CLI output, and boundary guard
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`

Depends on UBC-FRESH/femic-tsa29-instance#16. The parent submodule pointer should be updated after that PR is merged.

Refs #250.