### PR TITLE
P95: Prepare FEMIC 0.2.0a1 release

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19169,3 +19169,15 @@
 - Full local `mypy src` and full `pytest` still expose existing non-P94
   baseline issues in unrelated typing, local environment, and
   example-submodule-payload checks; P94-specific validation and CI are green.
+
+## 2026-07-01 - Opened P95 FEMIC 0.2.0a1 release prep
+
+- Created parent branch `feature/p95-femic-0.2.0a1-release` and GitHub issue
+  `#262` for the FEMIC `0.2.0a1` core decoupling alpha release.
+- Added the P95 release checklist to `ROADMAP.md` before release edits.
+- Synchronized `pyproject.toml` and `src/femic/__init__.py` at `0.2.0a1`.
+- Added `tests/test_version_metadata.py` so package metadata and
+  `femic.__version__` cannot drift silently.
+- Added `RELEASE_NOTES.md` summarizing the P80-P94 milestone, alpha scope,
+  known non-P95 baseline caveats, and optional example-instance deployment
+  boundary.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19181,3 +19181,21 @@
 - Added `RELEASE_NOTES.md` summarizing the P80-P94 milestone, alpha scope,
   known non-P95 baseline caveats, and optional example-instance deployment
   boundary.
+
+## 2026-07-01 - Validated P95 local release artifacts
+
+- Fixed the root CLI `--version` option so both `python -m femic --version`
+  and the installed `femic --version` console script report `0.2.0a1`.
+- Added `RELEASE_NOTES.md` to the source distribution through `MANIFEST.in`.
+- Focused release validation passed: `ruff format src tests`, `ruff check src
+  tests`, targeted `mypy` for touched version/CLI modules, focused
+  version/boundary/catalog/variant tests, Sphinx warning-clean docs build,
+  `python -m build`, `twine check dist/*`, CLI help/version smoke, and direct
+  artifact metadata inspection.
+- Built artifacts report `Version: 0.2.0a1`; the wheel retains the `femic`
+  console script and `freshforge.providers` entry point, and the sdist includes
+  `RELEASE_NOTES.md`.
+- Full release-audit `mypy src` still reports the known non-P95
+  pandas/SciPy/VDYP typing debt. Full release-audit `pytest` reports 19 known
+  non-P95 environment/runtime/baseline failures; focused P95 release
+  validation is green.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include RELEASE_NOTES.md
 recursive-include examples *.yaml

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,53 @@
+# FEMIC 0.2.0a1
+
+FEMIC 0.2.0a1 is an alpha release for the core decoupling milestone completed
+across P80-P94. It marks the shift from a parent package that knew about named
+example model instances to a core package that provides reusable engines,
+schemas, runners, validators, CLI plumbing, and extension mechanisms.
+
+## Highlights
+
+- Added FreshForge provider integration for FEMIC model-building workflows.
+- Added executable FreshForge orchestration support for explicit workflow runs,
+  while keeping validation, inspection, and planning as non-mutating surfaces.
+- Moved MKRF-specific FreshForge, workflow, and legacy XML builder code into
+  the MKRF instance package.
+- Added instance-owned extension paths for K3Z FMG/pipeline policies, TSA29
+  named-pipeline contracts, TSA29 TSR adjudication overlays, Patchworks
+  variant registries, and instance catalog metadata.
+- Removed named example-instance coupling from `src/femic`; example model
+  instances under `external/` are optional deployments, not FEMIC core package
+  dependencies.
+- Tightened regression coverage so new named `mkrf`, `k3z`, `tsa29`, `tfl6`,
+  or `femic-*-instance` references under `src/femic` fail unless a future
+  roadmap phase explicitly reopens the allowlist.
+
+## Alpha Scope
+
+This release is intended for FRESH development and early integration testing.
+The extension APIs are usable, but still provisional while the example instance
+packages continue to settle around the new boundaries.
+
+FreshForge remains optional. Example-instance providers, catalogs, registries,
+and overlays are discovered only when the relevant instance package is
+installed or an explicit user registry/config file is supplied.
+
+## Known Caveats
+
+- Full local `mypy src` still has pre-existing typing debt outside P95 in
+  pandas/SciPy-heavy pipeline modules.
+- Full local `pytest` still has environment-sensitive baseline failures outside
+  P95, including checks that require local email configuration, external
+  runtime availability, or materialized example-instance payloads.
+- This release does not make example instances part of the FEMIC wheel. That is
+  intentional: K3Z, TSA29, MKRF, TFL6, and future examples are optional
+  deployments that can be installed, removed, or renamed independently of FEMIC
+  core.
+
+## Release Artifacts
+
+- Version: `0.2.0a1`
+- Tag: `v0.2.0a1`
+- GitHub release title: `FEMIC 0.2.0a1`
+- Publication target: TestPyPI validation first, then GitHub pre-release and
+  PyPI publication.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2826,17 +2826,20 @@ example-instance coupling from `src/femic`.
   - [x] Add `RELEASE_NOTES.md` for `FEMIC 0.2.0a1`.
   - [x] Summarize P80-P94 as the release boundary.
   - [x] State alpha/provisional scope and known non-P95 baseline caveats.
