### PR TITLE
P99: Switch FreshForge extra to PyPI release

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19359,3 +19359,15 @@
 - Verified that `freshforge` is not yet resolvable from PyPI as `freshforge` in
   this environment, so FEMIC's FreshForge install guidance remains on the
   released GitHub tag until the PyPI package name or propagation is confirmed.
+
+## 2026-07-01 - Switched FreshForge optional extra to PyPI package
+
+- Opened issue `#274` for the follow-up dependency cleanup after FreshForge
+  became available as a normal PyPI package.
+- Verified PyPI JSON reports `freshforge` version `0.1.0a5` and that
+  `pip install --index-url https://pypi.org/simple --dry-run
+  freshforge==0.1.0a5` resolves in this environment.
+- Updated `femic[freshforge]` to install `freshforge==0.1.0a5`.
+- Replaced GitHub-tag FreshForge install examples in README/docs with the
+  normal FEMIC extra install path and updated the public-safe materialization
+  fixture overlay to reference the PyPI package.

--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ python -m pip install -r requirements-dev.txt
 This installs FEMIC in editable mode (`-e .`) plus development tools and
 DataLad (`datalad[full]`).
 
-FreshForge is optional and currently installed from its source repository until
-it has a PyPI release. To use FreshForge orchestration with FEMIC, install
-FreshForge explicitly after the FEMIC dev install:
+FreshForge is optional. To use FreshForge orchestration with FEMIC, install the
+FreshForge extra:
 
 ```bash
-python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"
+python -m pip install -e ".[freshforge]"
 ```
 
-The `femic[freshforge]` extra is retained as a PyPI-safe compatibility marker,
-but it does not install FreshForge while FreshForge has no PyPI distribution.
+For non-editable installs, use the same extra with the packaged FEMIC
+distribution. The extra currently pins `freshforge==0.1.0a5`.
 
 Then bootstrap annex-backed submodules and materialize real file content:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2998,6 +2998,28 @@ from prose documentation.
         inspect, plan, and run.
   - [x] Keep the first real instance overlay as a later TFL6 phase.
 
+## Phase 99: FreshForge PyPI Dependency Cleanup (`#274`)
+
+Status: complete; PR closeout pending
+
+Goal: switch FEMIC's optional FreshForge dependency and install guidance from
+the temporary GitHub tag workflow to the PyPI-published FreshForge alpha.
+
+- [x] P99.1 Verify FreshForge PyPI availability.
+  - [x] Confirm PyPI JSON reports `freshforge` version `0.1.0a5`.
+  - [x] Confirm `pip install --index-url https://pypi.org/simple --dry-run
+        freshforge==0.1.0a5` resolves in this environment.
+- [x] P99.2 Update FEMIC dependency and docs.
+  - [x] Set `femic[freshforge]` to install `freshforge==0.1.0a5`.
+  - [x] Replace GitHub-tag install examples with PyPI extra guidance.
+  - [x] Update the public-safe materialization fixture overlay package
+        reference.
+- [x] P99.3 Validate and close out.
+  - [x] Run focused FreshForge provider/materialization tests.
+  - [x] Run package metadata checks proving the extra carries
+        `freshforge==0.1.0a5`.
+  - [x] Update `CHANGE_LOG.md` and issue `#274`.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -3012,24 +3034,28 @@ from prose documentation.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P98` / `#270` is implemented locally and awaiting PR closeout. The
-    reusable `femic.materialization` FreshForge provider now supplies generic
-    materialization nodes, overlay parsing/validation, mocked execution tests,
-    and a public-safe report-only fixture workflow. Real MKRF, TFL6, K3Z, and
-    TSA29 overlays remain follow-on instance phases. The next planning edge is
-    to start with a TFL6-owned materialization overlay once P98 merges.
+  - `P99` / `#274` is complete locally and awaiting PR closeout: FreshForge is
+    now published on PyPI as `freshforge==0.1.0a5`, and FEMIC's optional
+    dependency metadata plus docs now use the normal `femic[freshforge]`
+    install path.
+  - `P98` / `#270` is complete: the reusable `femic.materialization`
+    FreshForge provider supplies generic materialization nodes, overlay
+    parsing/validation, mocked execution tests, and a public-safe report-only
+    fixture workflow. Real MKRF, TFL6, K3Z, and TSA29 overlays remain
+    follow-on instance phases.
   - `P97` / `#268` is complete: report-only namespace-aware FreshForge
     artifact metadata resolves workflow-declared artifact paths through
     FreshForge `RunContext.resolve_path(...)` for provider run records. FEMIC
     command construction remains unchanged, validation/inspection/planning
     remain non-mutating, and command-output routing remains deferred.
