### PR TITLE
P98.4: Add FreshForge materialization provider

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19339,3 +19339,23 @@
   keeping runtime implementation deferred to P98.4.
 - Narrowed the incoming DataLad wrapper idea so the larger lifecycle/provenance
   concept no longer duplicates the P98 bootstrap/materialization workflow.
+
+## 2026-07-01 - Implemented P98.4 FreshForge materialization provider template
+
+- Added the optional FreshForge provider entry point
+  `femic.materialization = femic.freshforge_materialization:provider_factory`.
+- Added `femic.freshforge_materialization` with generic, config-driven
+  materialization nodes for toolchain checks, Python environment setup, package
+  installation, submodule setup, git-annex initialization, special-remote
+  enablement, path materialization, annex availability audit, and deterministic
+  report writing.
+- Added public-safe fixture overlay and workflow examples under
+  `examples/freshforge/`; the smoke workflow writes only a materialization
+  report and does not run DataLad, git-annex, package installation, or
+  submodule mutation commands.
+- Updated FreshForge docs/API references and tests so provider discovery,
+  overlay parsing, validation, mocked execution, namespace-resolved report
+  artifacts, and CLI validate/inspect/plan/run behavior are covered.
+- Verified that `freshforge` is not yet resolvable from PyPI as `freshforge` in
+  this environment, so FEMIC's FreshForge install guidance remains on the
+  released GitHub tag until the PyPI package name or propagation is confirmed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2948,7 +2948,7 @@ FreshForge run context without changing FEMIC command outputs.
 
 ## Phase 98: FreshForge Template Workflow For Model-Instance Materialization (`#270`)
 
-Status: planned
+Status: implemented locally; PR closeout pending
 
 Goal: design a reusable FreshForge workflow family for deterministic
 model-instance materialization so MKRF, TFL6, TSA29, and future instances do
@@ -2987,14 +2987,16 @@ from prose documentation.
         must exist before it can run the workflow.
   - [x] Record the P98.4 implementation handoff in
         `planning/phase98_materialization_execution_surface.md`.
-- [ ] P98.4 Implement and test the reusable template in a later phase.
-  - [ ] Do not implement materialization execution as part of the TFL6 Phase 17
+- [x] P98.4 Implement and test the reusable template.
+  - [x] Do not implement materialization execution as part of the TFL6 Phase 17
         model-build workflow scaffold.
-  - [ ] Add the FEMIC-owned materialization FreshForge provider namespace and
+  - [x] Add the FEMIC-owned materialization FreshForge provider namespace and
         entry point.
-  - [ ] Add overlay parsing, validation, mocked execution tests, and a fixture
+  - [x] Add overlay parsing, validation, mocked execution tests, and a fixture
         FreshForge workflow.
-  - [ ] Prove the first real instance overlay in a later TFL6 phase.
+  - [x] Prove the public-safe fixture workflow with FreshForge validate,
+        inspect, plan, and run.
+  - [x] Keep the first real instance overlay as a later TFL6 phase.
 
 ### Detailed Next Steps Notes
 
@@ -3010,15 +3012,12 @@ from prose documentation.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P98` / `#270` is active: P98.1-P98.3 are complete and P98.4 remains the
-    implementation edge. The materialization execution surface is locked as a
-    FEMIC-owned, optional FreshForge provider namespace that stays generic and
-    config-driven. Instance repos will supply small overlay YAML files with
-    instance paths, install requirements, special remote names, required
-    materialization paths, audit paths, and report paths. The next bounded move
-    is P98.4: implement the provider, overlay parser, mocked execution tests,
-    and a fixture workflow before proving a real instance overlay in a later
-    TFL6 phase.
+  - `P98` / `#270` is implemented locally and awaiting PR closeout. The
+    reusable `femic.materialization` FreshForge provider now supplies generic
+    materialization nodes, overlay parsing/validation, mocked execution tests,
+    and a public-safe report-only fixture workflow. Real MKRF, TFL6, K3Z, and
+    TSA29 overlays remain follow-on instance phases. The next planning edge is
+    to start with a TFL6-owned materialization overlay once P98 merges.
   - `P97` / `#268` is complete: report-only namespace-aware FreshForge
     artifact metadata resolves workflow-declared artifact paths through
     FreshForge `RunContext.resolve_path(...)` for provider run records. FEMIC

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -37,7 +37,7 @@ Provider Discovery
 
 FEMIC registers provider entry points in the ``freshforge.providers`` group.
 When FreshForge is installed alongside FEMIC, FreshForge can discover provider
-ID ``femic``:
+IDs ``femic`` and ``femic.materialization``:
 
 .. code-block:: bash
 
@@ -57,6 +57,31 @@ Instance-specific provider references are not shipped by FEMIC core. For
 example, the MKRF instance owns its executable adapter package and exposes
 provider references such as ``mkrf.build_au_inputs`` only when that instance
 adapter is installed.