-- [ ] P95.4 Run local release validation
-  - [ ] Run `ruff format src tests`.
-  - [ ] Run `ruff check src tests`.
-  - [ ] Run targeted `mypy` for touched release/version modules.
-  - [ ] Run the focused version metadata test and P94 boundary/catalog tests.
-  - [ ] Run `sphinx-build -b html docs _build/html -W`.
-  - [ ] Run `python -m build`.
-  - [ ] Run `twine check dist/*`.
-  - [ ] Inspect built wheel/sdist metadata for version `0.2.0a1`.
-  - [ ] Run full `mypy src` and full `pytest` as release-audit checks, noting
+- [x] P95.4 Run local release validation
+  - [x] Run `ruff format src tests`.
+  - [x] Run `ruff check src tests`.
+  - [x] Run targeted `mypy` for touched release/version modules.
+  - [x] Run the focused version metadata test and P94 boundary/catalog tests.
+  - [x] Run `sphinx-build -b html docs _build/html -W`.
+  - [x] Run `python -m build`.
+  - [x] Run `twine check dist/*`.
+  - [x] Inspect built wheel/sdist metadata for version `0.2.0a1`.
+  - [x] Run full `mypy src` and full `pytest` as release-audit checks, noting
         known non-P95 baseline failures separately from release blockers.
+        Full `mypy src` still reports the known pandas/SciPy/VDYP typing debt.
+        Full `pytest` reports 19 known environment/runtime/baseline failures;
+        focused P95 release validation is green.
 - [ ] P95.5 Open and merge the release PR
   - [ ] Push the release branch and open the PR.
   - [ ] Require GitHub build and `package-release-checks` to pass.
@@ -2865,11 +2868,12 @@ example-instance coupling from `src/femic`.
   - `planning/roadmap_notes_archive.md`
 - Current edge:
   - `P95` / `#262` is active: publish FEMIC `0.2.0a1` as the core
-    decoupling alpha release. Version surfaces are synchronized and
-    `RELEASE_NOTES.md` is in place. The current edge is focused release
-    validation, artifact inspection, and PR publication. The unrelated
-    `external/femic-public-data` submodule state remains out of scope for this
-    release branch.
+    decoupling alpha release. Version surfaces are synchronized,
+    `RELEASE_NOTES.md` is in place, `--version` works through both
+    `python -m femic` and the console script, and focused release validation
+    plus artifact inspection passed. The current edge is PR publication and
+    GitHub release-check validation. The unrelated `external/femic-public-data`
+    submodule state remains out of scope for this release branch.
   - `P94` / `#254` is complete: remaining named-instance references were
     scrubbed from `src/femic`, packaged resources, generic templates, and
     generic CLI help. The boundary guard now rejects any new named

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2800,6 +2800,58 @@ example submodules present.
 - [x] P94.6 Run parent validation, open/merge the P94 PR, and close the
       P88-P94 core decoupling sequence.
 
