### PR TITLE
P98: Plan FreshForge materialization template and link TFL6 workflow

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19319,9 +19319,9 @@
 
 ## 2026-07-01 - Linked TFL6 Phase 17 FreshForge workflow scaffold
 
-- Advanced `external/femic-tfl6-instance` to commit `bf9d110`, which adds the
-  TFL6-owned FreshForge model-build workflow, Phase 17 planning note, docs, and
-  runbook guidance.
+- Advanced `external/femic-tfl6-instance` to merged TFL6 main commit
+  `3bbb307`, which adds the TFL6-owned FreshForge model-build workflow, Phase
+  17 planning note, docs, and runbook guidance.
 - Recorded that FreshForge `v0.1.0a4` supports validation, inspection, and
   planning for the TFL6 graph, but does not expose `freshforge run --dry-run`;
   full execution acceptance remains later scope.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19316,3 +19316,12 @@
   concrete instance values stay outside FEMIC core.
 - Added P98 roadmap tasks while keeping implementation separate from the first
   TFL6 FreshForge model-build workflow.
+
+## 2026-07-01 - Linked TFL6 Phase 17 FreshForge workflow scaffold
+
+- Advanced `external/femic-tfl6-instance` to commit `bf9d110`, which adds the
+  TFL6-owned FreshForge model-build workflow, Phase 17 planning note, docs, and
+  runbook guidance.
+- Recorded that FreshForge `v0.1.0a4` supports validation, inspection, and
+  planning for the TFL6 graph, but does not expose `freshforge run --dry-run`;
+  full execution acceptance remains later scope.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19305,3 +19305,14 @@
 - GitHub `package-release-checks` and docs `build` checks passed on the PR.
 - The PR is clean against `main`; P97 closeout is ready to merge after the
   final issue comment.
+
+## 2026-07-01 - Planned P98 FreshForge model-instance materialization template
+
+- Opened parent issue `#270` for a reusable FreshForge workflow template that
+  turns the Git submodule, virtualenv, DataLad, git-annex, `arbutus-s3`, and
+  targeted materialization ritual into an inspectable workflow.
+- Added `planning/phase98_freshforge_materialization_template.md` to capture
+  the generic node families, overlay configuration shape, and boundary that
+  concrete instance values stay outside FEMIC core.
+- Added P98 roadmap tasks while keeping implementation separate from the first
+  TFL6 FreshForge model-build workflow.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2946,9 +2946,41 @@ FreshForge run context without changing FEMIC command outputs.
   - [x] Post progress and closeout comments on issue `#268`.
   - [x] Open and merge the P97 PR after checks pass.
 
+## Phase 98: FreshForge Template Workflow For Model-Instance Materialization (`#270`)
+
+Status: planned
+
+Goal: design a reusable FreshForge workflow family for deterministic
+model-instance materialization so MKRF, TFL6, TSA29, and future instances do
+not require users to manually execute a long Git/DataLad/git-annex setup ritual
+from prose documentation.
+
+- [ ] P98.1 Capture materialization workflow requirements.
+  - [ ] Record the shared failure pattern from recent user deployment tests.
+  - [ ] Define the generic workflow node families: toolchain check, submodule
+        setup, virtual-environment validation, package install check, DataLad
+        and git-annex checks, `arbutus-s3` enablement, required payload
+        materialization, annex audit, and report generation.
+  - [ ] Keep the first planning note at
+        `planning/phase98_freshforge_materialization_template.md`.
+- [ ] P98.2 Define the instance overlay contract.
+  - [ ] Support instance path, special remote name, required materialization
+        paths, optional public-data mirror paths, install extras or instance
+        packages, and report output path.
+  - [ ] Keep instance-specific values outside FEMIC core.
+- [ ] P98.3 Plan the execution surface.
+  - [ ] Decide whether this belongs in a generic FreshForge provider, FEMIC
+        provider extension, or a dedicated materialization provider package.
+  - [ ] Keep a tiny bootstrap helper as future scope only, because FreshForge
+        must exist before it can run the workflow.
+- [ ] P98.4 Implement and test the reusable template in a later phase.
+  - [ ] Do not implement materialization execution as part of the TFL6 Phase 17
+        model-build workflow scaffold.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
+  - `planning/phase98_freshforge_materialization_template.md`
   - `planning/phase87_parent_instance_reference_audit.md`
   - `planning/phase78_figrecover_integration_notes.md`
   - `planning/phase75_bcdata_resolver_evaluation_notes.md`
@@ -2958,6 +2990,13 @@ FreshForge run context without changing FEMIC command outputs.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P98` / `#270` is planned: FEMIC needs a reusable FreshForge
+    model-instance materialization workflow template because recent MKRF, TFL6,
+    and TSA29 user deployment tests showed that manual submodule, virtualenv,
+    DataLad, git-annex, `arbutus-s3`, and `datalad get` setup fails too often
+    for new users. The first tracked planning note is
+    `planning/phase98_freshforge_materialization_template.md`; implementation
+    is deferred until after the TFL6 Phase 17 FreshForge model-build scaffold.
   - `P97` / `#268` is complete: report-only namespace-aware FreshForge
     artifact metadata resolves workflow-declared artifact paths through
     FreshForge `RunContext.resolve_path(...)` for provider run records. FEMIC

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2955,19 +2955,19 @@ model-instance materialization so MKRF, TFL6, TSA29, and future instances do
 not require users to manually execute a long Git/DataLad/git-annex setup ritual
 from prose documentation.
 
