### PR TITLE
P95: Fix PyPI optional dependency metadata

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19199,3 +19199,19 @@
   pandas/SciPy/VDYP typing debt. Full release-audit `pytest` reports 19 known
   non-P95 environment/runtime/baseline failures; focused P95 release
   validation is green.
+
+## 2026-07-01 - Fixed P95 PyPI optional-dependency metadata blocker
+
+- Tagged merged `main` as `v0.2.0a1` and dispatched the TestPyPI publish
+  workflow.
+- The TestPyPI publish failed before smoke install because PyPI rejects direct
+  Git URL dependencies in package metadata. FEMIC's optional metadata still
+  listed GitHub installs for FreshForge and figrecover.
+- Removed direct Git URL dependencies from publishable optional-dependency
+  metadata and retained `freshforge` / `figures` as PyPI-safe compatibility
+  marker extras.
+- Updated README and docs to explain that FreshForge and figrecover must be
+  installed explicitly from their source repositories until they have PyPI
+  releases.
+- Added release-test coverage that fails if future optional-dependency metadata
+  reintroduces `git+` direct URLs.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ python -m pip install -r requirements-dev.txt
 This installs FEMIC in editable mode (`-e .`) plus development tools and
 DataLad (`datalad[full]`).
 
-The development extra also installs the optional FreshForge integration used
-to validate and plan FEMIC model-build workflow graphs without executing FEMIC
-stages. For a runtime install that only needs that integration, use
-`femic[freshforge]`.
+FreshForge is optional and currently installed from its source repository until
+it has a PyPI release. To use FreshForge orchestration with FEMIC, install
+FreshForge explicitly after the FEMIC dev install:
+
+```bash
+python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine"
+```
+
+The `femic[freshforge]` extra is retained as a PyPI-safe compatibility marker,
+but it does not install FreshForge while FreshForge has no PyPI distribution.
 
 Then bootstrap annex-backed submodules and materialize real file content:
 
@@ -75,8 +81,8 @@ femic prep geospatial-preflight
 ```
 
 FreshForge can inspect, plan, and explicitly run provider-backed FEMIC
-model-build graphs when FEMIC is installed with the optional integration. FEMIC
-core ships a generic provider example; concrete K3Z, MKRF, or other instance
+model-build graphs when FreshForge is installed alongside FEMIC. FEMIC core
+ships a generic provider example; concrete K3Z, MKRF, or other instance
 workflow documents belong in the corresponding instance repositories.
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,9 +28,12 @@ This release is intended for FRESH development and early integration testing.
 The extension APIs are usable, but still provisional while the example instance
 packages continue to settle around the new boundaries.
 
-FreshForge remains optional. Example-instance providers, catalogs, registries,
-and overlays are discovered only when the relevant instance package is
-installed or an explicit user registry/config file is supplied.
+FreshForge remains optional. Because FreshForge and figrecover do not yet have
+PyPI releases, FEMIC's PyPI metadata does not include direct Git URL
+dependencies for them. Install those optional tools explicitly from their
+source repositories when needed. Example-instance providers, catalogs,
+registries, and overlays are discovered only when the relevant instance package
+is installed or an explicit user registry/config file is supplied.
 
 ## Known Caveats
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2845,8 +2845,13 @@ example-instance coupling from `src/femic`.
   - [ ] Require GitHub build and `package-release-checks` to pass.
   - [ ] Merge to `main` after release-prep checks pass.
 - [ ] P95.6 Publish staged and public release artifacts
-  - [ ] Tag `v0.2.0a1` from merged `main`.
+  - [x] Tag `v0.2.0a1` from merged `main`.
   - [ ] Run `publish-testpypi` and confirm TestPyPI smoke install.
+        First TestPyPI attempt failed because publishable optional dependency
+        metadata contained direct Git URL dependencies for FreshForge and
+        figrecover. P95 now removes those direct URL dependencies from
+        publishable package metadata and documents explicit source installs
+        until those optional packages have PyPI releases.
   - [ ] Create GitHub pre-release `FEMIC 0.2.0a1`.
   - [ ] Run `publish-pypi` and confirm PyPI smoke install for
         `femic==0.2.0a1`.
@@ -2871,9 +2876,13 @@ example-instance coupling from `src/femic`.
     decoupling alpha release. Version surfaces are synchronized,
     `RELEASE_NOTES.md` is in place, `--version` works through both
     `python -m femic` and the console script, and focused release validation
-    plus artifact inspection passed. The current edge is PR publication and
-    GitHub release-check validation. The unrelated `external/femic-public-data`
-    submodule state remains out of scope for this release branch.
+    plus artifact inspection passed. PR `#263` merged and tag `v0.2.0a1` was
+    pushed, but the first TestPyPI publish failed because PyPI rejects direct
+    Git URL dependencies in optional-dependency metadata. The current edge is
+    a P95 metadata-fix PR that removes those direct URLs, reruns release
+    checks, moves the tag to the corrected commit, and retries TestPyPI. The
+    unrelated `external/femic-public-data` submodule state remains out of
+    scope for this release branch.
   - `P94` / `#254` is complete: remaining named-instance references were
     scrubbed from `src/femic`, packaged resources, generic templates, and
     generic CLI help. The boundary guard now rejects any new named