+## Phase 95: Publish FEMIC 0.2.0a1 Core Decoupling Alpha
+
+Parent issue: #262
+
+Branch: `feature/p95-femic-0.2.0a1-release`
+
+Status: active
+
+Goal: prepare and publish an alpha FEMIC release that marks the P80-P94
+architecture milestone: FreshForge integration, instance-owned extension
+boundaries, externalized registries/catalogs, and final removal of named
+example-instance coupling from `src/femic`.
+
+- [x] P95.1 Prepare release lifecycle surfaces
+  - [x] Create parent branch `feature/p95-femic-0.2.0a1-release`.
+  - [x] Open parent GitHub issue `#262`.
+  - [x] Record the release checklist in `ROADMAP.md` before release edits.
+- [x] P95.2 Synchronize package version surfaces
+  - [x] Update `pyproject.toml` to `0.2.0a1`.
+  - [x] Update `src/femic/__init__.py` to `0.2.0a1`.
+  - [x] Add a focused test proving package metadata and `femic.__version__`
+        remain synchronized.
+- [x] P95.3 Add public release notes
+  - [x] Add `RELEASE_NOTES.md` for `FEMIC 0.2.0a1`.
+  - [x] Summarize P80-P94 as the release boundary.
+  - [x] State alpha/provisional scope and known non-P95 baseline caveats.
+- [ ] P95.4 Run local release validation
+  - [ ] Run `ruff format src tests`.
+  - [ ] Run `ruff check src tests`.
+  - [ ] Run targeted `mypy` for touched release/version modules.
+  - [ ] Run the focused version metadata test and P94 boundary/catalog tests.
+  - [ ] Run `sphinx-build -b html docs _build/html -W`.
+  - [ ] Run `python -m build`.
+  - [ ] Run `twine check dist/*`.
+  - [ ] Inspect built wheel/sdist metadata for version `0.2.0a1`.
+  - [ ] Run full `mypy src` and full `pytest` as release-audit checks, noting
+        known non-P95 baseline failures separately from release blockers.
+- [ ] P95.5 Open and merge the release PR
+  - [ ] Push the release branch and open the PR.
+  - [ ] Require GitHub build and `package-release-checks` to pass.
+  - [ ] Merge to `main` after release-prep checks pass.
+- [ ] P95.6 Publish staged and public release artifacts
+  - [ ] Tag `v0.2.0a1` from merged `main`.
+  - [ ] Run `publish-testpypi` and confirm TestPyPI smoke install.
+  - [ ] Create GitHub pre-release `FEMIC 0.2.0a1`.
+  - [ ] Run `publish-pypi` and confirm PyPI smoke install for
+        `femic==0.2.0a1`.
+- [ ] P95.7 Close out P95
+  - [ ] Update `CHANGE_LOG.md` with release-prep and publication results.
+  - [ ] Post required progress and closeout comments on issue `#262`.
+  - [ ] Close issue `#262` after publication and smoke checks pass.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2812,6 +2864,12 @@ example submodules present.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P95` / `#262` is active: publish FEMIC `0.2.0a1` as the core
+    decoupling alpha release. Version surfaces are synchronized and
+    `RELEASE_NOTES.md` is in place. The current edge is focused release
+    validation, artifact inspection, and PR publication. The unrelated
+    `external/femic-public-data` submodule state remains out of scope for this
+    release branch.
   - `P94` / `#254` is complete: remaining named-instance references were
     scrubbed from `src/femic`, packaged resources, generic templates, and
     generic CLI help. The boundary guard now rejects any new named

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "femic"
-version = "0.1.1a1"
+version = "0.2.0a1"
 description = "Forest Estate Modelling Integration Core"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/femic/__init__.py
+++ b/src/femic/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0a1"

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -287,6 +287,7 @@ from femic.workflows.legacy import (
 app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
+    invoke_without_command=True,
     help="Forest Estate Modelling Integration Core (FEMIC).",
 )
 prep_app = typer.Typer(
@@ -1037,6 +1038,7 @@ VERBOSE_OPTION = typer.Option(
 VERSION_OPTION = typer.Option(
     False,
     "--version",
+    is_eager=True,
     help="Show version and exit.",
 )
 DEBUG_OPTION = typer.Option(

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import femic
+
+
+def test_package_version_surfaces_are_synchronized() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["version"] == "0.2.0a1"
+    assert femic.__version__ == pyproject["project"]["version"]

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -4,6 +4,12 @@ import tomllib
 from pathlib import Path
 
 import femic
+from typer.testing import CliRunner
+
+from femic.cli.main import app
+
+
+runner = CliRunner()
 
 
 def test_package_version_surfaces_are_synchronized() -> None:
@@ -11,3 +17,10 @@ def test_package_version_surfaces_are_synchronized() -> None:
 
     assert pyproject["project"]["version"] == "0.2.0a1"
     assert femic.__version__ == pyproject["project"]["version"]
+
+
+def test_cli_version_reports_package_version() -> None:
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == femic.__version__


### PR DESCRIPTION
﻿## Summary

Prepare FEMIC `0.2.0a1` as the P80-P94 core decoupling alpha release.

## Changes

- Synchronize `pyproject.toml` and `femic.__version__` at `0.2.0a1`.
- Add `tests/test_version_metadata.py` for version metadata and CLI version regression coverage.
- Fix the root Typer app so `python -m femic --version` and `femic --version` report the package version before requiring a subcommand.
- Add `RELEASE_NOTES.md` and include it in the source distribution through `MANIFEST.in`.
- Add the P95 roadmap checklist and changelog entries.

## Validation

Passed locally:

- `python -m ruff format src tests`
- `python -m ruff check src tests`
- `python -m mypy src/femic/__init__.py src/femic/cli/main.py`
- `python -m pytest tests/test_version_metadata.py tests/test_instance_extension_boundaries.py tests/test_builtin_instances.py tests/test_patchworks_variants.py`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`
- `python -m femic --help`
- `python -m femic --version`
- `femic --version`
- direct wheel/sdist metadata inspection: wheel reports `Version: 0.2.0a1`, retains the `femic` console script and `freshforge.providers` entry point, and sdist includes `RELEASE_NOTES.md`.
- `pre-commit run --all-files`

Release audit, non-blocking known baseline:

- `python -m mypy src` still reports the known non-P95 pandas/SciPy/VDYP typing debt.
- `python -m pytest` reports 19 known non-P95 environment/runtime/baseline failures; focused P95 release validation is green.

## Notes

- Unrelated `external/femic-public-data` submodule dirt was left untouched.
- Publication steps remain after merge: tag `v0.2.0a1`, TestPyPI smoke, GitHub pre-release, PyPI publish, PyPI smoke.

Closes #262 after publication closeout.
