### PR TITLE
P97: Add namespace-aware FreshForge artifact reporting

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19265,3 +19265,35 @@
 - GitHub `package-release-checks` and docs `build` checks passed on the PR.
 - The PR is clean against `main`; P96 closeout is ready to merge after the
   final issue comment.
+
+## 2026-07-01 - Implemented P97 FreshForge namespace-aware artifact metadata
+
+- Opened P97 under issue `#268` on branch
+  `feature/p97-freshforge-namespace-artifacts`.
+- Added report-only artifact resolution to `femic.freshforge`: workflow-declared
+  string and path-like artifact values are resolved through FreshForge
+  `RunContext.resolve_path(...)` and returned as strings in
+  `ProviderRunResult.artifacts`.
+- Preserved the explicit scope boundary:
+  - FEMIC command construction is unchanged;
+  - namespace-resolved paths are not automatically passed into `--log-dir`,
+    `--output-dir`, Patchworks package paths, or other FEMIC CLI options;
+  - no runtime outputs are moved; and
+  - validation, inspection, and planning remain non-mutating.
+- Updated README and FreshForge integration docs to show
+  `freshforge run ... --workdir runtime/freshforge --namespace smoke` and to
+  explain that namespace-aware artifacts are metadata only in this phase.
+- Added tests covering no-namespace, namespace, absolute-path, and JSON-safe
+  non-string artifact behavior.
+- Focused validation passed:
+  `python -m pip install -e .[dev]`,
+  `python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"`,
+  `ruff format src tests`, `ruff check src tests`,
+  `mypy src/femic/freshforge.py`, `pytest tests/test_freshforge_integration.py`,
+  `sphinx-build -b html docs _build/html -W`, `python -m build`,
+  `twine check dist/*`, and `pre-commit run --all-files`.
+- FreshForge CLI smoke passed with a one-node geospatial-preflight workflow:
+  `freshforge run <temp workflow> --workdir runtime/freshforge --namespace
+  smoke --json` returned a namespace-resolved artifact path under
+  `runtime/freshforge/smoke/...` while leaving the command as
+  `python -m femic prep geospatial-preflight`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19297,3 +19297,11 @@
   smoke --json` returned a namespace-resolved artifact path under
   `runtime/freshforge/smoke/...` while leaving the command as
   `python -m femic prep geospatial-preflight`.
+
+## 2026-07-01 - Opened and verified P97 FreshForge artifact PR
+
+- Opened PR `#269` for the P97 namespace-aware FreshForge artifact metadata
+  refresh.
+- GitHub `package-release-checks` and docs `build` checks passed on the PR.
+- The PR is clean against `main`; P97 closeout is ready to merge after the
+  final issue comment.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ freshforge providers
 freshforge validate examples/freshforge/model_build_workflow.yaml
 freshforge inspect examples/freshforge/model_build_workflow.yaml
 freshforge plan examples/freshforge/model_build_workflow.yaml
-freshforge run examples/freshforge/model_build_workflow.yaml --namespace smoke
+freshforge run examples/freshforge/model_build_workflow.yaml --workdir runtime/freshforge --namespace smoke
 ```
 
 FreshForge validation, inspection, and planning are non-mutating. `freshforge
@@ -99,6 +99,12 @@ not materialize DataLad content, read declared artifacts, or replace
 `femic instance rebuild`. The generic example workflow is public-safe for
 validation, inspection, and planning, but a real run requires a real instance
 root and matching configuration.
+
+When `freshforge run` is called with `--workdir` and `--namespace`, FEMIC
+returns namespace-resolved declared artifact paths in the FreshForge run record.
+This is report-only metadata: FEMIC does not automatically reroute command
+outputs, logs, or Patchworks package paths unless the workflow parameters
+already pass those paths to the underlying FEMIC command.
 
 If `git annex version` fails, install `git-annex` at the OS level and re-open
 the shell before retrying.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2910,7 +2910,7 @@ Parent issue: #268
 
 Branch: `feature/p97-freshforge-namespace-artifacts`
 
-Status: active
+Status: complete
 
 Goal: add report-only namespace-aware artifact metadata to FEMIC's generic
 FreshForge provider by resolving workflow-declared artifact paths through the
