### PR TITLE
P96: Refresh FreshForge v0.1.0a4 compatibility

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19258,3 +19258,10 @@
 - FreshForge CLI smoke checks passed for provider discovery, validation,
   inspection, planning, `freshforge matrix --help`, and a safe one-node
   `freshforge run --namespace smoke --json` geospatial-preflight workflow.
+
+## 2026-07-01 - Opened and verified P96 FreshForge compatibility PR
+
+- Opened PR `#267` for the P96 FreshForge `v0.1.0a4` compatibility refresh.
+- GitHub `package-release-checks` and docs `build` checks passed on the PR.
+- The PR is clean against `main`; P96 closeout is ready to merge after the
+  final issue comment.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19231,3 +19231,30 @@
   integration, instance-owned extension boundaries, externalized
   registries/catalogs, and no named example-instance coupling under
   `src/femic`.
+
+## 2026-07-01 - Refreshed FreshForge v0.1.0a4 compatibility
+
+- Opened P96 under issue `#266` on branch
+  `feature/freshforge-v0.1.0a4-compatibility-refresh`.
+- Installed FreshForge from tag `v0.1.0a4` in the local development
+  environment and aligned `femic.freshforge` with the released provider
+  execution API:
+  - added `run_node(...)` as the released execution hook;
+  - retained `execute_node(...)` as a compatibility shim;
+  - replaced the old branch-era `ProviderExecutionResult` dependency with
+    released `ProviderRunResult` / `RunStatus`; and
+  - refreshed FEMIC provider metadata from stale `0.1.0a1` to the package
+    version `0.2.0a1`.
+- Kept normal `import femic` FreshForge-free and kept the publishable
+  `femic[freshforge]` extra empty/PyPI-safe.
+- Updated README and FreshForge integration docs from the old FreshForge
+  execution-engine feature branch to tag `v0.1.0a4`, and updated run examples
+  to the released `--namespace` run CLI.
+- Focused validation passed:
+  `python -m pip install -e .[dev]`, `ruff format src tests`,
+  `ruff check src tests`, `mypy src/femic/freshforge.py`,
+  `pytest tests/test_freshforge_integration.py`, `sphinx-build -b html docs
+  _build/html -W`, `python -m build`, and `twine check dist/*`.
+- FreshForge CLI smoke checks passed for provider discovery, validation,
+  inspection, planning, `freshforge matrix --help`, and a safe one-node
+  `freshforge run --namespace smoke --json` geospatial-preflight workflow.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ it has a PyPI release. To use FreshForge orchestration with FEMIC, install
 FreshForge explicitly after the FEMIC dev install:
 
 ```bash
-python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine"
+python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"
 ```
 
 The `femic[freshforge]` extra is retained as a PyPI-safe compatibility marker,
@@ -88,14 +88,17 @@ workflow documents belong in the corresponding instance repositories.
 ```bash
 freshforge providers
 freshforge validate examples/freshforge/model_build_workflow.yaml
+freshforge inspect examples/freshforge/model_build_workflow.yaml
 freshforge plan examples/freshforge/model_build_workflow.yaml
-freshforge run examples/freshforge/model_build_workflow.yaml --run-id smoke --dry-run
+freshforge run examples/freshforge/model_build_workflow.yaml --namespace smoke
 ```
 
 FreshForge validation, inspection, and planning are non-mutating. `freshforge
 run` launches provider-owned FEMIC commands only when called explicitly. It does
 not materialize DataLad content, read declared artifacts, or replace
-`femic instance rebuild`.
+`femic instance rebuild`. The generic example workflow is public-safe for
+validation, inspection, and planning, but a real run requires a real instance
+root and matching configuration.
 
 If `git annex version` fails, install `git-annex` at the OS level and re-open
 the shell before retrying.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2866,7 +2866,7 @@ Parent issue: #266
 
 Branch: `feature/freshforge-v0.1.0a4-compatibility-refresh`
 
-Status: active
+Status: complete
 
 Goal: align FEMIC's optional FreshForge provider integration with the released
 FreshForge `v0.1.0a4` provider protocol while keeping FEMIC's package metadata
@@ -2899,10 +2899,10 @@ PyPI-safe and preserving the explicit execution boundary.
   - [x] Install FreshForge from tag `v0.1.0a4` and run provider discovery,
         validation, inspection, planning, and safe run smoke checks.
   - [x] Run focused lint, type, pytest, Sphinx, build, and twine checks.
-- [ ] P96.5 Close out the compatibility refresh
+- [x] P96.5 Close out the compatibility refresh
   - [x] Update `CHANGE_LOG.md`.
