### PR TITLE
P94: Complete core decoupling from example instances

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19128,3 +19128,31 @@
 - P93 closes with FEMIC core no longer shipping named K3Z/TSA29 installable
   instance metadata by default; installed instance packages or explicit user
   catalog YAML files now provide example instance catalog entries.
+
+## 2026-07-01 - Opened P94 final core decoupling
+
+- Created parent branch `feature/p94-final-core-decoupling`.
+- Expanded the P94 roadmap into subtasks covering the final source audit,
+  generic template/help cleanup, zero-count boundary guard, absence regression
+  tests, docs/changelog updates, and closeout verification.
+- Locked the P94 goal: FEMIC core must not depend on any named example
+  instance under `external/`; K3Z, TSA29, MKRF, TFL6, and future examples are
+  optional deployments provided through instance packages or explicit user
+  configuration.
+
+## 2026-07-01 - Implemented P94 final named-instance scrub
+
+- Removed the remaining named example-instance references from `src/femic`
+  code comments, CLI help/default text, packaged Patchworks runtime templates,
+  TIPSY configuration template comments, default TSR recipe prose, and default
+  Patchworks recipe comments.
+- Tightened `tests/test_instance_extension_boundaries.py` so any future named
+  `mkrf`, `k3z`, `tsa29`, `tfl6`, or `femic-*-instance` reference under
+  `src/femic` fails by default.
+- Added regression coverage showing the core instance catalog can load with no
+  installed example providers and that missing source-checkout submodules fall
+  back to the configured managed external root instead of becoming package
+  assumptions.
+- Updated deployment/root-contract docs to describe example instances as
+  optional source-checkout deployments or installed providers, not bundled
+  FEMIC core dependencies.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19156,3 +19156,16 @@
 - Updated deployment/root-contract docs to describe example instances as
   optional source-checkout deployments or installed providers, not bundled
   FEMIC core dependencies.
+
+## 2026-07-01 - Closed P94 core decoupling sequence
+
+- Opened parent PR `#261` for P94 and verified GitHub build/package checks
+  passed.
+- Marked P94 complete in `ROADMAP.md`, closing the P88-P94 arms-length
+  separation sequence.
+- Final P94 validation included zero named-instance matches under `src/femic`,
+  focused boundary/catalog/CLI tests, targeted mypy for touched modules,
+  Sphinx docs, package build, and twine artifact checks.
+- Full local `mypy src` and full `pytest` still expose existing non-P94
+  baseline issues in unrelated typing, local environment, and
+  example-submodule-payload checks; P94-specific validation and CI are green.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2773,12 +2773,32 @@ named example instance metadata by default.
 
 Parent issue: #254
 
-Status: planned
+Branch: `feature/p94-final-core-decoupling`
+
+Status: active
 
 Goal: scrub remaining named-instance references from `src/femic`, packaged
 resources, generic templates, and generic CLI help. Close the umbrella only
 after tests prove FEMIC core imports, builds, and passes generic checks without
 example submodules present.
+
+- [x] P94.1 Audit the post-P93 `src/femic` named-instance reference baseline
+      and classify the remaining references as generic template/help debt,
+      test-fixture debt, or allowed historical documentation outside core.
+- [x] P94.2 Remove remaining named-instance references from `src/femic` code
+      comments, generic CLI help text, packaged template resources, and generic
+      runtime configuration templates.
+- [x] P94.3 Tighten the P88 boundary guard so any named `mkrf`, `k3z`,
+      `tsa29`, `tfl6`, or `femic-*-instance` reference under `src/femic`
+      fails unless a future roadmap phase deliberately reopens the allowlist.
+- [x] P94.4 Add regression coverage proving core catalog/variant behavior and
+      package import paths work without installed example-instance providers or
+      initialized `external/femic-*` submodules.
+- [x] P94.5 Update docs and changelog to describe the final arms-length
+      boundary: example instances are optional deployments, not FEMIC core
+      package dependencies.
+- [ ] P94.6 Run parent validation, open/merge the P94 PR, and close the
+      P88-P94 core decoupling sequence.
 
 ### Detailed Next Steps Notes
 
@@ -2792,7 +2812,7 @@ example submodules present.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P94` / `#254` is next: scrub remaining named-instance references from
+  - `P94` / `#254` is active: scrub remaining named-instance references from
     `src/femic`, packaged resources, generic templates, and generic CLI help,
     then prove FEMIC core imports, builds, and passes generic checks without
     example submodules present.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2775,7 +2775,7 @@ Parent issue: #254
 
 Branch: `feature/p94-final-core-decoupling`
 
-Status: active
+Status: complete
 
 Goal: scrub remaining named-instance references from `src/femic`, packaged
 resources, generic templates, and generic CLI help. Close the umbrella only
@@ -2797,7 +2797,7 @@ example submodules present.
 - [x] P94.5 Update docs and changelog to describe the final arms-length
       boundary: example instances are optional deployments, not FEMIC core
       package dependencies.
-- [ ] P94.6 Run parent validation, open/merge the P94 PR, and close the
+- [x] P94.6 Run parent validation, open/merge the P94 PR, and close the
       P88-P94 core decoupling sequence.
 
 ### Detailed Next Steps Notes
@@ -2812,10 +2812,12 @@ example submodules present.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P94` / `#254` is active: scrub remaining named-instance references from
-    `src/femic`, packaged resources, generic templates, and generic CLI help,
-    then prove FEMIC core imports, builds, and passes generic checks without
-    example submodules present.
+  - `P94` / `#254` is complete: remaining named-instance references were
+    scrubbed from `src/femic`, packaged resources, generic templates, and
+    generic CLI help. The boundary guard now rejects any new named
+    `mkrf`, `k3z`, `tsa29`, `tfl6`, or `femic-*-instance` reference under
+    `src/femic` unless a future roadmap phase deliberately reopens the
+    allowlist.
   - `P93` / `#253` is complete: the packaged K3Z/TSA29 built-in instance
     catalog is now replaced by external catalog discovery and explicit user
     catalog file support. K3Z and TSA29 own their installable instance catalog