@@ -2938,13 +2938,13 @@ FreshForge run context without changing FEMIC command outputs.
   - [x] Add focused tests for no-namespace, namespace, absolute-path, and
         non-string artifact behavior.
   - [x] Verify returned artifacts remain JSON-serializable.
-- [ ] P97.5 Validate and close out
+- [x] P97.5 Validate and close out
   - [x] Install editable dev dependencies and FreshForge `v0.1.0a4`.
   - [x] Run Ruff, targeted mypy, focused pytest, Sphinx, build, twine, and
         FreshForge CLI smoke checks.
   - [x] Update `CHANGE_LOG.md`.
-  - [ ] Post progress and closeout comments on issue `#268`.
-  - [ ] Open and merge the P97 PR after checks pass.
+  - [x] Post progress and closeout comments on issue `#268`.
+  - [x] Open and merge the P97 PR after checks pass.
 
 ### Detailed Next Steps Notes
 
@@ -2958,12 +2958,11 @@ FreshForge run context without changing FEMIC command outputs.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P97` / `#268` is locally implemented and pending PR lifecycle:
-    report-only namespace-aware FreshForge artifact metadata resolves
-    workflow-declared artifact paths through FreshForge
-    `RunContext.resolve_path(...)` for provider run records. FEMIC command
-    construction remains unchanged, validation/inspection/planning remain
-    non-mutating, and command-output routing remains deferred.
+  - `P97` / `#268` is complete: report-only namespace-aware FreshForge
+    artifact metadata resolves workflow-declared artifact paths through
+    FreshForge `RunContext.resolve_path(...)` for provider run records. FEMIC
+    command construction remains unchanged, validation/inspection/planning
+    remain non-mutating, and command-output routing remains deferred.
   - `P96` / `#266` is complete locally: FEMIC's optional FreshForge provider
     integration now targets released FreshForge `v0.1.0a4`. The provider
     exposes `run_node(...)`, returns `ProviderRunResult`, reports provider

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2904,6 +2904,48 @@ PyPI-safe and preserving the explicit execution boundary.
   - [x] Post progress and closeout comments on issue `#266`.
   - [x] Open and merge the P96 PR after checks pass.
 
+## Phase 97: Namespace-Aware FEMIC FreshForge Artifacts
+
+Parent issue: #268
+
+Branch: `feature/p97-freshforge-namespace-artifacts`
+
+Status: active
+
+Goal: add report-only namespace-aware artifact metadata to FEMIC's generic
+FreshForge provider by resolving workflow-declared artifact paths through the
+FreshForge run context without changing FEMIC command outputs.
+
+- [x] P97.1 Prepare lifecycle surfaces
+  - [x] Open parent GitHub issue `#268`.
+  - [x] Create branch `feature/p97-freshforge-namespace-artifacts`.
+  - [x] Record this roadmap plan before implementation.
+- [x] P97.2 Resolve declared artifact metadata through FreshForge run context
+  - [x] Add a lazy helper that uses `context.resolve_path(...)` when available.
+  - [x] Return resolved artifact paths as strings in `ProviderRunResult.artifacts`.
+  - [x] Preserve non-string JSON-safe artifact metadata without path resolution.
+  - [x] Keep FEMIC command construction, stdout/stderr data, and return-code
+        behavior unchanged.
+- [x] P97.3 Preserve the report-only boundary
+  - [x] Do not automatically pass namespaced paths into FEMIC CLI options.
+  - [x] Do not move existing FEMIC runtime outputs.
+  - [x] Do not claim resolved artifact paths exist unless commands create them.
+  - [x] Keep `validate`, `inspect`, and `plan` non-mutating.
+- [x] P97.4 Update docs and tests
+  - [x] Document namespace-aware artifact metadata and the report-only boundary.
+  - [x] Document `freshforge run ... --namespace smoke --workdir
+        runtime/freshforge` as the recommended smoke pattern.
+  - [x] Add focused tests for no-namespace, namespace, absolute-path, and
+        non-string artifact behavior.
+  - [x] Verify returned artifacts remain JSON-serializable.
+- [ ] P97.5 Validate and close out
+  - [x] Install editable dev dependencies and FreshForge `v0.1.0a4`.
+  - [x] Run Ruff, targeted mypy, focused pytest, Sphinx, build, twine, and
+        FreshForge CLI smoke checks.
+  - [x] Update `CHANGE_LOG.md`.
+  - [ ] Post progress and closeout comments on issue `#268`.
+  - [ ] Open and merge the P97 PR after checks pass.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -2916,6 +2958,12 @@ PyPI-safe and preserving the explicit execution boundary.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P97` / `#268` is locally implemented and pending PR lifecycle:
+    report-only namespace-aware FreshForge artifact metadata resolves
+    workflow-declared artifact paths through FreshForge
+    `RunContext.resolve_path(...)` for provider run records. FEMIC command
+    construction remains unchanged, validation/inspection/planning remain
+    non-mutating, and command-output routing remains deferred.
   - `P96` / `#266` is complete locally: FEMIC's optional FreshForge provider
     integration now targets released FreshForge `v0.1.0a4`. The provider
     exposes `run_node(...)`, returns `ProviderRunResult`, reports provider

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -74,13 +74,29 @@ Validate and plan it with:
    freshforge validate examples/freshforge/model_build_workflow.yaml
    freshforge inspect examples/freshforge/model_build_workflow.yaml
    freshforge plan examples/freshforge/model_build_workflow.yaml