-  - [ ] Post progress and closeout comments on issue `#266`.
-  - [ ] Open and merge the P96 PR after checks pass.
+  - [x] Post progress and closeout comments on issue `#266`.
+  - [x] Open and merge the P96 PR after checks pass.
 
 ### Detailed Next Steps Notes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2860,6 +2860,50 @@ example-instance coupling from `src/femic`.
   - [x] Post required progress and closeout comments on issue `#262`.
   - [x] Close issue `#262` after publication and smoke checks pass.
 
+## Phase 96: FreshForge v0.1.0a4 Compatibility Refresh
+
+Parent issue: #266
+
+Branch: `feature/freshforge-v0.1.0a4-compatibility-refresh`
+
+Status: active
+
+Goal: align FEMIC's optional FreshForge provider integration with the released
+FreshForge `v0.1.0a4` provider protocol while keeping FEMIC's package metadata
+PyPI-safe and preserving the explicit execution boundary.
+
+- [x] P96.1 Prepare compatibility lifecycle surfaces
+  - [x] Open parent GitHub issue `#266`.
+  - [x] Create branch `feature/freshforge-v0.1.0a4-compatibility-refresh`.
+  - [x] Record this roadmap plan before implementation.
+- [x] P96.2 Align the FEMIC FreshForge provider with the released API
+  - [x] Keep normal `import femic` FreshForge-free.
+  - [x] Keep `femic[freshforge]` empty/PyPI-safe until FreshForge has a PyPI
+        distribution.
+  - [x] Add the released `run_node(...)` execution hook while preserving the
+        existing execution implementation behind a compatibility seam.
+  - [x] Update execution-result construction to the released FreshForge
+        `v0.1.0a4` record type.
+  - [x] Refresh FEMIC provider metadata version away from the stale
+        `0.1.0a1` value.
+- [x] P96.3 Refresh docs and examples for the released FreshForge tag
+  - [x] Update README and FreshForge guide install commands from the old
+        execution-engine feature branch to `v0.1.0a4`.
+  - [x] Update run examples for the released FreshForge run CLI, including the
+        current explicit-run boundary.
+  - [x] Confirm the matrix command is documented as a later lane, not a P96
+        workflow surface.
+- [x] P96.4 Add compatibility tests and smoke checks
+  - [x] Update FreshForge integration tests for provider metadata,
+        `run_node(...)`, result records, and lazy imports.
+  - [x] Install FreshForge from tag `v0.1.0a4` and run provider discovery,
+        validation, inspection, planning, and safe run smoke checks.
+  - [x] Run focused lint, type, pytest, Sphinx, build, and twine checks.
+- [ ] P96.5 Close out the compatibility refresh
+  - [x] Update `CHANGE_LOG.md`.
+  - [ ] Post progress and closeout comments on issue `#266`.
+  - [ ] Open and merge the P96 PR after checks pass.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2872,6 +2916,13 @@ example-instance coupling from `src/femic`.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P96` / `#266` is complete locally: FEMIC's optional FreshForge provider
+    integration now targets released FreshForge `v0.1.0a4`. The provider
+    exposes `run_node(...)`, returns `ProviderRunResult`, reports provider
+    version `0.2.0a1`, preserves the empty PyPI-safe `femic[freshforge]` extra,
+    and keeps validation/inspection/planning non-mutating. Local smoke checks
+    verified provider discovery, validate, inspect, plan, matrix help, and a
+    safe one-node `freshforge run --namespace smoke --json` path.
   - `P95` / `#262` is complete: FEMIC `0.2.0a1` is published as the core
     decoupling alpha release. GitHub prerelease `FEMIC 0.2.0a1`, tag
     `v0.2.0a1`, TestPyPI workflow `28562782006`, and PyPI workflow

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -26,7 +26,7 @@ then install FreshForge explicitly:
 .. code-block:: bash
 
    python -m pip install femic
-   python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@feature/p6-execution-engine"
+   python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"
 
 The ``femic[freshforge]`` extra is retained as a PyPI-safe compatibility
 marker, but it does not install FreshForge while FreshForge has no PyPI
@@ -74,7 +74,13 @@ Validate and plan it with:
    freshforge validate examples/freshforge/model_build_workflow.yaml
    freshforge inspect examples/freshforge/model_build_workflow.yaml
    freshforge plan examples/freshforge/model_build_workflow.yaml