--- a/docs/guides/document-figure-recovery.rst
+++ b/docs/guides/document-figure-recovery.rst
@@ -12,12 +12,15 @@ require ``figrecover``.
 Install
 -------
 
-Install FEMIC with the figure-recovery extra only on workstations that will
+Install figrecover from its source repository only on workstations that will
 prepare or review document figures:
 
 .. code-block:: bash
 
-   python -m pip install -e ".[figures]"
+   python -m pip install "figrecover[pdf,cv,vlm] @ git+https://github.com/UBC-FRESH/figrecover.git@v0.1.0a1"
+
+The ``femic[figures]`` extra is retained as a PyPI-safe compatibility marker,
+but it does not install figrecover while figrecover has no PyPI distribution.
 
 Then verify the optional stack:
 

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -19,19 +19,25 @@ runtime configuration, and artifact names are owned.
 Install
 -------
 
-For development, ``requirements-dev.txt`` installs the FreshForge integration
-through FEMIC's ``dev`` extra. For a smaller runtime install, use:
+FreshForge is optional and currently installed from its source repository until
+it has a PyPI release. For development or runtime use, install FEMIC first and
+then install FreshForge explicitly:
 
 .. code-block:: bash
 
-   python -m pip install "femic[freshforge]"
+   python -m pip install femic
+   python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine"
+
+The ``femic[freshforge]`` extra is retained as a PyPI-safe compatibility
+marker, but it does not install FreshForge while FreshForge has no PyPI
+distribution.
 
 Provider Discovery
 ------------------
 
 FEMIC registers provider entry points in the ``freshforge.providers`` group.
-When FEMIC is installed with the optional FreshForge dependency, FreshForge can
-discover provider ID ``femic``:
+When FreshForge is installed alongside FEMIC, FreshForge can discover provider
+ID ``femic``:
 
 .. code-block:: bash
 

--- a/docs/reference/api/femic-freshforge.rst
+++ b/docs/reference/api/femic-freshforge.rst
@@ -4,8 +4,9 @@
 The :mod:`femic.freshforge` module owns FEMIC's optional FreshForge provider
 integration.
 
-It intentionally keeps FreshForge behind the optional ``femic[freshforge]``
-dependency boundary. Normal FEMIC imports do not import FreshForge eagerly.
+It intentionally keeps FreshForge optional. Normal FEMIC imports do not import
+FreshForge eagerly, and users install FreshForge alongside FEMIC when they need
+workflow orchestration.
 
 Responsibilities
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,11 @@ dependencies = [
 
 [project.optional-dependencies]
 freshforge = [
-    "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine",
 ]
 figures = [
-    "figrecover[pdf,cv,vlm] @ git+https://github.com/UBC-FRESH/figrecover.git@v0.1.0a1",
 ]
 dev = [
     "datalad[full]",
-    "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine",
     "ipywidgets",
     "mypy",
     "pre-commit",

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -149,8 +149,8 @@ def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
     optional = pyproject["project"]["optional-dependencies"]
-    assert any("freshforge" in item for item in optional["freshforge"])
-    assert any("freshforge" in item for item in optional["dev"])
+    assert "freshforge" in optional
+    assert all("git+" not in item for deps in optional.values() for item in deps)
     entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
     assert entry_points["femic"] == "femic.freshforge:provider_factory"
     assert "femic_mkrf" not in entry_points


### PR DESCRIPTION
﻿## Summary

Fix the P95 TestPyPI blocker by removing direct Git URL dependencies from publishable optional dependency metadata.

## Why

The first `publish-testpypi` run for `v0.2.0a1` failed at upload with:

`400 Can't have direct dependency: freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine ; extra == "freshforge"`

PyPI rejects direct URL dependencies in metadata. FreshForge and figrecover are not on PyPI yet, so FEMIC cannot publish metadata that declares them as extras via direct Git URLs.

## Changes

- Retain `freshforge` and `figures` as PyPI-safe marker extras with no direct URL dependencies.
- Remove FreshForge direct URL dependency from `dev` metadata.
- Update README/docs/release notes to install FreshForge and figrecover explicitly from their source repositories until they have PyPI releases.
- Update the FreshForge packaging test to fail if optional metadata reintroduces `git+` dependencies.
- Record the failed TestPyPI attempt and fix in roadmap/changelog.

## Validation

Passed locally:

- `python -m ruff format src tests`
- `python -m ruff check src tests`
- `python -m pytest tests/test_version_metadata.py tests/test_freshforge_integration.py tests/test_cli_main.py::test_doc_figures_preflight_fails_when_figrecover_missing`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`
- direct artifact inspection: no FreshForge/figrecover `Requires-Dist`; sdist includes `RELEASE_NOTES.md`
- `pre-commit run --all-files`

Unrelated `external/femic-public-data` submodule dirt remains untouched.