-   freshforge run examples/freshforge/model_build_workflow.yaml --namespace smoke
+   freshforge run examples/freshforge/model_build_workflow.yaml --workdir runtime/freshforge --namespace smoke
 
 FreshForge `v0.1.0a4` also exposes workflow matrix commands through
-``freshforge matrix``. Matrix examples and namespace-aware FEMIC artifact
-conventions are planned as later compatibility phases; this guide keeps the
-first released-tag example focused on direct provider discovery, validation,
-inspection, planning, and explicit serial runs.
+``freshforge matrix``. Matrix examples and command-output namespace routing
+are planned as later compatibility phases; this guide keeps the first
+released-tag example focused on direct provider discovery, validation,
+inspection, planning, explicit serial runs, and report-only artifact metadata.
+
+Namespace-Aware Artifacts
+-------------------------
+
+When ``freshforge run`` is called with ``--workdir`` and ``--namespace``,
+FEMIC resolves workflow-declared artifact paths in the returned FreshForge run
+record. For example, a declared artifact such as
+``runtime/logs/run_manifest.json`` is reported under
+``runtime/freshforge/smoke/runtime/logs/run_manifest.json`` when the command
+uses ``--workdir runtime/freshforge --namespace smoke``.
+
+This is currently report-only metadata. FEMIC does not automatically pass the
+resolved paths into command options such as ``--log-dir`` or ``--output-dir``,
+does not move existing runtime outputs, and does not claim that resolved
+artifact paths exist unless the provider-owned command actually creates them.
+Collision-safe command-output routing is a later phase.
 
 The graph declares this order:
 

--- a/src/femic/freshforge.py
+++ b/src/femic/freshforge.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from femic import __version__
@@ -339,7 +340,7 @@ def _execute_with_builder(
                 location=f"nodes.{node.id}",
             ),
         )
-    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    artifacts = _resolved_artifacts(node, context)
     outputs = node.outputs if isinstance(node.outputs, dict) else {}
     return result_type(
         status=run_status.SUCCESS if completed.returncode == 0 else run_status.FAILED,
@@ -348,6 +349,20 @@ def _execute_with_builder(
         artifacts=artifacts,
         data=data,
     )
+
+
+def _resolved_artifacts(node: Any, context: Any) -> dict[str, Any]:
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    resolve_path = getattr(context, "resolve_path", None)
+    if not callable(resolve_path):
+        return dict(artifacts)
+    resolved: dict[str, Any] = {}
+    for key, value in artifacts.items():
+        if isinstance(value, (str, Path)):
+            resolved[key] = str(resolve_path(value))
+        else:
+            resolved[key] = value
+    return resolved
 
 
 def _default_command_runner(

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import tomllib
+import json
 from pathlib import Path
 
 import pytest
@@ -295,6 +296,146 @@ def test_generic_provider_execution_constructs_femic_command() -> None:
             "config/run_profile.mkrf.yaml",
         )
     ]