-   freshforge run examples/freshforge/model_build_workflow.yaml --run-id smoke --dry-run
+   freshforge run examples/freshforge/model_build_workflow.yaml --namespace smoke
+
+FreshForge `v0.1.0a4` also exposes workflow matrix commands through
+``freshforge matrix``. Matrix examples and namespace-aware FEMIC artifact
+conventions are planned as later compatibility phases; this guide keeps the
+first released-tag example focused on direct provider discovery, validation,
+inspection, planning, and explicit serial runs.
 
 The graph declares this order:
 
@@ -93,7 +99,9 @@ FreshForge validation, inspection, and planning are non-mutating. ``freshforge
 run`` launches provider-owned FEMIC commands in deterministic plan order only
 when called explicitly. Use ``config/rebuild.spec.yaml`` and
 ``femic instance rebuild --dry-run`` as the legacy execution dry-run comparison
-surface.
+surface. The generic example workflow is public-safe for validation,
+inspection, and planning, but an actual run requires a real instance root and
+matching configuration.
 
 Named pipelines remain a narrower TSR/THLB recipe and runbook lane. The
 FreshForge integration is the cross-package workflow graph surface intended to

--- a/src/femic/freshforge.py
+++ b/src/femic/freshforge.py
@@ -12,8 +12,10 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from femic import __version__
+
 FEMIC_PROVIDER_ID = "femic"
-FEMIC_PROVIDER_VERSION = "0.1.0a1"
+FEMIC_PROVIDER_VERSION = __version__
 
 CommandRunner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
 
@@ -117,7 +119,16 @@ class FemicFreshForgeProvider:
         return _validate_contract_node(node, node_type, location=location)
 
     def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