-  - `P96` / `#266` is complete locally: FEMIC's optional FreshForge provider
+  - `P96` / `#266` is complete: FEMIC's optional FreshForge provider
     integration now targets released FreshForge `v0.1.0a4`. The provider
     exposes `run_node(...)`, returns `ProviderRunResult`, reports provider
-    version `0.2.0a1`, preserves the empty PyPI-safe `femic[freshforge]` extra,
-    and keeps validation/inspection/planning non-mutating. Local smoke checks
-    verified provider discovery, validate, inspect, plan, matrix help, and a
-    safe one-node `freshforge run --namespace smoke --json` path.
+    version `0.2.0a1`, and keeps validation/inspection/planning non-mutating.
+    P99 superseded the temporary empty `femic[freshforge]` extra after the
+    FreshForge PyPI package became available. Local smoke checks verified
+    provider discovery, validate, inspect, plan, matrix help, and a safe
+    one-node `freshforge run --namespace smoke --json` path.
   - `P95` / `#262` is complete: FEMIC `0.2.0a1` is published as the core
     decoupling alpha release. GitHub prerelease `FEMIC 0.2.0a1`, tag
     `v0.2.0a1`, TestPyPI workflow `28562782006`, and PyPI workflow

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -19,18 +19,20 @@ runtime configuration, and artifact names are owned.
 Install
 -------
 
-FreshForge is optional and currently installed from its source repository until
-it has a PyPI release. For development or runtime use, install FEMIC first and
-then install FreshForge explicitly:
+FreshForge is optional. Install FEMIC with the FreshForge extra when you need
+workflow orchestration:
 
 .. code-block:: bash
 
-   python -m pip install femic
-   python -m pip install "freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4"
+   python -m pip install "femic[freshforge]"
 
-The ``femic[freshforge]`` extra is retained as a PyPI-safe compatibility
-marker, but it does not install FreshForge while FreshForge has no PyPI
-distribution.
+For local development, install the editable checkout with:
+
+.. code-block:: bash
+
+   python -m pip install -e ".[freshforge]"
+
+The extra currently pins ``freshforge==0.1.0a5``.
 
 Provider Discovery
 ------------------
@@ -101,7 +103,7 @@ Validate and plan it with:
    freshforge plan examples/freshforge/model_build_workflow.yaml
    freshforge run examples/freshforge/model_build_workflow.yaml --workdir runtime/freshforge --namespace smoke
 
-FreshForge `v0.1.0a4` also exposes workflow matrix commands through
+FreshForge also exposes workflow matrix commands through
 ``freshforge matrix``. Matrix examples and command-output namespace routing
 are planned as later compatibility phases; this guide keeps the first
 released-tag example focused on direct provider discovery, validation,

--- a/examples/freshforge/materialization_overlay.yaml
+++ b/examples/freshforge/materialization_overlay.yaml
@@ -10,7 +10,7 @@ install:
     - dev
     - freshforge
   packages:
-    - freshforge @ git+https://github.com/UBC-FRESH/freshforge.git@v0.1.0a4
+    - freshforge==0.1.0a5
 annex:
   special_remote: arbutus-s3
 materialization:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 freshforge = [
+    "freshforge==0.1.0a5",
 ]
 figures = [
 ]

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -152,6 +152,7 @@ def test_pyproject_declares_freshforge_extra_and_entry_point() -> None:
 
     optional = pyproject["project"]["optional-dependencies"]
     assert "freshforge" in optional
+    assert optional["freshforge"] == ["freshforge==0.1.0a5"]
     assert all("git+" not in item for deps in optional.values() for item in deps)
     entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
     assert entry_points["femic"] == "femic.freshforge:provider_factory"


### PR DESCRIPTION
## Summary

- Switches the optional `femic[freshforge]` extra from the temporary empty marker to the PyPI package `freshforge==0.1.0a5`.
- Replaces GitHub-tag install examples in README/docs with normal extra install guidance.
- Updates the public-safe materialization fixture overlay to install the PyPI FreshForge package.
- Adds a focused test assertion so the FreshForge extra cannot silently drift back to an empty or Git-based dependency.

Closes #274.

## Validation

- `python -m pip install -e .[freshforge]` installed `freshforge-0.1.0a5` from PyPI.
- `python -m ruff check src tests`
- `python -m pytest tests/test_freshforge_materialization.py tests/test_freshforge_integration.py` (`35 passed`)
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`
- Inspected built wheel metadata: `Requires-Dist: freshforge==0.1.0a5; extra == freshforge` and both FreshForge provider entry points are present.

Unrelated local submodule dirt in `external/femic-public-data` was left untouched.