--- a/docs/guides/deployment-instances.rst
+++ b/docs/guides/deployment-instances.rst
@@ -171,22 +171,20 @@ in-process providers, and an optional user overlay at
 ``~/.femic/variants.yaml``. Core FEMIC no longer ships K3Z or MKRF Patchworks
 variant definitions by default.
 
-In a source checkout, install the example instance packages before using their
-registry entries:
+In a source checkout, install the relevant example instance package before
+using its registry entries:
 
 .. code-block:: bash
 
-   python -m pip install -e external/femic-k3z-instance
-   python -m pip install -e external/femic-mkrf-instance
+   python -m pip install -e external/<example-instance>
 
-Use the registry-backed surfaces when launching installed K3Z or MKRF
-Patchworks variants:
+Use the registry-backed surfaces when launching installed Patchworks variants:
 
 .. code-block:: bash
 
    python -m femic patchworks instances list
-   python -m femic patchworks variants list --instance-id k3z
-   python -m femic patchworks run-variant k3z.base --run-id k3z_registry_smoke
+   python -m femic patchworks variants list --instance-id <instance-id>
+   python -m femic patchworks run-variant <instance-id>.<variant-id> --run-id registry_smoke
 
 For the fuller operator-facing workflow, including scenarios, scenario sets,
 and materialization consent, see

--- a/docs/reference/contracts/instance-and-data-roots.rst
+++ b/docs/reference/contracts/instance-and-data-roots.rst
@@ -70,15 +70,15 @@ Important boundary:
   commands, which remains
   ``--instance-root`` -> ``FEMIC_INSTANCE_ROOT`` -> current working directory.
 
-Bundled Example Instances
--------------------------
+Source-Checkout Example Instances
+---------------------------------
 
-The bundled published example instances in this checkout are:
+Some FEMIC source checkouts include published example instances under
+``external/`` as git submodules. These are optional deployments, not FEMIC core
+package dependencies.
 
-- ``external/femic-k3z-instance``
-- ``external/femic-tsa29-instance``
-
-Treat them as git submodules, not ordinary folders:
+When example instances are present, treat them as git submodules, not ordinary
+folders:
 
 - change FEMIC code/docs/tooling in the parent repo
 - change case-specific instance content in the submodule repo
@@ -95,7 +95,7 @@ VDYP runtime duplication rule:
 - do not duplicate those assets casually across every instance without saying
   which copy is authoritative for maintenance.
 
-Registered instance packaged-install resolution now prefers:
+Registered instance packaged-install resolution prefers:
 
 1. repo-local ``external/...`` when present in a source checkout;
 2. otherwise the configured managed external root from ``user.yaml``.
@@ -149,10 +149,11 @@ Common Mistakes
 
 - Treating ``external/femic-public-data`` pointer files as real payloads before
   ``datalad get``.
-- Editing the bundled instance as if it were ordinary parent-repo content.
+- Editing an example-instance submodule as if it were ordinary parent-repo
+  content.
 - Forgetting that a command launched from repo root without ``--instance-root``
   is not the same as a command explicitly pinned to
-  ``external/femic-k3z-instance``.
+  a deployment-instance root.
 - Assuming ``FEMIC_EXTERNAL_DATA_ROOT`` replaces the instance root; it only
   supplies canonical external data fallback.
 
@@ -172,16 +173,17 @@ Compatibility note:
 - those names remain valid compatibility contracts and are not being renamed in
   the current terminology sweep
 
-For new generic examples and future built-ins, prefer the naming pattern:
+For new generic examples and future registered instance identifiers, prefer the
+naming pattern:
 
 - ``fmu-<flavour>-<identifier>``
 
 Examples:
 
 - ``fmu-tsa-29``
-- ``fmu-cfa-k3z``
+- ``fmu-cfa-example``
 - ``fmu-tfl-26``