-- [ ] P98.1 Capture materialization workflow requirements.
-  - [ ] Record the shared failure pattern from recent user deployment tests.
-  - [ ] Define the generic workflow node families: toolchain check, submodule
+- [x] P98.1 Capture materialization workflow requirements.
+  - [x] Record the shared failure pattern from recent user deployment tests.
+  - [x] Define the generic workflow node families: toolchain check, submodule
         setup, virtual-environment validation, package install check, DataLad
         and git-annex checks, `arbutus-s3` enablement, required payload
         materialization, annex audit, and report generation.
-  - [ ] Keep the first planning note at
+  - [x] Keep the first planning note at
         `planning/phase98_freshforge_materialization_template.md`.
-- [ ] P98.2 Define the instance overlay contract.
-  - [ ] Support instance path, special remote name, required materialization
+- [x] P98.2 Define the instance overlay contract.
+  - [x] Support instance path, special remote name, required materialization
         paths, optional public-data mirror paths, install extras or instance
         packages, and report output path.
-  - [ ] Keep instance-specific values outside FEMIC core.
+  - [x] Keep instance-specific values outside FEMIC core.
 - [ ] P98.3 Plan the execution surface.
   - [ ] Decide whether this belongs in a generic FreshForge provider, FEMIC
         provider extension, or a dedicated materialization provider package.
@@ -2997,6 +2997,9 @@ from prose documentation.
     for new users. The first tracked planning note is
     `planning/phase98_freshforge_materialization_template.md`; implementation
     is deferred until after the TFL6 Phase 17 FreshForge model-build scaffold.
+    TFL6 branch `feature/p17-freshforge-model-build-workflow` now contains the
+    first instance-owned FreshForge model-build workflow and the parent
+    submodule pointer is advanced to `bf9d110`.
   - `P97` / `#268` is complete: report-only namespace-aware FreshForge
     artifact metadata resolves workflow-declared artifact paths through
     FreshForge `RunContext.resolve_path(...)` for provider run records. FEMIC

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2999,7 +2999,7 @@ from prose documentation.
     is deferred until after the TFL6 Phase 17 FreshForge model-build scaffold.
     TFL6 branch `feature/p17-freshforge-model-build-workflow` now contains the
     first instance-owned FreshForge model-build workflow and the parent
-    submodule pointer is advanced to `bf9d110`.
+    submodule pointer is advanced to merged TFL6 main commit `3bbb307`.
   - `P97` / `#268` is complete: report-only namespace-aware FreshForge
     artifact metadata resolves workflow-declared artifact paths through
     FreshForge `RunContext.resolve_path(...)` for provider run records. FEMIC

--- a/planning/phase98_freshforge_materialization_template.md
+++ b/planning/phase98_freshforge_materialization_template.md
@@ -1,0 +1,50 @@
+# P98 FreshForge Model-Instance Materialization Template
+
+## Purpose
+
+Recent MKRF, TFL6, and TSA29 deployment tests showed that the manual
+model-instance bootstrap ritual is too fragile for new users. The documented
+sequence is deterministic, but it crosses too many tools: Git submodules,
+repo-root virtual environments, FEMIC installation, FreshForge installation,
+DataLad, git-annex, special remote enablement, and targeted payload
+materialization.
+
+P98 records the parent FEMIC plan for a reusable FreshForge workflow template
+that can be specialized by small instance-owned overlay configuration. The
+goal is to make the ritual executable and inspectable instead of asking users
+to manually reproduce it from prose.
+
+## Planned Workflow Family
+
+The first generic materialization workflow should cover these node families:
+
+1. toolchain check for Git, Python, FEMIC, FreshForge, DataLad, and git-annex;
+2. submodule initialization/update for the requested model instance;
+3. repo-root virtual-environment creation or validation;
+4. package install check for FEMIC and any instance-owned adapter packages;
+5. git-annex repository initialization and `arbutus-s3` enablement;
+6. targeted `datalad get` or `git annex get` for required model/data paths;
+7. annex availability audit for required payload families; and
+8. user-facing materialization report.
+
+## Overlay Configuration
+
+The reusable template should be driven by a small instance overlay rather than
+hardcoded instance names. Expected overlay fields:
+
+- instance path;
+- special remote name, defaulting to `arbutus-s3`;
+- required materialization paths;
+- optional public-data mirror paths;
+- install extras or instance package paths; and
+- report output path.
+
+## Boundaries
+
+- P98 is a planned parent FEMIC/FreshForge workflow family, not part of the
+  first TFL6 FreshForge model-build workflow.
+- The template should not make MKRF, TFL6, TSA29, or any future example
+  instance a core FEMIC dependency.
+- A tiny bootstrap script may be needed later because FreshForge itself must
+  exist before it can run the workflow. The deterministic ritual should still
+  live in the FreshForge workflow, not in a bespoke per-instance script.


### PR DESCRIPTION
## Summary
- add P98 roadmap and planning note for a reusable FreshForge model-instance materialization workflow template
- record the shared submodule/venv/DataLad/git-annex/arbutus-s3 materialization failure pattern from user deployment tests
- update the TFL6 submodule pointer to the Phase 17 FreshForge workflow scaffold branch commit

## Validation
- `pytest tests/test_freshforge_integration.py`
- `sphinx-build -b html docs _build/html -W`
- inspected `pyproject.toml` FreshForge provider entry points and confirmed only `femic = femic.freshforge:provider_factory`

## Notes
This PR depends on UBC-FRESH/femic-tfl6-instance#159 landing first, or an equivalent TFL6 main commit containing `bf9d110`.

Closes #270.
