### PR TITLE
P100: Add TFL6 FreshForge materialization overlay

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19371,3 +19371,31 @@
 - Replaced GitHub-tag FreshForge install examples in README/docs with the
   normal FEMIC extra install path and updated the public-safe materialization
   fixture overlay to reference the PyPI package.
+
+## 2026-07-01 - Launched P100 TFL6 FreshForge materialization overlay
+
+- Opened parent issue `#276` and TFL6 issue `#160` for the first real
+  FreshForge model-instance materialization workflow.
+- Added `planning/phase100_tfl6_materialization_overlay.md` and coordinated
+  with the TFL6 Phase 18 overlay/workflow surfaces.
+- Hardened `femic.materialization.check_python_environment` so an existing
+  configured venv is validated instead of recreated, after the first real TFL6
+  run exposed that active-venv bootstrap case.
+- Validated provider discovery, `freshforge validate`, `freshforge inspect`,
+  `freshforge plan`, and a bounded `freshforge run` against the TFL6
+  materialization workflow from the parent checkout.
+- Verified the run wrote only ignored `runtime/freshforge/` output locally and
+  that `git annex find --not --in arbutus-s3 -- models` reported no TFL6 model
+  payload gaps.
+
+## 2026-07-01 - Closed P100 TFL6 FreshForge materialization overlay
+
+- Merged the TFL6 Phase 18 PR and advanced the parent TFL6 submodule pointer to
+  the merged TFL6 `main` commit.
+- Re-ran parent-checkout `freshforge validate`, `freshforge inspect`, and
+  `freshforge plan` against the merged TFL6 materialization workflow.
+- Re-ran the TFL6 model payload audit with
+  `git annex find --not --in arbutus-s3 -- models`; no required model payload
+  gaps were reported.
+- Marked P100 complete in `ROADMAP.md`; follow-on instance materialization
+  overlays for MKRF, K3Z, and TSA29 remain separate phases.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3000,7 +3000,7 @@ from prose documentation.
 
 ## Phase 99: FreshForge PyPI Dependency Cleanup (`#274`)
 
-Status: complete; PR closeout pending
+Status: complete
 
 Goal: switch FEMIC's optional FreshForge dependency and install guidance from
 the temporary GitHub tag workflow to the PyPI-published FreshForge alpha.
@@ -3020,6 +3020,39 @@ the temporary GitHub tag workflow to the PyPI-published FreshForge alpha.
         `freshforge==0.1.0a5`.
   - [x] Update `CHANGE_LOG.md` and issue `#274`.
 
+## Phase 100: First FreshForge Materialization Overlay For TFL6 (`#276`)
+
+Status: complete
+
+Goal: prove the first real model-instance materialization workflow using the
+generic `femic.materialization` FreshForge provider, with TFL6 as the parent
+checkout acceptance case.
+
+- [x] P100.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#276` and TFL6 issue `#160`.
+  - [x] Create parent branch `feature/p100-tfl6-materialization-overlay`.
+  - [x] Create TFL6 branch `feature/p18-freshforge-materialization-overlay`.
+  - [x] Add `planning/phase100_tfl6_materialization_overlay.md`.
+- [x] P100.2 Add TFL6-owned overlay and workflow.
+  - [x] Add TFL6 materialization overlay and workflow YAML under
+        `external/femic-tfl6-instance/workflows/freshforge/`.
+  - [x] Use only the generic `femic.materialization.*` provider namespace.
+  - [x] Keep runtime reports under ignored `runtime/freshforge/`.
+- [x] P100.3 Validate parent-checkout materialization surfaces.
+  - [x] Harden `femic.materialization.check_python_environment` so an existing
+        configured venv is validated instead of recreated.
+  - [x] Run provider discovery, validate, inspect, and plan from the parent
+        checkout.
+  - [x] Run the bounded FreshForge materialization workflow from the parent
+        checkout.
+  - [x] Verify required `models/**` payload availability and Arbutus remote
+        coverage.
+- [x] P100.4 Close out.
+  - [x] Merge the TFL6 Phase 18 PR first.
+  - [x] Update the parent TFL6 submodule pointer.
+  - [x] Re-run parent validation after the pointer update.
+  - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -3034,10 +3067,14 @@ the temporary GitHub tag workflow to the PyPI-published FreshForge alpha.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P99` / `#274` is complete locally and awaiting PR closeout: FreshForge is
-    now published on PyPI as `freshforge==0.1.0a5`, and FEMIC's optional
-    dependency metadata plus docs now use the normal `femic[freshforge]`
-    install path.
+  - `P100` / `#276` is complete locally and ready for parent PR review: the
+    first real `femic.materialization` FreshForge workflow targets the TFL6
+    submodule materialization ritual from the parent FEMIC checkout. The TFL6
+    Phase 18 PR has merged, the parent submodule pointer has been updated, and
+    merged-pointer validation passed.
+  - `P99` / `#274` is complete and merged: FreshForge is now published on PyPI
+    as `freshforge==0.1.0a5`, and FEMIC's optional dependency metadata plus
+    docs use the normal `femic[freshforge]` install path.
   - `P98` / `#270` is complete: the reusable `femic.materialization`
     FreshForge provider supplies generic materialization nodes, overlay
     parsing/validation, mocked execution tests, and a public-safe report-only