+
+
+def test_provider_run_resolves_relative_artifacts_under_workdir(tmp_path: Path) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import WorkflowNode
+
+    commands: list[tuple[str, ...]] = []
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner(commands))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "validate_case"
+    )
+    node = WorkflowNode(
+        id="validate_case",
+        provider="femic.validate_case",
+        parameters={
+            "instance_root": ".",
+            "run_config": "config/run_profile.example.yaml",
+        },
+        artifacts={"run_manifest": "runtime/logs/a.json"},
+    )
+
+    result = provider.run_node(
+        node,
+        node_type,
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.artifacts == {
+        "run_manifest": str(tmp_path / "runtime" / "logs" / "a.json")
+    }
+    assert commands == [
+        (
+            sys.executable,
+            "-m",
+            "femic",
+            "prep",
+            "validate-case",
+            "--instance-root",
+            ".",
+            "--run-config",
+            "config/run_profile.example.yaml",
+        )
+    ]
+
+
+def test_provider_run_resolves_relative_artifacts_under_namespace(
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import WorkflowNode
+
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner([]))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "validate_case"
+    )
+    node = WorkflowNode(
+        id="validate_case",
+        provider="femic.validate_case",
+        parameters={
+            "instance_root": ".",
+            "run_config": "config/run_profile.example.yaml",
+        },
+        artifacts={"run_manifest": "runtime/logs/a.json"},
+    )
+
+    result = provider.run_node(
+        node,
+        node_type,
+        context=RunContext(workflow_id="wf", workdir=tmp_path, run_namespace="smoke"),
+    )
+
+    assert result.artifacts == {
+        "run_manifest": str(tmp_path / "smoke" / "runtime" / "logs" / "a.json")
+    }
+
+
+def test_provider_run_preserves_absolute_artifact_paths(tmp_path: Path) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import WorkflowNode
+
+    absolute_artifact = tmp_path / "absolute" / "a.json"
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner([]))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "validate_case"
+    )
+    node = WorkflowNode(
+        id="validate_case",
+        provider="femic.validate_case",
+        parameters={
+            "instance_root": ".",
+            "run_config": "config/run_profile.example.yaml",
+        },
+        artifacts={"run_manifest": absolute_artifact},
+    )
+
+    result = provider.run_node(
+        node,
+        node_type,
+        context=RunContext(workflow_id="wf", workdir=tmp_path, run_namespace="smoke"),
+    )
+
+    assert result.artifacts == {"run_manifest": str(absolute_artifact)}
+
+
+def test_provider_run_preserves_json_safe_non_string_artifact_metadata(
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import WorkflowNode
+
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner([]))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "validate_case"
+    )
+    node = WorkflowNode(
+        id="validate_case",
+        provider="femic.validate_case",
+        parameters={
+            "instance_root": ".",
+            "run_config": "config/run_profile.example.yaml",
+        },
+        artifacts={
+            "run_manifest": "runtime/logs/a.json",
+            "count": 3,
+            "metadata": {"kind": "declared"},
+        },
+    )
+
+    result = provider.run_node(
+        node,
+        node_type,
+        context=RunContext(workflow_id="wf", workdir=tmp_path, run_namespace="smoke"),
+    )
+
+    assert result.artifacts["run_manifest"] == str(
+        tmp_path / "smoke" / "runtime" / "logs" / "a.json"
+    )
+    assert result.artifacts["count"] == 3
+    assert result.artifacts["metadata"] == {"kind": "declared"}
+    json.dumps(result.to_dict())
 
 
 def test_legacy_execute_node_shim_delegates_to_run_node() -> None:


### PR DESCRIPTION
﻿## Summary
- add report-only namespace-aware artifact resolution to the generic FEMIC FreshForge provider
- resolve workflow-declared artifact paths through FreshForge `RunContext.resolve_path(...)` and return strings in `ProviderRunResult.artifacts`
- preserve command construction, command output locations, and non-mutating validate/inspect/plan behavior
- document the `--workdir runtime/freshforge --namespace smoke` smoke pattern and the current report-only boundary

Closes #268.

## Validation
- `python -m pip install -e .[dev]`
- `python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"`
- `ruff format src tests`
- `ruff check src tests`
- `mypy src/femic/freshforge.py`
- `pytest tests/test_freshforge_integration.py`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`
- `pre-commit run --all-files`
- FreshForge CLI smoke with a safe one-node geospatial-preflight workflow using `--workdir runtime/freshforge --namespace smoke`

## Notes
- This does not route FEMIC command outputs into the FreshForge namespace.
- The unrelated `external/femic-public-data` submodule state is intentionally untouched.