+
+Materialization Provider
+------------------------
+
+The ``femic.materialization`` provider is the generic FreshForge surface for
+model-instance bootstrap and DataLad/git-annex materialization workflows. It is
+config-driven: model instances supply small overlay YAML files, while FEMIC
+owns reusable node implementations for toolchain checks, Python environment
+setup, package installation, submodule setup, git-annex initialization,
+special-remote enablement, required path materialization, annex availability
+audits, and report generation.
+
+The public-safe smoke workflow writes only a report and does not run
+``datalad get``, package installs, submodule updates, or git-annex commands:
+
+.. code-block:: bash
+
+   freshforge validate examples/freshforge/materialization_smoke_workflow.yaml
+   freshforge inspect examples/freshforge/materialization_smoke_workflow.yaml
+   freshforge plan examples/freshforge/materialization_smoke_workflow.yaml
+   freshforge run examples/freshforge/materialization_smoke_workflow.yaml --workdir runtime/freshforge --namespace smoke --json
+
+Real MKRF, TFL6, K3Z, and TSA29 materialization overlays are later instance
+phases. They should use the same provider and overlay contract rather than
+adding instance names to FEMIC core.
 
 Generic Workflow Example
 ------------------------

--- a/docs/reference/api/femic-freshforge-materialization.rst
+++ b/docs/reference/api/femic-freshforge-materialization.rst
@@ -1,0 +1,19 @@
+``femic.freshforge_materialization`` Module
+===========================================
+
+The :mod:`femic.freshforge_materialization` module owns FEMIC's optional
+FreshForge provider for generic model-instance materialization workflows.
+
+It is separate from :mod:`femic.freshforge`, which owns model-build stages.
+The materialization provider is config-driven and must not hardcode named
+example instances. Instance repositories supply overlay YAML files that
+describe instance paths, install requirements, special remotes, materialization
+paths, audit paths, and report paths.
+
+API
+---
+
+.. automodule:: femic.freshforge_materialization
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/api/modules.rst
+++ b/docs/reference/api/modules.rst
@@ -48,6 +48,7 @@ Current curated pages in this section include ``femic.instance_context``,
 ``femic.bcdc_dwds``,
 ``femic.document_figures``,
 ``femic.freshforge``,
+``femic.freshforge_materialization``,
 ``femic.tsr_catalog``,
 ``femic.geospatial_preflight``,
 ``femic.pipeline.bundle``, ``femic.pipeline.legacy_runtime``, and
@@ -63,6 +64,7 @@ Current curated pages in this section include ``femic.instance_context``,
    femic-bcdc-dwds
    femic-document-figures
    femic-freshforge
+   femic-freshforge-materialization
    femic-tsr-catalog
    femic-geospatial-preflight
    femic-pipeline-bundle

--- a/examples/freshforge/materialization_overlay.yaml
+++ b/examples/freshforge/materialization_overlay.yaml
@@ -1,0 +1,25 @@
+instance:
+  root: examples/freshforge/fixture-instance
+  submodule_path: external/femic-example-instance
+environment:
+  venv_path: .venv
+install:
+  requirements: []
+  editable_paths: []
+  extras:
+    - dev
+    - freshforge
+  packages:
+    - freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4
+annex:
+  special_remote: arbutus-s3
+materialization:
+  required_paths:
+    - data
+    - models
+audit:
+  required_paths:
+    - data
+    - models
+report:
+  path: runtime/freshforge/materialization_report.json

--- a/examples/freshforge/materialization_smoke_workflow.yaml
+++ b/examples/freshforge/materialization_smoke_workflow.yaml
@@ -1,0 +1,13 @@
+workflow:
+  id: femic_materialization_smoke
+  name: FEMIC materialization provider smoke workflow
+  description: Public-safe FreshForge run that writes only a materialization report.
+nodes:
+  - id: write_materialization_report
+    provider: femic.materialization.write_materialization_report
+    outputs:
+      materialization_report: materialization_report
+    parameters:
+      overlay: examples/freshforge/materialization_overlay.yaml
+    artifacts:
+      report: runtime/freshforge/materialization_report.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ femic = "femic.cli.main:app"
 
 [project.entry-points."freshforge.providers"]
 femic = "femic.freshforge:provider_factory"