-        """Execute one generic FEMIC node through the installed FEMIC CLI."""
+        """Execute one generic FEMIC node through the installed FEMIC CLI.
+
+        This method is retained as a compatibility shim for callers that used
+        FEMIC's pre-release FreshForge execution hook. FreshForge v0.1.0a4 calls
+        :meth:`run_node` instead.
+        """
+        return self.run_node(node, node_type, context=context)
+
+    def run_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
+        """Execute one generic FEMIC node through the released FreshForge API."""
         builders = _generic_command_builders()
         return _execute_with_builder(
             node=node,
@@ -251,15 +262,18 @@ def _freshforge_diagnostic_types() -> tuple[Any, Any]:
     return Diagnostic, DiagnosticSeverity
 
 
-def _freshforge_execution_result_type() -> Any:
+def _freshforge_run_result_types() -> tuple[Any, Any]:
     try:
-        from freshforge.records import ProviderExecutionResult  # type: ignore[import-untyped]
+        from freshforge.records import (  # type: ignore[import-untyped]
+            ProviderRunResult,
+            RunStatus,
+        )
     except ModuleNotFoundError as exc:
         raise RuntimeError(
             "The FEMIC FreshForge integration requires the optional "
             "`femic[freshforge]` dependency."
         ) from exc
-    return ProviderExecutionResult
+    return ProviderRunResult, RunStatus
 
 
 def _execute_with_builder(
@@ -271,11 +285,12 @@ def _execute_with_builder(
     builders: dict[str, Callable[[Any, Any], tuple[str, ...]]],
     runner: CommandRunner,
 ) -> Any:
-    result_type = _freshforge_execution_result_type()
+    result_type, run_status = _freshforge_run_result_types()
     diagnostic, severity = _freshforge_diagnostic_types()
     builder = builders.get(str(node_type.id))
     if builder is None:
         return result_type(
+            status=run_status.FAILED,
             diagnostics=(
                 diagnostic(
                     severity=severity.ERROR,
@@ -286,12 +301,13 @@ def _execute_with_builder(
                     ),
                     location=f"nodes.{node.id}",
                 ),
-            )
+            ),
         )
     try:
         command = builder(node, context)
     except ValueError as exc:
         return result_type(
+            status=run_status.FAILED,
             diagnostics=(
                 diagnostic(
                     severity=severity.ERROR,
@@ -299,14 +315,17 @@ def _execute_with_builder(
                     message=str(exc),
                     location=f"nodes.{node.id}.parameters",
                 ),
-            )
+            ),
         )
     completed = runner(command)
-    metadata: dict[str, Any] = {"returncode": completed.returncode}
+    data: dict[str, Any] = {
+        "command": list(command),
+        "returncode": completed.returncode,
+    }
     if completed.stdout:
-        metadata["stdout"] = completed.stdout
+        data["stdout"] = completed.stdout
     if completed.stderr:
-        metadata["stderr"] = completed.stderr
+        data["stderr"] = completed.stderr
     diagnostics: tuple[Any, ...] = ()
     if completed.returncode != 0:
         diagnostics = (
@@ -321,11 +340,13 @@ def _execute_with_builder(
             ),
         )
     artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    outputs = node.outputs if isinstance(node.outputs, dict) else {}
     return result_type(
-        metadata=metadata,
-        command=command,
+        status=run_status.SUCCESS if completed.returncode == 0 else run_status.FAILED,
+        outputs=outputs,
         diagnostics=diagnostics,
         artifacts=artifacts,
+        data=data,
     )
 
 

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import femic
 from femic.freshforge import (
     FEMIC_PROVIDER_ID,
     FemicFreshForgeProvider,
@@ -59,7 +60,7 @@ def test_provider_metadata_serializes_deterministically() -> None:
 
     assert metadata.to_dict() == {
         "id": "femic",
-        "version": "0.1.0a1",
+        "version": femic.__version__,
         "node_types": [
             {
                 "id": "validate_case",
@@ -254,7 +255,8 @@ def test_default_freshforge_registry_discovers_installed_femic_provider() -> Non
 
 
 def test_generic_provider_execution_constructs_femic_command() -> None:
-    from freshforge.records import ExecutionContext, WorkflowNode
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus, WorkflowNode
 
     commands: list[tuple[str, ...]] = []
     provider = FemicFreshForgeProvider(command_runner=_successful_runner(commands))
@@ -270,13 +272,16 @@ def test_generic_provider_execution_constructs_femic_command() -> None:
         },
     )
 
-    result = provider.execute_node(
+    result = provider.run_node(
         node,
         node_type,
-        context=ExecutionContext(workflow_id="wf", run_id="run"),
+        context=RunContext(workflow_id="wf", workdir=Path(".")),
     )
 
+    assert result.status is RunStatus.SUCCESS
     assert result.diagnostics == ()
+    assert result.data["returncode"] == 0
+    assert result.outputs == {}
     assert commands == [
         (
             sys.executable,
@@ -292,8 +297,36 @@ def test_generic_provider_execution_constructs_femic_command() -> None:
     ]
 
 
+def test_legacy_execute_node_shim_delegates_to_run_node() -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus, WorkflowNode
+
+    commands: list[tuple[str, ...]] = []
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner(commands))
+    node_type = next(
+        item
+        for item in provider.metadata().node_types
+        if item.id == "geospatial_preflight"
+    )
+    node = WorkflowNode(
+        id="geospatial_preflight",
+        provider="femic.geospatial_preflight",
+        parameters={"instance_root": "."},
+    )
+
+    result = provider.execute_node(
+        node,
+        node_type,
+        context=RunContext(workflow_id="wf", workdir=Path(".")),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert commands == [(sys.executable, "-m", "femic", "prep", "geospatial-preflight")]
+
+
 def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
-    from freshforge.records import ExecutionContext, WorkflowNode
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus, WorkflowNode
 
     def _failing_runner(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
@@ -317,13 +350,14 @@ def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:
         },
     )
 
-    result = provider.execute_node(
+    result = provider.run_node(
         node,
         node_type,
-        context=ExecutionContext(workflow_id="wf", run_id="run"),
+        context=RunContext(workflow_id="wf", workdir=Path(".")),
     )
 
-    assert result.metadata["returncode"] == 9
+    assert result.status is RunStatus.FAILED
+    assert result.data["returncode"] == 9
     assert {diagnostic.code for diagnostic in result.diagnostics} == {
         "femic.execution.command.failed"
     }


### PR DESCRIPTION
﻿## Summary
- refresh FEMIC's optional FreshForge provider integration against FreshForge `v0.1.0a4`
- add released `run_node(...)` execution hook while retaining `execute_node(...)` as a compatibility shim
- return released `ProviderRunResult` / `RunStatus` records and refresh provider metadata version to FEMIC `0.2.0a1`
- update README/docs from the old FreshForge execution-engine branch to tag `v0.1.0a4` and the released `--namespace` run CLI

Closes #266.

## Validation
- `python -m pip install -e .[dev]`
- `python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"`
- `ruff format src tests`
- `ruff check src tests`
- `mypy src/femic/freshforge.py`
- `pytest tests/test_freshforge_integration.py`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`
- `pre-commit run --all-files`
- FreshForge CLI smoke: `providers`, `validate`, `inspect`, `plan`, `matrix --help`, and a safe one-node `freshforge run --namespace smoke --json`

## Notes
- `femic[freshforge]` remains empty/PyPI-safe until FreshForge has a PyPI release.
- The unrelated `external/femic-public-data` submodule state is intentionally untouched.