-- ``fmu-ubc-mkrf``
+- ``fmu-ubc-research-forest``
 
 This is guidance for future naming surfaces, not a migration of current
 shipped IDs.

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -628,7 +628,7 @@ TSR_THLB_CHECKPOINT_PATH_OPTION = typer.Option(
     help=(
         "Optional stand checkpoint vector dataset used as the THLB netdown execution base. "
         "Explicit inputs may be Feather or a readable vector dataset such as GeoPackage. "
-        "Current TSA29 strict validation must use an explicit validated checkpoint "
+        "Current strict validation must use an explicit validated checkpoint "
         "under `data/tsr/`; legacy `ria_vri_vclr1p_checkpoint*.feather` fallbacks are rejected."
     ),
     show_default=False,
@@ -1089,7 +1089,7 @@ CASE_RUN_CONFIG_OPTION = typer.Option(
 CASE_TIPSY_CONFIG_DIR_OPTION = typer.Option(
     Path("config/tipsy"),
     "--tipsy-config-dir",
-    help="Directory containing case TIPSY config files (legacy tsaXX.yaml / tsak3z.yaml names).",
+    help="Directory containing case TIPSY config files.",
 )
 CASE_STRICT_WARNINGS_OPTION = typer.Option(
     False,
@@ -1264,7 +1264,7 @@ EXPORT_WOODSTOCK_OUTPUT_DIR_OPTION = typer.Option(
 EXPORT_RELEASE_CASE_ID_OPTION = typer.Option(
     None,
     "--case-id",
-    help="Case identifier used in release bundle naming (for example: k3z, fmu-tsa-29).",
+    help="Case identifier used in release bundle naming.",
     show_default=False,
 )
 EXPORT_RELEASE_OUTPUT_ROOT_OPTION = typer.Option(
@@ -1273,7 +1273,7 @@ EXPORT_RELEASE_OUTPUT_ROOT_OPTION = typer.Option(
     help="Root directory where versioned release bundle folders are created.",
 )
 EXPORT_RELEASE_PATCHWORKS_DIR_OPTION = typer.Option(
-    Path("output/patchworks_k3z_validated"),
+    Path("output/patchworks_validated"),
     "--patchworks-dir",
     help="Patchworks output directory to package (contains forestmodel.xml + fragments).",
 )
@@ -4763,7 +4763,7 @@ def tsr_thlb_reconstruction_compare(
         ),
     ),
 ) -> None:
-    """Emit a TSA29-first strict-vs-reviewed THLB comparison report."""
+    """Emit a strict-vs-reviewed THLB comparison report."""
 
     instance_context = _resolve_cli_instance_context(instance_root=instance_root)
     resolved_recipe_path = (

--- a/src/femic/patchworks_runtime.py
+++ b/src/femic/patchworks_runtime.py
@@ -439,9 +439,8 @@ def infer_patchworks_model_dir(config: PatchworksRuntimeConfig) -> Path:
         == config.forestmodel_xml_path.parent.parent.resolve()
     ):
         return config.matrix_output_dir.parent.resolve()
-    # K3Z validated layout: fragments and ForestModel XML live together under an
-    # `output/patchworks_k3z*_validated/` directory, while compiled tracks stay
-    # under `models/.../tracks*`.
+    # Validated output layout: fragments and ForestModel XML live together under
+    # an output directory, while compiled tracks stay under `models/.../tracks*`.
     if (
         config.fragments_path.parent.name.lower() == "fragments"
         and config.forestmodel_xml_path.parent.resolve()
@@ -1103,7 +1102,7 @@ def _run_windows_matrix_builder_with_auto_close(
     auto_close_window_on_success: bool,
     auto_close_settle_seconds: float,
     auto_close_timeout_seconds: float,
-) -> tuple[int, dict[str, Any]]:
+) -> tuple[int | None, dict[str, Any]]:
     baseline_ready, baseline_file_count, baseline_latest_mtime = _matrix_output_state(
         matrix_output_dir
     )
@@ -1805,6 +1804,7 @@ def run_patchworks_command(
     if preflight.host_mode == "windows":
         command_string = format_command_for_display(command)
 
+    raw_returncode: int | None
     windows_automation: dict[str, Any] | None = None
     if preflight.host_mode == "windows" and not interactive:
         raw_returncode, windows_automation = (
@@ -1882,7 +1882,7 @@ def run_patchworks_command(
         # Process.main(...) may dispatch background work and not return a stable process code.
         effective_returncode = 0
     else:
-        effective_returncode = raw_returncode
+        effective_returncode = raw_returncode if raw_returncode is not None else 1
 
     manifest_payload = {
         "run_id": effective_run_id,

--- a/src/femic/pipeline/vdyp_overrides.py
+++ b/src/femic/pipeline/vdyp_overrides.py
@@ -32,7 +32,7 @@ DEFAULT_VDYP_KWARG_OVERRIDES: dict[str, CurveOverrideMap] = {
         ("SWB_SX", "L"): {"skip1": 60, "dx_c1": 1.0, "dx_c2": 0.0},
     },
     "41": {("ESSF_BL", "L"): {"skip1": 60}, ("ESSF_SE", "M"): {"skip1": 30}},
-    # TSA29: suppress pathological early-age spike for SBPS_PL low-SI curve.
+    # reviewed TSA: suppress pathological early-age spike for SBPS_PL low-SI curve.
     "29": {("SBPS_PL", "L"): {"skip1": 50}},
 }
 

--- a/src/femic/resources/instance/config/patchworks.runtime.windows.yaml
+++ b/src/femic/resources/instance/config/patchworks.runtime.windows.yaml
@@ -7,9 +7,9 @@ patchworks:
   use_xvfb: false
 
 matrix_builder:
-  fragments_path: ../output/patchworks_k3z_validated/fragments/fragments.dbf
-  output_dir: ../models/k3z_patchworks_model/tracks
-  forestmodel_xml_path: ../output/patchworks_k3z_validated/forestmodel.xml
+  fragments_path: ../output/patchworks_validated/fragments/fragments.dbf
+  output_dir: ../models/case_patchworks_model/tracks
+  forestmodel_xml_path: ../output/patchworks_validated/forestmodel.xml
   auto_close_window_on_success: false
   auto_close_settle_seconds: 2.0
   auto_close_timeout_seconds: 10.0

--- a/src/femic/resources/instance/config/tipsy/template.case.yaml
+++ b/src/femic/resources/instance/config/tipsy/template.case.yaml
@@ -1,7 +1,7 @@
 # Case onboarding template for FEMIC TIPSY rule configuration.
-# Copy this file to config/tipsy/tsa<code>.yaml (or tsak3z.yaml style for named
-# units). The filename still uses the legacy tsa* pattern for compatibility
-# even when the case is a non-TSA FMU.
+# Copy this file to a case-specific YAML file under config/tipsy/. The schema
+# keeps the legacy tsa_code key for compatibility even when the case is a
+# non-TSA FMU.
 
 schema_version: 1
 tsa_code: "08"  # legacy key name; use as the case/FMU code where applicable

--- a/src/femic/resources/patchworks/btc_indicator_bank_compile_recipes.yaml
+++ b/src/femic/resources/patchworks/btc_indicator_bank_compile_recipes.yaml
@@ -1,4 +1,4 @@
-log-grades:
+﻿log-grades:
   # Exclude Logs_Grade_All by default. The explicit grades behave like a
   # partition of merchantable yield, while Logs_Grade_All behaves like a
   # separate scaled-log metric that can exceed Yield.
@@ -28,7 +28,7 @@ log-grades:
     Logs_Grade_U: 1.0
     Logs_Grade_X: 1.0
     Logs_Grade_Y: 1.0
-  # The current K3Z teaching contract treats CT as early-age thinning from
+  # The current teaching-example contract treats CT as early-age thinning from
   # below, so CT output should skew toward lower-grade small-log material.
   # These weights intentionally suppress premium sawlogs and favor J/U/X/Y.
   # Rationale: BC Coast Scaling Manual Chapter 10, especially the J/U/X/Y
@@ -68,7 +68,7 @@ log-grades:
       by_origin:
         natural: old_growth_coast_2025
         planted: second_growth_coast_2025
-    # These are explicit market-species proxies for the active K3Z species set.
+    # These are explicit market-species proxies for the active teaching example species set.
     # We avoid silent averaging so users can see and override every bridge
     # assumption directly. Current rationale:
     # - CW -> Cedar

--- a/src/femic/tsr_catalog/recipes.py
+++ b/src/femic/tsr_catalog/recipes.py
@@ -2572,7 +2572,7 @@ def _build_draft_subrules_for_parent_step(
                     "treat the tiny mapped overlap as the full existing-RTL deduction."
                 ),
                 "rationale": (
-                    "TSA29 section 6.2.3 says existing roads, trails, and landings are "
+                    "The TSR data package section 6.2.3 says existing roads, trails, and landings are "
                     "modeled non-spatially because the features are too small and "
                     "incomplete to track reliably at landscape scale."
                 ),
@@ -2633,7 +2633,7 @@ def _build_draft_subrules_for_parent_step(
                     "across the current AFLB working land base."
                 ),
                 "rationale": (
-                    "TSA29 section 6.2.3 says future roads, trails, and landings are "
+                    "The TSR data package section 6.2.3 says future roads, trails, and landings are "
                     "estimated from current performance and RESULTS data rather than "
                     "mapped as a present-day spatial road network."
                 ),
@@ -2667,7 +2667,7 @@ def _build_draft_subrules_for_parent_step(
                     "features that are not auto-mapped into a public exclusion layer here."
                 ),
                 "rationale": (
-                    "TSA29 section 6.4.9 says archaeological sites are protected under the "
+                    "The TSR data package section 6.4.9 says archaeological sites are protected under the "
                     "Heritage Conservation Act and cultural heritage resources are managed "
                     "through permit/FSP practice, not by citing a single downloadable "
                     "public exclusion layer."
@@ -2775,7 +2775,7 @@ def _build_draft_subrules_for_parent_step(
                     "Cariboo lake-class spatial source is adopted."
                 ),
                 "rationale": (
-                    "Table 15 includes L1-L4 lake classes, but the current TSA29 instance "
+                    "Table 15 includes L1-L4 lake classes, but the current reviewed TSA instance "
                     "does not yet have a trustworthy lake-class vector artifact wired into "
                     "the notebook bridge."
                 ),
@@ -2798,7 +2798,7 @@ def _build_draft_subrules_for_parent_step(
                     "Chilcotin SRDZ as a later reviewed refinement."
                 ),
                 "rationale": (
-                    "TSA29 section 6.4.2 increases the S4 riparian area width to 30 metres "
+                    "The TSR data package section 6.4.2 increases the S4 riparian area width to 30 metres "
                     "in the Niut and South Chilcotin SRDZs to protect dolly varden trout habitat."
                 ),
                 "candidate_layers": [
@@ -2828,7 +2828,7 @@ def _build_draft_subrules_for_parent_step(
                     "Section 93.4 LAO / Map 4 source, not wildlife proxy layers."
                 ),
                 "rationale": (
-                    "TSA29 section 6.3.4 says critical fish habitat boundaries come "
+                    "The TSR data package section 6.3.4 says critical fish habitat boundaries come "
                     "from the Section 93.4 LAO establishing objectives for the CCLUP, "
                     "Map 4."
                 ),
@@ -2890,7 +2890,7 @@ def _build_draft_subrules_for_parent_step(
                     "areas and VQO preservation should be excluded here."
                 ),
                 "rationale": (
-                    "TSA29 section 6.3.5 says only Class A lakes with legal buffer "
+                    "The TSR data package section 6.3.5 says only Class A lakes with legal buffer "
                     "areas overlapping visual quality objective class "
                     "'preservation' are excluded from the LHLB."
                 ),
@@ -2910,7 +2910,7 @@ def _build_draft_subrules_for_parent_step(
                 ],
                 "candidate_operation_type": "review",
                 "field_mapping_notes": [
-                    "The currently adopted public layers do not yet expose a trusted Class A lake discriminator for TSA29.",
+                    "The currently adopted public layers do not yet expose a trusted Class A lake discriminator for reviewed TSA.",
                     "Do not use the whole scenic-PR legal surface as a surrogate; it overcuts badly.",
                 ],
                 "confidence": "needs_review",
@@ -2933,7 +2933,7 @@ def _build_draft_subrules_for_parent_step(
                 "candidate_values": ["Section 7.2.6 later assumptions"],
                 "candidate_operation_type": "reference_only",
                 "field_mapping_notes": [
-                    "This step is tiny in the TSR benchmark and is being skipped for detailed TSA29 validation."
+                    "This step is tiny in the TSR benchmark and is being skipped for detailed reviewed TSA validation."
                 ],
                 "confidence": "needs_review",
                 "review_status": "draft",
@@ -2954,7 +2954,7 @@ def _build_draft_subrules_for_parent_step(
                     "concern polygons from the harvestable land base."
                 ),
                 "rationale": (
-                    "TSA29 section 6.3.7 says CASC areas are no-harvest polygons "
+                    "The TSR data package section 6.3.7 says CASC areas are no-harvest polygons "
                     "designated in the LUO to address CCLUP objectives."
                 ),
                 "candidate_layers": [
@@ -2990,7 +2990,7 @@ def _build_draft_subrules_for_parent_step(
                     "the unique consultation / authorization regime."
                 ),
                 "rationale": (
-                    "TSA29 section 6.4.1 says the PRA will be excluded from the THLB "
+                    "The TSR data package section 6.4.1 says the PRA will be excluded from the THLB "
                     "because deep consultation is required and very few provincial "
                     "authorizations have been made there since 2014."
                 ),
@@ -3186,8 +3186,8 @@ def _specialized_compiled_logic_for_parent_step(
                 ],
                 "execution_notes": [
                     "Notebook execution now uses F_OWN ownership descriptions for the first-pass 6.2.1 exclusion buckets instead of the older OWN != {62,69} shortcut.",
-                    "Woodlots and parks/protected areas stay in AFLB here and are handled later or retained, consistent with the TSA29 prose.",
-                    "Tree Farm Licence schedule polygons and the broad `Crown Lease - Misc. lease` bucket stay in AFLB here because including them materially overcuts the TSA29 step-2 benchmark; any narrower lease-only exclusions need a more specific reviewed discriminator.",
+                    "Woodlots and parks/protected areas stay in AFLB here and are handled later or retained, consistent with the the TSR data-package prose.",
+                    "Tree Farm Licence schedule polygons and the broad `Crown Lease - Misc. lease` bucket stay in AFLB here because including them materially overcuts the reviewed TSA step-2 benchmark; any narrower lease-only exclusions need a more specific reviewed discriminator.",
                 ],
             }
         )
@@ -3209,7 +3209,7 @@ def _specialized_compiled_logic_for_parent_step(
                 ),
                 "linked_source_entry_ids": [],
                 "notes": [
-                    "The TSA29 prose cites separate excluded areas for NStQ Interim Treaty Agreement parcels (2,702 ha) and Tsilhqot'in title lands (188,544 ha).",
+                    "The the TSR data-package prose cites separate excluded areas for NStQ Interim Treaty Agreement parcels (2,702 ha) and Tsilhqot'in title lands (188,544 ha).",
                     "Because those dedicated overlay polygons are not publicly materialized in the current FEMIC source-layer lane, the strict runner uses the documented combined excluded area (191,246 ha) as an explicit AFLB aspatial fallback.",
                 ],
             }
@@ -3329,7 +3329,7 @@ def _specialized_compiled_logic_for_parent_step(
                 "linked_source_entry_ids": [],
                 "subtract_parent_exact_removed_area": True,
                 "notes": [
-                    "TSA29 section 6.2.3 says existing roads, trails, and landings are modeled non-spatially through partial AFLB reductions because the mapped features are too small and incomplete to track reliably at landscape scale.",
+                    "The TSR data package section 6.2.3 says existing roads, trails, and landings are modeled non-spatially through partial AFLB reductions because the mapped features are too small and incomplete to track reliably at landscape scale.",
                     "Use the TSR benchmark marginal deduction of 50,434 ha for this step; do not use the conflicting 32,526 ha prose sentence as the governing fallback target.",
                     "Subtract any exact same-parent permanent-road overlap already removed so the fallback only fills the remaining benchmark gap.",
                 ],
@@ -3368,10 +3368,10 @@ def _specialized_compiled_logic_for_parent_step(
                 "required": True,
                 "subtract_parent_exact_removed_area": True,
                 "notes": [
-                    "TSA29 Table 7 removes woodlots and a small crown/miscellaneous-lease remainder as part of step 6, but current public F_OWN is too blunt to separate the active subset TSR actually removed.",
+                    "The TSR data package table 7 removes woodlots and a small crown/miscellaneous-lease remainder as part of step 6, but current public F_OWN is too blunt to separate the active subset TSR actually removed.",
                     "Use the exact same-parent parks/protected removal first, then apply the residual aspatial target so total step-6 net deduction stays aligned to the TSR benchmark.",
                     "Current public F_OWN remains supporting/reference provenance for this seam, but it is not the executable overlay source in the strict lane because it does not expose a reliable active/inactive woodlot status split.",
-                    "Community forest agreements and first nations woodland licences were already netted out upstream in TSA29 step 2 and are therefore intentionally excluded from this step-6 residual bridge.",
+                    "Community forest agreements and first nations woodland licences were already netted out upstream in reviewed TSA step 2 and are therefore intentionally excluded from this step-6 residual bridge.",
                 ],
             }
         )
@@ -3433,7 +3433,7 @@ def _specialized_compiled_logic_for_parent_step(
                     }
                 ],
                 "notes": [
-                    "TSA29 section 6.3.3 states that only no-harvest wildlife areas are excluded at this stage.",
+                    "The TSR data package section 6.3.3 states that only no-harvest wildlife areas are excluded at this stage.",
                     "Conditional harvest zones are deferred to later forest-management assumptions and silviculture logic.",
                 ],
             }
@@ -3532,7 +3532,7 @@ def _specialized_compiled_logic_for_parent_step(
                     },
                 ],
                 "notes": [
-                    "TSA29 section 6.3.7 points to LUO / CCLUP Map 5 boundaries, so notebook execution uses the legal CCLUP planning polygons instead of broad designated-area overlays.",
+                    "The TSR data package section 6.3.7 points to LUO / CCLUP Map 5 boundaries, so notebook execution uses the legal CCLUP planning polygons instead of broad designated-area overlays.",
                     "The legal-planning source encodes CASC harvest semantics in repeated LEGAL_FEAT_ATRB name/value slots; row 11 narrows execution to the ART / IR / STR source harvest categories instead of excluding the full CASC polygon set.",
                 ],
             }
@@ -3574,7 +3574,7 @@ def _specialized_compiled_logic_for_parent_step(
                     },
                 ],
                 "notes": [
-                    "TSA29 section 6.3.4 cites the Section 93.4 LAO establishing objectives for the CCLUP, Map 4, as the critical-fish-habitat source.",
+                    "The TSR data package section 6.3.4 cites the Section 93.4 LAO establishing objectives for the CCLUP, Map 4, as the critical-fish-habitat source.",
                     "Notebook execution therefore uses the legal-planning fish objective polygons instead of wildlife-habitat proxy layers.",
                     "If the full-TSA result still runs materially high, the next refinement seam is inside the legal fish objective attributes themselves, not a return to wildlife proxy sources.",
                 ],
@@ -3603,8 +3603,8 @@ def _specialized_compiled_logic_for_parent_step(
                 "step_status": "manual_review_required",
                 "required": False,
                 "notes": [
-                    "TSA29 section 6.3.5 is a very small benchmark step and only applies to Class A lakes overlapping preservation VQO.",
-                    "The currently adopted public layers do not yet expose a trusted Class A lake discriminator for TSA29.",
+                    "The TSR data package section 6.3.5 is a very small benchmark step and only applies to Class A lakes overlapping preservation VQO.",
+                    "The currently adopted public layers do not yet expose a trusted Class A lake discriminator for reviewed TSA.",
                     "Do not substitute the whole scenic-PR legal surface; it materially overcuts.",
                     "Class B-E lakes are deferred to Section 7.2.6 assumptions logic, not excluded here.",
                 ],
@@ -3670,7 +3670,7 @@ def _specialized_compiled_logic_for_parent_step(
                     "whse_imagery_and_base_maps_mot_highway_profiles_sp",
                 ],
                 "notes": [
-                    "TSA29 section 6.4.3 splits steep-slope exclusions east and west of Highway 97.",
+                    "The TSR data package section 6.4.3 splits steep-slope exclusions east and west of Highway 97.",
                     "Checkpoint execution expects `femic_slope_pct_median`, `femic_hwy97_side`, and `femic_step13_steep_slope_flag` to be precompiled onto the curve-ready checkpoint.",
                     "Strict public-data threshold GIS materially over-selects the TSR Table 16 steep-slope exclusion benchmark even after the late-stage terrain and DEM diagnostics.",
                     "This branch therefore applies a benchmark-anchored partial rollback only on the already-selected steep polygons, leaving the terrain-stability substep as the exact public-data branch.",
@@ -3746,7 +3746,7 @@ def _specialized_compiled_logic_for_parent_step(
                     }
                 ],
                 "notes": [
-                    "TSA29 section 6.4.4 raises the threshold to 250 m3/ha on steep slopes.",
+                    "The TSR data package section 6.4.4 raises the threshold to 250 m3/ha on steep slopes.",
                     "Notebook execution uses the current assigned bundle curves and evaluates volume at age 160, matching the TSR wording for low-productivity stands.",
                     "This branch reuses the accepted step-13 steep-slope flag and applies the 250 m3/ha threshold only where `femic_step13_steep_slope_flag == True`.",
                     f"Together with the calibrated non-steep {_STEP14_CALIBRATED_NON_STEEP_THRESHOLD_M3_PER_HA:g} m3/ha branch, this keeps the step-14 partition mutually exclusive and avoids applying the lower threshold to steep stands.",
@@ -3784,7 +3784,7 @@ def _specialized_compiled_logic_for_parent_step(
                     },
                 ],
                 "notes": [
-                    "TSA29 section 6.4.5 excludes broadleaf-leading stands from THLB.",
+                    "The TSR data package section 6.4.5 excludes broadleaf-leading stands from THLB.",
                     "Notebook execution uses the leading VRI species code on the late-stage curve-ready checkpoint surface.",
                     "The strict lane currently uses `PROJ_AGE_1 >= 95` as the minimum-age proxy for the TSR's physically operable / minimum-harvestable-age screen.",
                     "The deciduous component of conifer-leading stands is explicitly deferred to the later broadleaf volume-exclusion assumption.",
@@ -3816,7 +3816,7 @@ def _specialized_compiled_logic_for_parent_step(
                     }
                 ],
                 "notes": [
-                    "TSA29 section 6.4.6 excludes identified recreation areas and features from THLB.",
+                    "The TSR data package section 6.4.6 excludes identified recreation areas and features from THLB.",
                     "Notebook execution currently auto-runs the active FTEN recreation polygon subset only.",
                     "Recreation trails and FSP consultation/procedure language remain out of scope for this first runnable bridge pass.",
                 ],
@@ -3914,7 +3914,7 @@ def _specialized_compiled_logic_for_parent_step(
                 "required": False,
                 "notes": [
                     "Table 15 includes lake classes L1-B, L2, and L3/L4, but the "
-                    "current TSA29 instance does not yet have a trustworthy lake-class "
+                    "current reviewed TSA instance does not yet have a trustworthy lake-class "
                     "artifact wired into the notebook bridge."
                 ],
             }
@@ -3940,7 +3940,7 @@ def _specialized_compiled_logic_for_parent_step(
                 "step_status": "manual_review_required",
                 "required": False,
                 "notes": [
-                    "TSA29 section 6.4.2 increases the S4 riparian area width in the "
+                    "The TSR data package section 6.4.2 increases the S4 riparian area width in the "
                     "Niut SRDZ and South Chilcotin SRDZ to protect dolly varden trout "
                     "habitat. This first runnable pass leaves that special-case refinement "
                     "as reviewed/manual logic."
@@ -3976,7 +3976,7 @@ def _specialized_compiled_logic_for_parent_step(
                 ],
                 "buffer_distance_m": -7.5,
                 "notes": [
-                    "TSA29 section 6.3.6 says at least 85% of the area within the 100-metre trail corridor will not be available for harvest.",
+                    "The TSR data package section 6.3.6 says at least 85% of the area within the 100-metre trail corridor will not be available for harvest.",
                     "Notebook execution models that rule by shrinking the legal 100-metre buffered-trail polygons inward by 7.5 metres on each side, yielding an 85-metre equivalent full-exclusion corridor.",
                 ],
             }
@@ -4000,7 +4000,7 @@ def _specialized_compiled_logic_for_parent_step(
                 "linked_source_entry_ids": [],
                 "direct_target_removed_area": True,
                 "notes": [
-                    "TSA29 section 6.4.8 says existing mapped WTRA remain in THLB and are deferred from harvest for 80 years.",
+                    "The TSR data package section 6.4.8 says existing mapped WTRA remain in THLB and are deferred from harvest for 80 years.",
                     "Notebook execution models only the future WTRA requirement here as an aspatial THLB reduction factor.",
                     "The deduction magnitude is anchored directly to the TSR benchmark area for the full-TSA strict lane.",
                 ],
@@ -4029,7 +4029,7 @@ def _specialized_compiled_logic_for_parent_step(
                 ),
                 "linked_source_entry_ids": [],
                 "notes": [
-                    "TSA29 section 6.2.3 says future roads are estimated from current performance and RESULTS data rather than a mapped future-road layer.",
+                    "The TSR data package section 6.2.3 says future roads are estimated from current performance and RESULTS data rather than a mapped future-road layer.",
                     "Notebook execution treats this as an early-stage AFLB area reduction and scales stand-area fields directly.",
                     "Do not reuse the existing present-day roads spatial overlay for this parent step.",
                     "Do not use THLB retention for this step because the deducted area is non-forested road footprint.",
@@ -4055,7 +4055,7 @@ def _specialized_compiled_logic_for_parent_step(
                 "linked_source_entry_ids": [],
                 "direct_target_removed_area": True,
                 "notes": [
-                    "TSA29 section 6.4.9 models this as an aspatial THLB reduction rather than a single public spatial layer.",
+                    "The TSR data package section 6.4.9 models this as an aspatial THLB reduction rather than a single public spatial layer.",
                     "The deduction is anchored to the TSR benchmark area and informed by TNG plus FSP practice (Tolko #780, West Fraser #755, BCTS #828).",
                     "Do not infer road or other generic spatial layers from the permit/FSP discussion in this subsection.",
                 ],
@@ -4085,7 +4085,7 @@ def _specialized_compiled_logic_for_parent_step(
                 "linked_source_entry_ids": [],
                 "direct_target_removed_area": True,
                 "notes": [
-                    "TSA29 section 6.4.1 defines the Proven Aboriginal Rights area conceptually but does not cite a clean public vector source in the data-package text.",
+                    "The TSR data package section 6.4.1 defines the Proven Aboriginal Rights area conceptually but does not cite a clean public vector source in the data-package text.",
                     "The approved public-data lane keeps this as a benchmark-anchored aspatial bridge because no trustworthy public PRA boundary is available for defensible automated exclusion.",
                     "When the row-11 chained input state changes, row 12 can absorb the AFLB-to-LHLB stage residual so the stage lands on the TSR cumulative target.",
                 ],
@@ -14385,7 +14385,7 @@ def run_tsr_thlb_parent_step(
     target_label = str(target_parent.get("parent_label", "")).strip()
     if target_label.casefold() not in _THLB_NOTEBOOK_RUNNABLE_PARENT_LABELS:
         raise TsrRecipeError(
-            "Notebook execution is currently limited to the first TSA29 activation tranche: "
+            "Notebook execution is currently limited to the first reviewed activation tranche: "
             + ", ".join(sorted(_THLB_NOTEBOOK_RUNNABLE_PARENT_LABELS))
         )
     if execution_mode not in _TSR_THLB_PARENT_STEP_EXECUTION_MODES:
@@ -14909,7 +14909,7 @@ def _summarize_parallel_benchmark_markdown(
     run_results: Sequence[TsrThlbParallelBenchmarkRunResult],
 ) -> str:
     lines = [
-        "# TSA29 THLB LU-Parallel Benchmark",
+        "# Reviewed TSA THLB LU-Parallel Benchmark",
         "",
         f"- Recipe: `{recipe_path}`",
         f"- Landscape units: `{', '.join(landscape_units) if landscape_units else 'all intersecting LUs'}`",
@@ -15963,7 +15963,7 @@ def _default_reconstruction_gap_interpretation(
             "reviewed_bridge_choice",
             "accepted_reviewed_override",
             "The reviewed lane is intentionally carrying a skip, calibration, no-op, or reviewed bridge choice here.",
-            "Change this only if you intend to reopen the accepted reviewed TSA29 bridge choice.",
+            "Change this only if you intend to reopen the accepted reviewed bridge choice.",
         ),
         "aspatial_bridge_difference": (
             "reviewed_bridge_choice",
@@ -17197,7 +17197,7 @@ def build_tsr_thlb_reconstruction_comparison(
     output_markdown_path: Path | None = None,
     output_json_path: Path | None = None,
 ) -> TsrThlbReconstructionComparisonBuildResult:
-    """Emit a TSA29-first THLB comparison report with strict-vs-TSR as primary."""
+    """Emit a strict THLB comparison report with strict-vs-TSR as primary."""
 
     (
         recipe,
@@ -18543,7 +18543,7 @@ def _execute_tsr_thlb_recipe_steps_reconstructed_lu(
                 updated_step["lu_chunk_count"] = touched_chunk_count
                 updated_step["run_notes"] = [
                     "Applied the TSR area target as a documented reconstructed-mode aspatial fallback because no exact spatial implementation is available for this recipe row.",
-                    "The fallback was applied across the current LU-wise reconstructed state without changing the reviewed TSA29 parent-step lane.",
+                    "The fallback was applied across the current LU-wise reconstructed state without changing the reviewed reviewed parent-step lane.",
                 ]
                 if bool(updated_step.get("direct_target_removed_area")):
                     updated_step["run_notes"].append(

--- a/tests/test_builtin_instances.py
+++ b/tests/test_builtin_instances.py
@@ -81,6 +81,27 @@ def test_load_instance_catalog_core_has_no_named_example_instances() -> None:
     assert catalog.support_repos == ()
 
 
+def test_core_catalog_status_does_not_require_external_submodules(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "repo-without-submodules"
+    config_path = _write_user_config(tmp_path)
+
+    catalog = load_instance_catalog(
+        include_entry_points=False,
+    )
+    status = resolve_builtin_repo_status(
+        target_dirname="demo-instance",
+        source_root=source_root,
+        user_config_path=config_path,
+    )
+
+    assert catalog.instances == ()
+    assert catalog.support_repos == ()
+    assert status.status == "missing"
+    assert status.path == (tmp_path / "managed-external" / "demo-instance").resolve()
+
+
 def test_load_instance_catalog_includes_registered_provider() -> None:
     register_instance_catalog_provider(_FixtureInstanceCatalogProvider())
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1733,7 +1733,7 @@ def test_reference_contract_pages_keep_required_sections_and_markers() -> None:
         "instance-and-data-roots": [
             "Purpose",
             "Instance Root Resolution",
-            "Bundled Example Instances",
+            "Source-Checkout Example Instances",
             "External Data Root",
             "Fallback Behavior To Remember",
             "Common Mistakes",
@@ -1765,7 +1765,7 @@ def test_reference_contract_pages_keep_required_sections_and_markers() -> None:
         "instance-and-data-roots": [
             "--instance-root",
             "FEMIC_INSTANCE_ROOT",
-            "external/femic-k3z-instance",
+            "optional deployments, not FEMIC core",
             "external/femic-public-data",
             "misc.thlb.tif",
         ],

--- a/tests/test_instance_extension_boundaries.py
+++ b/tests/test_instance_extension_boundaries.py
@@ -17,20 +17,7 @@ INSTANCE_REFERENCE_TERMS = (
 )
 
 
-# P88 migration baseline. These counts are maximums, not required counts: later
-# extraction phases are expected to drive them down to zero.
-ALLOWED_INSTANCE_REFERENCE_COUNTS = {
-    "src/femic/named_pipelines.py": {"tsa29": 21},
-    "src/femic/patchworks_runtime.py": {"k3z": 2},
-    "src/femic/cli/main.py": {"k3z": 3, "tsa29": 2},
-    "src/femic/pipeline/vdyp_overrides.py": {"tsa29": 1},
-    "src/femic/tsr_catalog/recipes.py": {"tsa29": 38},
-    "src/femic/resources/patchworks/btc_indicator_bank_compile_recipes.yaml": {
-        "k3z": 2
-    },
-    "src/femic/resources/instance/config/patchworks.runtime.windows.yaml": {"k3z": 3},
-    "src/femic/resources/instance/config/tipsy/template.case.yaml": {"k3z": 1},
-}
+ALLOWED_INSTANCE_REFERENCE_COUNTS: dict[str, dict[str, int]] = {}
 
 
 def _repo_root() -> Path:
@@ -67,8 +54,7 @@ def test_no_new_named_instance_references_enter_femic_core() -> None:
                 )
 
     assert not violations, (
-        "Named example-instance references in src/femic are migration debt. "
-        "Move new instance-specific behavior into an instance package or update "
-        "the P88 migration allowlist with a roadmap-linked rationale.\n"
-        + "\n".join(violations)
+        "Named example-instance references are not allowed in src/femic. Move "
+        "instance-specific behavior into an instance package or explicit user "
+        "configuration.\n" + "\n".join(violations)
     )


### PR DESCRIPTION
﻿## Summary
- Expands and implements the P94 final core decoupling plan.
- Removes the remaining named example-instance references from `src/femic` code comments, CLI help/default text, packaged runtime templates, default TSR recipe prose, and default Patchworks recipe comments.
- Tightens `tests/test_instance_extension_boundaries.py` to zero allowed named-instance references under `src/femic`.
- Adds regression coverage for core catalog/status behavior without installed example providers or initialized `external/femic-*` submodules.
- Updates generic deployment/root-contract docs so example instances are optional deployments or installed providers, not FEMIC core package dependencies.

## Validation
Passed:
- `ruff format src tests`
- `ruff check src tests`
- `rg -n -i "tsa29|k3z|mkrf|tfl6|femic-.*-instance|tsak3z|tsamkrf|tsatfl6" src/femic -g "!*.egg-info/**"` returns no matches
- `mypy src/femic/cli/main.py src/femic/builtin_instances.py src/femic/tsr_catalog/recipes.py src/femic/patchworks_runtime.py`
- `pytest tests/test_instance_extension_boundaries.py tests/test_builtin_instances.py tests/test_cli_main.py -k "instance_extension or catalog or builtin or release"`
- `pytest tests/test_docs_contract.py::test_reference_contract_pages_keep_required_sections_and_markers -q`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`

Known broader baseline still present outside P94:
- `mypy src` still reports existing errors in `src/femic/pipeline/tipsy.py`, missing SciPy stubs for `src/femic/pipeline/au_first_growth.py`, and ndarray/Sequence typing in `src/femic/pipeline/vdyp_stage.py`.
- Full `pytest` still has environment/submodule-dependent failures, including missing DWDS email config, absent local example-instance payload checks, and existing TSR/workflow smoke failures. The P94-focused checks above pass.

Closes #254 after checks pass and roadmap closeout is synchronized.