+"femic.materialization" = "femic.freshforge_materialization:provider_factory"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/femic/freshforge_materialization.py
+++ b/src/femic/freshforge_materialization.py
@@ -1,0 +1,797 @@
+"""FreshForge provider for FEMIC model-instance materialization workflows."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from femic import __version__
+
+MATERIALIZATION_PROVIDER_ID = "femic.materialization"
+MATERIALIZATION_PROVIDER_VERSION = __version__
+
+CommandRunner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class _NodeContract:
+    id: str
+    name: str
+    description: str
+    inputs: tuple[str, ...] = ()
+    outputs: tuple[str, ...] = ()
+    parameters: tuple[str, ...] = ("overlay",)
+    artifacts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MaterializationOverlay:
+    """Generic model-instance materialization overlay."""
+
+    instance_root: Path
+    venv_path: Path
+    special_remote: str
+    materialization_paths: tuple[Path, ...]
+    audit_paths: tuple[Path, ...]
+    report_path: Path
+    submodule_path: Path | None = None
+    install_requirements: tuple[Path, ...] = ()
+    install_editable_paths: tuple[Path, ...] = ()
+    install_extras: tuple[str, ...] = ()
+    install_packages: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "instance_root": str(self.instance_root),
+            "venv_path": str(self.venv_path),
+            "special_remote": self.special_remote,
+            "materialization_paths": [str(path) for path in self.materialization_paths],
+            "audit_paths": [str(path) for path in self.audit_paths],
+            "report_path": str(self.report_path),
+            "install_requirements": [str(path) for path in self.install_requirements],
+            "install_editable_paths": [
+                str(path) for path in self.install_editable_paths
+            ],
+            "install_extras": list(self.install_extras),
+            "install_packages": list(self.install_packages),
+        }
+        if self.submodule_path is not None:
+            data["submodule_path"] = str(self.submodule_path)
+        return data
+
+
+_NODE_CONTRACTS: tuple[_NodeContract, ...] = (
+    _NodeContract(
+        id="check_toolchain",
+        name="Check toolchain",
+        description="Check Git, Python, FEMIC, FreshForge, DataLad, and git-annex.",
+        outputs=("toolchain",),
+    ),
+    _NodeContract(
+        id="check_python_environment",
+        name="Check Python environment",
+        description="Create or validate the configured Python virtual environment.",
+        inputs=("toolchain",),
+        outputs=("python_environment",),
+    ),
+    _NodeContract(
+        id="install_packages",
+        name="Install packages",
+        description="Install configured FEMIC/FreshForge and instance packages.",
+        inputs=("python_environment",),
+        outputs=("packages",),
+    ),
+    _NodeContract(
+        id="init_submodules",
+        name="Initialize submodules",
+        description="Initialize or update configured Git submodules.",
+        inputs=("packages",),
+        outputs=("submodules",),
+    ),
+    _NodeContract(
+        id="init_annex",
+        name="Initialize git-annex",
+        description="Initialize git-annex in the configured instance repository.",
+        inputs=("submodules",),
+        outputs=("annex_repository",),
+    ),
+    _NodeContract(
+        id="enable_special_remote",
+        name="Enable special remote",
+        description="Enable the configured git-annex special remote.",
+        inputs=("annex_repository",),
+        outputs=("special_remote",),
+    ),
+    _NodeContract(
+        id="materialize_paths",
+        name="Materialize required paths",
+        description="Materialize configured DataLad/git-annex payload paths.",
+        inputs=("special_remote",),
+        outputs=("materialized_paths",),
+    ),
+    _NodeContract(
+        id="audit_annex_availability",
+        name="Audit annex availability",
+        description="Audit configured payload families against the special remote.",
+        inputs=("materialized_paths",),
+        outputs=("annex_audit",),
+    ),
+    _NodeContract(
+        id="write_materialization_report",
+        name="Write materialization report",
+        description="Write a deterministic user-facing materialization report.",
+        outputs=("materialization_report",),
+        artifacts=("report",),
+    ),
+)
+
+
+class FemicMaterializationProvider:
+    """FreshForge provider for generic FEMIC model-instance materialization."""
+
+    def __init__(self, command_runner: CommandRunner | None = None) -> None:
+        self._command_runner = command_runner or _default_command_runner
+
+    def metadata(self) -> Any:
+        """Return FreshForge provider metadata."""
+        node_type_metadata, provider_metadata = _freshforge_metadata_types()
+        return provider_metadata(
+            id=MATERIALIZATION_PROVIDER_ID,
+            version=MATERIALIZATION_PROVIDER_VERSION,
+            name="FEMIC materialization provider",
+            description=(
+                "Provider for generic FEMIC model-instance bootstrap and "
+                "DataLad/git-annex materialization workflows."
+            ),
+            node_types=tuple(
+                node_type_metadata(
+                    id=contract.id,
+                    name=contract.name,
+                    description=contract.description,
+                    inputs=contract.inputs,
+                    outputs=contract.outputs,
+                    parameters=contract.parameters,
+                    artifacts=contract.artifacts,
+                )
+                for contract in _NODE_CONTRACTS
+            ),
+        )
+
+    def validate_node(
+        self, node: Any, node_type: Any, *, location: str
+    ) -> tuple[Any, ...]:
+        """Validate broad materialization node shape without executing commands."""
+        diagnostic, severity = _freshforge_diagnostic_types()
+        diagnostics: list[Any] = []
+        diagnostics.extend(
+            _missing_key_diagnostics(
+                diagnostic=diagnostic,
+                severity=severity,
+                required=tuple(node_type.inputs),
+                actual=node.inputs,
+                field_name="inputs",
+                location=location,
+            )
+        )
+        diagnostics.extend(
+            _missing_key_diagnostics(
+                diagnostic=diagnostic,
+                severity=severity,
+                required=tuple(node_type.outputs),
+                actual=node.outputs,
+                field_name="outputs",
+                location=location,
+            )
+        )
+        diagnostics.extend(
+            _missing_key_diagnostics(
+                diagnostic=diagnostic,
+                severity=severity,
+                required=tuple(node_type.parameters),
+                actual=node.parameters,
+                field_name="parameters",
+                location=location,
+            )
+        )
+        artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+        diagnostics.extend(
+            _missing_key_diagnostics(
+                diagnostic=diagnostic,
+                severity=severity,
+                required=tuple(node_type.artifacts),
+                actual=artifacts,
+                field_name="artifacts",
+                location=location,
+            )
+        )
+        overlay_path = _optional_parameter(node, "overlay")
+        if overlay_path:
+            overlay, overlay_errors = load_materialization_overlay(Path(overlay_path))
+            diagnostics.extend(
+                _overlay_diagnostics(
+                    diagnostic=diagnostic,
+                    severity=severity,
+                    errors=overlay_errors,
+                    location=f"{location}.parameters.overlay",
+                )
+            )
+            if overlay is not None and node_type.id == "write_materialization_report":
+                if not str(overlay.report_path).strip():
+                    diagnostics.append(
+                        diagnostic(
+                            severity=severity.ERROR,
+                            code="femic.materialization.overlay.report_missing",
+                            message="Materialization overlay requires report.path.",
+                            location=f"{location}.parameters.overlay",
+                        )
+                    )
+        return tuple(diagnostics)
+
+    def run_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
+        """Run one materialization node through the released FreshForge API."""
+        result_type, run_status = _freshforge_run_result_types()
+        diagnostic, severity = _freshforge_diagnostic_types()
+        overlay, overlay_errors = load_materialization_overlay(
+            Path(_parameter(node, "overlay"))
+        )
+        if overlay is None:
+            return result_type(
+                status=run_status.FAILED,
+                diagnostics=tuple(
+                    diagnostic(
+                        severity=severity.ERROR,
+                        code="femic.materialization.overlay.invalid",
+                        message=error,
+                        location=f"nodes.{node.id}.parameters.overlay",
+                    )
+                    for error in overlay_errors
+                ),
+            )
+        if str(node_type.id) == "write_materialization_report":
+            return _write_report_result(
+                node=node,
+                context=context,
+                overlay=overlay,
+                result_type=result_type,
+                run_status=run_status,
+            )
+
+        commands = _commands_for_node(str(node_type.id), overlay)
+        if commands is None:
+            return result_type(
+                status=run_status.FAILED,
+                diagnostics=(
+                    diagnostic(
+                        severity=severity.ERROR,
+                        code="femic.materialization.execution.unsupported",
+                        message=(
+                            "FEMIC materialization provider has no execution hook "
+                            f"for node type '{node_type.id}'."
+                        ),
+                        location=f"nodes.{node.id}",
+                    ),
+                ),
+            )
+        completed = [self._command_runner(command) for command in commands]
+        diagnostics = _command_diagnostics(
+            completed=completed,
+            diagnostic=diagnostic,
+            severity=severity,
+            node_id=node.id,
+            node_type=str(node_type.id),
+        )
+        status = run_status.FAILED if diagnostics else run_status.SUCCESS
+        return result_type(
+            status=status,
+            outputs=node.outputs if isinstance(node.outputs, dict) else {},
+            artifacts=_resolved_artifacts(node, context),
+            diagnostics=tuple(diagnostics),
+            data={
+                "commands": [list(command) for command in commands],
+                "returncodes": [item.returncode for item in completed],
+                "stdout": [item.stdout for item in completed if item.stdout],
+                "stderr": [item.stderr for item in completed if item.stderr],
+            },
+        )
+
+
+def provider_factory() -> FemicMaterializationProvider:
+    """Return the FEMIC materialization provider for entry-point discovery."""
+    return FemicMaterializationProvider()
+
+
+def load_materialization_overlay(
+    path: Path,
+) -> tuple[MaterializationOverlay | None, tuple[str, ...]]:
+    """Load and validate a materialization overlay YAML document."""
+    if not path.exists():
+        return None, (f"Materialization overlay does not exist: {path}",)
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return None, (f"Could not read materialization overlay '{path}': {exc}",)
+    if not isinstance(payload, Mapping):
+        return None, ("Materialization overlay must be a mapping.",)
+
+    errors: list[str] = []
+    instance = _mapping(payload.get("instance"), "instance", errors)
+    environment = _mapping(payload.get("environment"), "environment", errors)
+    install = _mapping(payload.get("install"), "install", errors)
+    annex = _mapping(payload.get("annex"), "annex", errors)
+    materialization = _mapping(
+        payload.get("materialization"), "materialization", errors
+    )
+    audit = _mapping(payload.get("audit"), "audit", errors)
+    report = _mapping(payload.get("report"), "report", errors)
+    if errors:
+        return None, tuple(errors)
+
+    instance_root = _required_path(instance, "root", "instance.root", errors)
+    venv_path = _required_path(
+        environment, "venv_path", "environment.venv_path", errors
+    )
+    special_remote = _required_str(
+        annex, "special_remote", "annex.special_remote", errors
+    )
+    report_path = _required_path(report, "path", "report.path", errors)
+    materialization_paths = _path_list(
+        materialization, "required_paths", "materialization.required_paths", errors
+    )
+    audit_paths = _path_list(audit, "required_paths", "audit.required_paths", errors)
+    if errors:
+        return None, tuple(errors)
+
+    install_requirements = _path_list(
+        install, "requirements", "install.requirements", errors
+    )
+    install_editable_paths = _path_list(
+        install, "editable_paths", "install.editable_paths", errors
+    )
+    install_extras = _str_list(install, "extras", "install.extras", errors)
+    install_packages = _str_list(install, "packages", "install.packages", errors)
+    if errors:
+        return None, tuple(errors)
+
+    return (
+        MaterializationOverlay(
+            instance_root=instance_root,
+            submodule_path=_optional_path(instance.get("submodule_path")),
+            venv_path=venv_path,
+            special_remote=special_remote,
+            materialization_paths=tuple(materialization_paths),
+            audit_paths=tuple(audit_paths),
+            report_path=report_path,
+            install_requirements=tuple(install_requirements),
+            install_editable_paths=tuple(install_editable_paths),
+            install_extras=tuple(install_extras),
+            install_packages=tuple(install_packages),
+        ),
+        (),
+    )
+
+
+def _commands_for_node(
+    node_type_id: str,
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...] | None:
+    builders: dict[
+        str, Callable[[MaterializationOverlay], tuple[tuple[str, ...], ...]]
+    ] = {
+        "check_toolchain": _check_toolchain_commands,
+        "check_python_environment": _python_environment_commands,
+        "install_packages": _install_package_commands,
+        "init_submodules": _init_submodule_commands,
+        "init_annex": _init_annex_commands,
+        "enable_special_remote": _enable_remote_commands,
+        "materialize_paths": _materialize_path_commands,
+        "audit_annex_availability": _audit_annex_commands,
+    }
+    builder = builders.get(node_type_id)
+    return None if builder is None else builder(overlay)
+
+
+def _check_toolchain_commands(
+    _overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    return (
+        ("git", "--version"),
+        (sys.executable, "--version"),
+        (sys.executable, "-m", "femic", "--help"),
+        (sys.executable, "-m", "freshforge", "--version"),
+        ("datalad", "--version"),
+        ("git", "annex", "version"),
+    )
+
+
+def _python_environment_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    return ((sys.executable, "-m", "venv", str(overlay.venv_path)),)
+
+
+def _install_package_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    python = _venv_python(overlay.venv_path)
+    commands: list[tuple[str, ...]] = []
+    if overlay.install_extras:
+        commands.append(
+            (
+                python,
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                f".[{','.join(overlay.install_extras)}]",
+            )
+        )
+    for requirement in overlay.install_requirements:
+        commands.append((python, "-m", "pip", "install", "-r", str(requirement)))
+    for editable_path in overlay.install_editable_paths:
+        commands.append((python, "-m", "pip", "install", "-e", str(editable_path)))
+    for package in overlay.install_packages:
+        commands.append((python, "-m", "pip", "install", package))
+    return tuple(commands)
+
+
+def _init_submodule_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    command = ["git", "submodule", "update", "--init", "--recursive"]
+    if overlay.submodule_path is not None:
+        command.append(str(overlay.submodule_path))
+    return (tuple(command),)
+
+
+def _init_annex_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    return (("git", "-C", str(overlay.instance_root), "annex", "init"),)
+
+
+def _enable_remote_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    return (
+        (
+            "git",
+            "-C",
+            str(overlay.instance_root),
+            "annex",
+            "enableremote",
+            overlay.special_remote,
+        ),
+    )
+
+
+def _materialize_path_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    return tuple(
+        ("datalad", "get", "-r", str(_instance_path(overlay, path)))
+        for path in overlay.materialization_paths
+    )
+
+
+def _audit_annex_commands(
+    overlay: MaterializationOverlay,
+) -> tuple[tuple[str, ...], ...]:
+    return tuple(
+        (
+            "git",
+            "-C",
+            str(overlay.instance_root),
+            "annex",
+            "find",
+            "--not",
+            "--in",
+            overlay.special_remote,
+            "--",
+            str(path),
+        )
+        for path in overlay.audit_paths
+    )
+
+
+def _write_report_result(
+    *,
+    node: Any,
+    context: Any,
+    overlay: MaterializationOverlay,
+    result_type: Any,
+    run_status: Any,
+) -> Any:
+    report_path = _resolve_run_path(context, overlay.report_path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "workflow_id": getattr(context, "workflow_id", None),
+        "provider_id": MATERIALIZATION_PROVIDER_ID,
+        "node_id": node.id,
+        "overlay": overlay.to_dict(),
+        "completed_outputs": getattr(context, "completed_outputs", {}),
+        "completed_artifacts": getattr(context, "completed_artifacts", {}),
+    }
+    report_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    artifacts = _resolved_artifacts(node, context)
+    artifacts.setdefault("report", str(report_path))
+    return result_type(
+        status=run_status.SUCCESS,
+        outputs=node.outputs if isinstance(node.outputs, dict) else {},
+        artifacts=artifacts,
+        data={"report_path": str(report_path)},
+    )
+
+
+def _command_diagnostics(
+    *,
+    completed: Sequence[subprocess.CompletedProcess[str]],
+    diagnostic: Any,
+    severity: Any,
+    node_id: str,
+    node_type: str,
+) -> list[Any]:
+    diagnostics: list[Any] = []
+    for index, item in enumerate(completed, start=1):
+        if item.returncode != 0:
+            diagnostics.append(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="femic.materialization.command.failed",
+                    message=(
+                        f"Materialization command {index} for node '{node_id}' "
+                        f"exited with return code {item.returncode}."
+                    ),
+                    location=f"nodes.{node_id}",
+                )
+            )
+        if node_type == "audit_annex_availability" and item.stdout.strip():
+            diagnostics.append(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="femic.materialization.audit.missing_remote_content",
+                    message=(
+                        "Annex audit found paths that are not present in the "
+                        "configured special remote."
+                    ),
+                    location=f"nodes.{node_id}",
+                )
+            )
+    return diagnostics
+
+
+def _mapping(value: object, field_name: str, errors: list[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        errors.append(f"Materialization overlay requires mapping field '{field_name}'.")
+        return {}
+    return value
+
+
+def _required_path(
+    payload: Mapping[str, object],
+    key: str,
+    label: str,
+    errors: list[str],
+) -> Path:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"Materialization overlay requires nonempty '{label}'.")
+        return Path("")
+    return Path(value)
+
+
+def _required_str(
+    payload: Mapping[str, object],
+    key: str,
+    label: str,
+    errors: list[str],
+) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"Materialization overlay requires nonempty '{label}'.")
+        return ""
+    return value
+
+
+def _optional_path(value: object) -> Path | None:
+    if isinstance(value, str) and value.strip():
+        return Path(value)
+    return None
+
+
+def _path_list(
+    payload: Mapping[str, object],
+    key: str,
+    label: str,
+    errors: list[str],
+) -> list[Path]:
+    values = payload.get(key)
+    if not isinstance(values, list):
+        errors.append(f"Materialization overlay requires list field '{label}'.")
+        return []
+    paths: list[Path] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value.strip():
+            errors.append(
+                f"Materialization overlay field '{label}[{index}]' is invalid."
+            )
+        else:
+            paths.append(Path(value))
+    return paths
+
+
+def _str_list(
+    payload: Mapping[str, object],
+    key: str,
+    label: str,
+    errors: list[str],
+) -> list[str]:
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        errors.append(f"Materialization overlay field '{label}' must be a list.")
+        return []
+    strings: list[str] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value.strip():
+            errors.append(
+                f"Materialization overlay field '{label}[{index}]' is invalid."
+            )
+        else:
+            strings.append(value)
+    return strings
+
+
+def _overlay_diagnostics(
+    *,
+    diagnostic: Any,
+    severity: Any,
+    errors: Sequence[str],
+    location: str,
+) -> tuple[Any, ...]:
+    return tuple(
+        diagnostic(
+            severity=severity.ERROR,
+            code="femic.materialization.overlay.invalid",
+            message=error,
+            location=location,
+        )
+        for error in errors
+    )
+
+
+def _missing_key_diagnostics(
+    *,
+    diagnostic: Any,
+    severity: Any,
+    required: Sequence[str],
+    actual: dict[str, object],
+    field_name: str,
+    location: str,
+) -> list[Any]:
+    diagnostics: list[Any] = []
+    for key in required:
+        if key not in actual:
+            diagnostics.append(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code=f"femic.materialization.{field_name}.missing",
+                    message=(
+                        f"FEMIC materialization node requires {field_name} key '{key}'."
+                    ),
+                    location=f"{location}.{field_name}.{key}",
+                )
+            )
+    return diagnostics
+
+
+def _parameter(node: Any, key: str) -> str:
+    value = node.parameters.get(key)
+    if value is None:
+        raise ValueError(f"FEMIC materialization node '{node.id}' requires '{key}'.")
+    if isinstance(value, str):
+        if not value.strip():
+            raise ValueError(
+                f"FEMIC materialization node '{node.id}' parameter '{key}' "
+                "must be nonempty."
+            )
+        return value
+    return str(value)
+
+
+def _optional_parameter(node: Any, key: str) -> str | None:
+    value = node.parameters.get(key)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value if value.strip() else None
+    return str(value)
+
+
+def _venv_python(venv_path: Path) -> str:
+    if sys.platform.startswith("win"):
+        return str(venv_path / "Scripts" / "python.exe")
+    return str(venv_path / "bin" / "python")
+
+
+def _instance_path(overlay: MaterializationOverlay, path: Path) -> Path:
+    return path if path.is_absolute() else overlay.instance_root / path
+
+
+def _resolve_run_path(context: Any, path: Path) -> Path:
+    resolve_path = getattr(context, "resolve_path", None)
+    if callable(resolve_path):
+        return Path(resolve_path(path))
+    return path
+
+
+def _resolved_artifacts(node: Any, context: Any) -> dict[str, Any]:
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    resolved: dict[str, Any] = {}
+    for key, value in artifacts.items():
+        if isinstance(value, (str, Path)):
+            resolved[key] = str(_resolve_run_path(context, Path(value)))
+        else:
+            resolved[key] = value
+    return resolved
+
+
+def _default_command_runner(
+    command: tuple[str, ...],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _freshforge_metadata_types() -> tuple[Any, Any]:
+    try:
+        from freshforge.providers import (  # type: ignore[import-untyped]
+            NodeTypeMetadata,
+            ProviderMetadata,
+        )
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The FEMIC materialization provider requires the optional "
+            "`femic[freshforge]` dependency."
+        ) from exc
+    return NodeTypeMetadata, ProviderMetadata
+
+
+def _freshforge_diagnostic_types() -> tuple[Any, Any]:
+    try:
+        from freshforge.records import (  # type: ignore[import-untyped]
+            Diagnostic,
+            DiagnosticSeverity,
+        )
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The FEMIC materialization provider requires the optional "
+            "`femic[freshforge]` dependency."
+        ) from exc
+    return Diagnostic, DiagnosticSeverity
+
+
+def _freshforge_run_result_types() -> tuple[Any, Any]:
+    try:
+        from freshforge.records import (  # type: ignore[import-untyped]
+            ProviderRunResult,
+            RunStatus,
+        )
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The FEMIC materialization provider requires the optional "
+            "`femic[freshforge]` dependency."
+        ) from exc
+    return ProviderRunResult, RunStatus

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -155,6 +155,10 @@ def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
     assert all("git+" not in item for deps in optional.values() for item in deps)
     entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
     assert entry_points["femic"] == "femic.freshforge:provider_factory"
+    assert (
+        entry_points["femic.materialization"]
+        == "femic.freshforge_materialization:provider_factory"
+    )
     assert "femic_mkrf" not in entry_points
 
 
@@ -252,6 +256,7 @@ def test_default_freshforge_registry_discovers_installed_femic_provider() -> Non
 
     assert not diagnostics
     assert registry.get("femic") is not None
+    assert registry.get("femic.materialization") is not None
     assert registry.get("femic.mkrf") is None
 
 

--- a/tests/test_freshforge_materialization.py
+++ b/tests/test_freshforge_materialization.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import femic
+from femic.freshforge_materialization import (
+    MATERIALIZATION_PROVIDER_ID,
+    FemicMaterializationProvider,
+    load_materialization_overlay,
+    provider_factory,
+)
+
+freshforge = pytest.importorskip("freshforge")
+
+OVERLAY_PATH = Path("examples/freshforge/materialization_overlay.yaml")
+WORKFLOW_PATH = Path("examples/freshforge/materialization_smoke_workflow.yaml")
+COMMAND_NODE_TYPES = (
+    "check_toolchain",
+    "check_python_environment",
+    "install_packages",
+    "init_submodules",
+    "init_annex",
+    "enable_special_remote",
+    "materialize_paths",
+    "audit_annex_availability",
+)
+
+
+def _successful_runner(commands: list[tuple[str, ...]]):
+    def _run(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    return _run
+
+
+def _failing_runner(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=list(command),
+        returncode=7,
+        stdout="",
+        stderr="failed",
+    )
+
+
+def _audit_missing_runner(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=list(command),
+        returncode=0,
+        stdout="models/missing.bin\n",
+        stderr="",
+    )
+
+
+def _workflow_node(node_type_id: str, *, overlay: str | None = None):
+    from freshforge.records import WorkflowNode
+
+    output_key_by_node_type = {
+        "check_toolchain": "toolchain",
+        "check_python_environment": "python_environment",
+        "install_packages": "packages",
+        "init_submodules": "submodules",
+        "init_annex": "annex_repository",
+        "enable_special_remote": "special_remote",
+        "materialize_paths": "materialized_paths",
+        "audit_annex_availability": "annex_audit",
+        "write_materialization_report": "materialization_report",
+    }
+    return WorkflowNode(
+        id=node_type_id,
+        provider=f"femic.materialization.{node_type_id}",
+        outputs={output_key_by_node_type[node_type_id]: "ok"},
+        parameters={"overlay": overlay or str(OVERLAY_PATH)},
+        artifacts=(
+            {"report": "runtime/freshforge/materialization_report.json"}
+            if node_type_id == "write_materialization_report"
+            else {}
+        ),
+    )
+
+
+def _node_type(provider: FemicMaterializationProvider, node_type_id: str):
+    return next(
+        item for item in provider.metadata().node_types if item.id == node_type_id
+    )
+
+
+def test_materialization_provider_metadata_serializes_deterministically() -> None:
+    metadata = provider_factory().metadata()
+
+    payload = metadata.to_dict()
+    assert payload["id"] == MATERIALIZATION_PROVIDER_ID
+    assert payload["version"] == femic.__version__
+    assert [item["id"] for item in payload["node_types"]] == [
+        "check_toolchain",
+        "check_python_environment",
+        "install_packages",
+        "init_submodules",
+        "init_annex",
+        "enable_special_remote",
+        "materialize_paths",
+        "audit_annex_availability",
+        "write_materialization_report",
+    ]
+    assert all(item["parameters"] == ["overlay"] for item in payload["node_types"])
+
+
+def test_pyproject_declares_materialization_provider_entry_point() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
+
+    assert entry_points["femic"] == "femic.freshforge:provider_factory"
+    assert (
+        entry_points["femic.materialization"]
+        == "femic.freshforge_materialization:provider_factory"
+    )
+
+
+def test_overlay_parser_accepts_public_safe_fixture() -> None:
+    overlay, diagnostics = load_materialization_overlay(OVERLAY_PATH)
+
+    assert diagnostics == ()
+    assert overlay is not None
+    assert overlay.instance_root == Path("examples/freshforge/fixture-instance")
+    assert overlay.special_remote == "arbutus-s3"
+    assert overlay.materialization_paths == (Path("data"), Path("models"))
+    assert overlay.audit_paths == (Path("data"), Path("models"))
+
+
+def test_overlay_parser_reports_missing_required_fields(tmp_path: Path) -> None:
+    overlay_path = tmp_path / "bad_overlay.yaml"
+    overlay_path.write_text("instance: {}\n", encoding="utf-8")
+
+    overlay, diagnostics = load_materialization_overlay(overlay_path)
+
+    assert overlay is None
+    assert any("environment" in message for message in diagnostics)
+    assert any("annex" in message for message in diagnostics)
+
+
+def test_provider_validation_reports_missing_overlay_parameter() -> None:
+    provider = provider_factory()
+    node_type = _node_type(provider, "check_toolchain")
+    node = _workflow_node("check_toolchain")
+    node = type(node)(
+        id=node.id,
+        provider=node.provider,
+        outputs=node.outputs,
+        parameters={},
+    )
+
+    diagnostics = provider.validate_node(node, node_type, location="nodes.0")
+
+    assert {diagnostic.code for diagnostic in diagnostics} == {
+        "femic.materialization.parameters.missing"
+    }
+
+
+def test_provider_validation_reports_bad_overlay_path() -> None:
+    provider = provider_factory()
+    node_type = _node_type(provider, "check_toolchain")
+    node = _workflow_node("check_toolchain", overlay="missing.yaml")
+
+    diagnostics = provider.validate_node(node, node_type, location="nodes.0")
+
+    assert any(
+        diagnostic.code == "femic.materialization.overlay.invalid"
+        for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.parametrize("node_type_id", COMMAND_NODE_TYPES)
+def test_materialization_command_nodes_use_mocked_runner(
+    node_type_id: str,
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    commands: list[tuple[str, ...]] = []
+    provider = FemicMaterializationProvider(command_runner=_successful_runner(commands))
+    node = _workflow_node(node_type_id)
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, node_type_id),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert commands
+    assert result.data["commands"] == [list(command) for command in commands]
+
+
+def test_materialization_command_failure_returns_diagnostic(tmp_path: Path) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    provider = FemicMaterializationProvider(command_runner=_failing_runner)
+    node = _workflow_node("init_annex")
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, "init_annex"),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.FAILED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {
+        "femic.materialization.command.failed"
+    }
+
+
+def test_annex_audit_stdout_is_failure_even_with_zero_returncode(
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    provider = FemicMaterializationProvider(command_runner=_audit_missing_runner)
+    node = _workflow_node("audit_annex_availability")
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, "audit_annex_availability"),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.FAILED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {
+        "femic.materialization.audit.missing_remote_content"
+    }
+
+
+def test_write_report_node_resolves_namespace_artifact(tmp_path: Path) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    provider = provider_factory()
+    node = _workflow_node("write_materialization_report")
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, "write_materialization_report"),
+        context=RunContext(
+            workflow_id="wf",
+            workdir=tmp_path,
+            run_namespace="smoke",
+            completed_outputs={"check": {"ok": True}},
+        ),
+    )
+
+    report_path = (
+        tmp_path / "smoke" / "runtime" / "freshforge" / ("materialization_report.json")
+    )
+    assert result.status is RunStatus.SUCCESS
+    assert result.artifacts["report"] == str(
+        tmp_path / "smoke" / "runtime" / "freshforge" / "materialization_report.json"
+    )
+    assert report_path.exists()
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["provider_id"] == MATERIALIZATION_PROVIDER_ID
+    assert payload["completed_outputs"] == {"check": {"ok": True}}
+
+
+def test_materialization_fixture_workflow_validates_and_plans() -> None:
+    from freshforge.loading import load_workflow
+    from freshforge.planning import create_run_plan
+    from freshforge.validation import validate_workflow_with_providers
+
+    spec, diagnostics = load_workflow(WORKFLOW_PATH)
+    assert spec is not None
+    diagnostics = validate_workflow_with_providers(
+        spec,
+        structural_diagnostics=diagnostics,
+    )
+    plan = create_run_plan(spec, diagnostics=diagnostics)
+
+    assert not plan.has_errors
+    assert [node.id for node in plan.nodes] == ["write_materialization_report"]
+
+
+def test_materialization_fixture_cli_run_writes_report(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "freshforge",
+            "run",
+            str(WORKFLOW_PATH),
+            "--workdir",
+            str(tmp_path),
+            "--namespace",
+            "smoke",
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["summary"]["succeeded_count"] == 1
+    assert (
+        tmp_path / "smoke" / "runtime" / "freshforge" / "materialization_report.json"
+    ).exists()


### PR DESCRIPTION
## Summary
- adds the generic FEMIC FreshForge materialization provider namespace `femic.materialization`
- adds overlay parsing/validation, provider execution hooks, mocked command coverage, and a public-safe report-only fixture workflow
- documents the materialization provider separately from the model-build provider and marks P98.4 complete locally

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/test_freshforge_materialization.py tests/test_freshforge_integration.py`
- `.\.venv\Scripts\python.exe -m ruff format src tests`
- `.\.venv\Scripts\python.exe -m ruff check src tests`
- `.\.venv\Scripts\python.exe -m mypy src/femic/freshforge_materialization.py`
- `.\.venv\Scripts\python.exe -m freshforge providers --json`
- `.\.venv\Scripts\python.exe -m freshforge validate examples/freshforge/materialization_smoke_workflow.yaml --json`
- `.\.venv\Scripts\python.exe -m freshforge inspect examples/freshforge/materialization_smoke_workflow.yaml --json`
- `.\.venv\Scripts\python.exe -m freshforge plan examples/freshforge/materialization_smoke_workflow.yaml --json`
- `.\.venv\Scripts\python.exe -m freshforge run examples/freshforge/materialization_smoke_workflow.yaml --workdir <temp> --namespace smoke --json`
- `.\.venv\Scripts\sphinx-build.exe -b html docs _build/html -W`
- `.\.venv\Scripts\python.exe -m build`
- `.\.venv\Scripts\twine.exe check dist\*`
- inspected wheel metadata for both `femic` and `femic.materialization` FreshForge provider entry points

## Notes
- Real MKRF/TFL6/K3Z/TSA29 overlays remain follow-on instance phases.
- PyPI lookup for `freshforge==0.1.0a4` returned no matching distribution from this environment, so docs keep the GitHub tag install path for now.
- Leaves unrelated `external/femic-public-data` submodule state untouched.

Refs #270