--- a/planning/phase100_tfl6_materialization_overlay.md
+++ b/planning/phase100_tfl6_materialization_overlay.md
@@ -1,0 +1,27 @@
+# P100 TFL6 FreshForge materialization overlay
+
+P100 is the first real instance materialization workflow that uses the generic
+FEMIC `femic.materialization` FreshForge provider. The acceptance case is the
+parent FEMIC checkout with TFL6 mounted as `external/femic-tfl6-instance`,
+because that is the workflow that has been failing for new users.
+
+The TFL6 repository owns the overlay and workflow documents. FEMIC owns the
+generic provider only. The workflow should initialize the TFL6 submodule,
+validate the parent `.venv` and editable FEMIC/FreshForge install, enable the
+TFL6 `arbutus-s3` annex remote, materialize the tracked model/config/workflow
+payloads, audit `models/` remote coverage, and write a local FreshForge report.
+
+The first overlay is intentionally parent-checkout oriented, not a standalone
+TFL6-only clone contract. Standalone instance materialization can be added
+later once this parent-submodule workflow is stable.
+
+Validation surfaces:
+
+- `freshforge providers --json`
+- `freshforge validate external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --json`
+- `freshforge inspect external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --json`
+- `freshforge plan external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --json`
+- `freshforge run external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --workdir runtime/freshforge --namespace tfl6/materialization --json`
+
+Runtime reports remain local/generated under `runtime/freshforge/` and must not
+be tracked.

--- a/src/femic/freshforge_materialization.py
+++ b/src/femic/freshforge_materialization.py
@@ -413,6 +413,9 @@ def _check_toolchain_commands(
 def _python_environment_commands(
     overlay: MaterializationOverlay,
 ) -> tuple[tuple[str, ...], ...]:
+    python = _venv_python(overlay.venv_path)
+    if Path(python).exists():
+        return ((python, "--version"),)
     return ((sys.executable, "-m", "venv", str(overlay.venv_path)),)
 
 

--- a/tests/test_freshforge_materialization.py
+++ b/tests/test_freshforge_materialization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tomllib
@@ -220,6 +221,56 @@ def test_materialization_command_failure_returns_diagnostic(tmp_path: Path) -> N
     assert {diagnostic.code for diagnostic in result.diagnostics} == {
         "femic.materialization.command.failed"
     }
+
+
+def test_python_environment_node_validates_existing_venv(
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    overlay_path = tmp_path / "overlay.yaml"
+    venv_scripts = tmp_path / ".venv" / ("Scripts" if os.name == "nt" else "bin")
+    venv_scripts.mkdir(parents=True)
+    python_path = venv_scripts / ("python.exe" if os.name == "nt" else "python")
+    python_path.write_text("", encoding="utf-8")
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "instance:",
+                "  root: .",
+                "environment:",
+                f"  venv_path: {tmp_path / '.venv'}",
+                "install:",
+                "  requirements: []",
+                "  editable_paths: []",
+                "  extras: []",
+                "  packages: []",
+                "annex:",
+                "  special_remote: arbutus-s3",
+                "materialization:",
+                "  required_paths: [models]",
+                "audit:",
+                "  required_paths: [models]",
+                "report:",
+                "  path: runtime/freshforge/report.json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    commands: list[tuple[str, ...]] = []
+    provider = FemicMaterializationProvider(command_runner=_successful_runner(commands))
+    node = _workflow_node("check_python_environment", overlay=str(overlay_path))
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, "check_python_environment"),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert commands == [(str(python_path), "--version")]
 
 
 def test_annex_audit_stdout_is_failure_even_with_zero_returncode(


### PR DESCRIPTION
Closes #276.

## Summary
- adds the P100 planning note for the first real FreshForge materialization overlay
- advances the TFL6 submodule pointer to merged TFL6 Phase 18 commit b921c93
- hardens `femic.materialization.check_python_environment` so an existing configured `.venv` is validated instead of recreated
- adds regression coverage for the existing-venv command path
- marks P100 complete in the roadmap and changelog

## Validation
- `python -m pytest tests/test_freshforge_materialization.py tests/test_freshforge_integration.py` -> 36 passed
- `python -m ruff check src tests` -> passed
- `python -m mypy src/femic/freshforge_materialization.py` -> passed
- `sphinx-build -b html docs _build/html -W` -> passed
- `python -m build --no-isolation` -> passed
- `twine check dist/*` -> passed
- `freshforge validate external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --json` -> ok
- `freshforge inspect external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --json` -> ok
- `freshforge plan external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --json` -> ok
- `freshforge run external/femic-tfl6-instance/workflows/freshforge/tfl6_materialization_workflow.yaml --workdir runtime/freshforge --namespace tfl6/materialization --json` -> all nodes success in bounded local acceptance
- `git -C external/femic-tfl6-instance annex find --not --in arbutus-s3 -- models` -> no model payload gaps reported

## Notes
- Isolated `python -m build` hit an environment/network socket block while fetching build requirements from PyPI. The no-isolation build and `twine check` passed in the prepared release environment.
- `external/femic-public-data` has unrelated submodule dirt and is intentionally left out of this PR.
