### PR TITLE
P101: Add MKRF FreshForge materialization overlay

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19399,3 +19399,36 @@
   gaps were reported.
 - Marked P100 complete in `ROADMAP.md`; follow-on instance materialization
   overlays for MKRF, K3Z, and TSA29 remain separate phases.
+
+## 2026-07-01 - Launched P101 MKRF FreshForge materialization overlay
+
+- Opened parent issue `#278` and MKRF issue
+  `UBC-FRESH/femic-mkrf-instance#48` for the second real FreshForge
+  model-instance materialization workflow.
+- Added `planning/phase101_mkrf_materialization_overlay.md` and coordinated
+  with MKRF-owned workflow, overlay, and planning-note surfaces.
+- Added an MKRF materialization overlay that targets the parent checkout,
+  installs `.[dev,freshforge]`, installs `external/femic-mkrf-instance`
+  editable, enables `arbutus-s3`, materializes `models`, `config`,
+  `workflows`, and `data/source`, and audits `models` plus `data/source`.
+- Updated MKRF README/runbook/docs to use the released FreshForge
+  `--workdir` / `--namespace` run CLI shape instead of stale branch-era
+  `--run-id` / `--report` examples.
+- Validated provider discovery, `freshforge validate`, `freshforge inspect`,
+  `freshforge plan`, and a bounded `freshforge run` against the MKRF
+  materialization workflow from the parent checkout.
+- Verified the run wrote only ignored `runtime/freshforge/` output locally and
+  that `git annex find --not --in arbutus-s3 -- models data/source` reported
+  no MKRF payload gaps.
+
+## 2026-07-01 - Closed P101 MKRF FreshForge materialization overlay
+
+- Merged the MKRF materialization PR and advanced the parent MKRF submodule
+  pointer to the merged MKRF `main` commit.
+- Re-ran parent-checkout `freshforge validate`, `freshforge inspect`, and
+  `freshforge plan` against the merged MKRF materialization workflow.
+- Re-ran the MKRF payload audit with
+  `git annex find --not --in arbutus-s3 -- models data/source`; no required
+  model or source payload gaps were reported.
+- Marked P101 complete in `ROADMAP.md`; follow-on instance materialization
+  overlays for K3Z and TSA29 remain separate phases.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3053,6 +3053,41 @@ checkout acceptance case.
   - [x] Re-run parent validation after the pointer update.
   - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
+## Phase 101: FreshForge Materialization Overlay For MKRF (`#278`)
+
+Status: complete
+
+Goal: add the second real model-instance materialization workflow using the
+generic `femic.materialization` FreshForge provider, with MKRF as the parent
+checkout acceptance case after TFL6.
+
+- [x] P101.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#278` and MKRF issue `UBC-FRESH/femic-mkrf-instance#48`.
+  - [x] Create parent branch `feature/p101-mkrf-materialization-overlay`.
+  - [x] Create MKRF branch `feature/freshforge-materialization-overlay`.
+  - [x] Add `planning/phase101_mkrf_materialization_overlay.md`.
+- [x] P101.2 Add MKRF-owned overlay and workflow.
+  - [x] Add MKRF materialization overlay and workflow YAML under
+        `external/femic-mkrf-instance/workflows/freshforge/`.
+  - [x] Use only the generic `femic.materialization.*` provider namespace.
+  - [x] Install the MKRF editable adapter package during materialization so
+        the `mkrf` FreshForge provider is available after bootstrap.
+- [x] P101.3 Update MKRF docs and validate surfaces.
+  - [x] Document parent-checkout materialization commands.
+  - [x] Replace stale branch-era FreshForge `--run-id` / `--report` examples
+        with the released `--workdir` / `--namespace` CLI shape.
+  - [x] Run provider discovery, validate, inspect, and plan from the parent
+        checkout.
+  - [x] Run the bounded FreshForge materialization workflow from the parent
+        checkout.
+  - [x] Verify `models` and `data/source` payload availability and Arbutus
+        remote coverage.
+- [x] P101.4 Close out.
+  - [x] Merge the MKRF materialization PR first.
+  - [x] Update the parent MKRF submodule pointer.
+  - [x] Re-run parent validation after the pointer update.
+  - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
@@ -3067,10 +3102,15 @@ checkout acceptance case.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P100` / `#276` is complete locally and ready for parent PR review: the
-    first real `femic.materialization` FreshForge workflow targets the TFL6
-    submodule materialization ritual from the parent FEMIC checkout. The TFL6
-    Phase 18 PR has merged, the parent submodule pointer has been updated, and
+  - `P101` / `#278` is complete locally and ready for parent PR review: the
+    second real `femic.materialization` FreshForge workflow targets the MKRF
+    submodule materialization ritual from the parent FEMIC checkout. The MKRF
+    materialization PR has merged, the parent submodule pointer has been
+    updated, and merged-pointer validation passed.
+  - `P100` / `#276` is complete and merged: the first real
+    `femic.materialization` FreshForge workflow targets the TFL6 submodule
+    materialization ritual from the parent FEMIC checkout. The TFL6 Phase 18 PR
+    has merged, the parent submodule pointer has been updated, and
     merged-pointer validation passed.
   - `P99` / `#274` is complete and merged: FreshForge is now published on PyPI
     as `freshforge==0.1.0a5`, and FEMIC's optional dependency metadata plus

--- a/planning/phase101_mkrf_materialization_overlay.md
+++ b/planning/phase101_mkrf_materialization_overlay.md
@@ -1,0 +1,31 @@
+# P101 MKRF FreshForge Materialization Overlay
+
+P101 adds the second real model-instance materialization workflow using the
+generic `femic.materialization` FreshForge provider. TFL6 proved the parent
+checkout pattern first; MKRF proves the same provider contract can bootstrap an
+instance that also owns an editable FreshForge adapter package.
+
+The workflow targets commands run from the parent FEMIC checkout with MKRF at
+`external/femic-mkrf-instance`. MKRF supplies only overlay values and workflow
+composition. FEMIC core still owns the generic materialization provider, and
+MKRF-specific model-build orchestration remains in the MKRF instance package.
+
+The MKRF overlay materializes `models`, `config`, `workflows`, and
+`data/source`, then audits `models` and `data/source` against `arbutus-s3`.
+The package install step installs `.[dev,freshforge]` from the parent checkout
+and installs `external/femic-mkrf-instance` editable so later FreshForge
+commands can discover the `mkrf` provider.
+
+Validation targets:
+
+- `freshforge providers --json`
+- `freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json`
+- `freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json`
+- `freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json`
+- `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json`
+- `git -C external/femic-mkrf-instance annex find --not --in arbutus-s3 -- models data/source`
+
+P101 also corrects stale MKRF FreshForge model-build examples that still used
+branch-era `--run-id` and `--report` flags. Released FreshForge uses
+`--workdir`, `--namespace`, and `--json`; `freshforge plan` is the non-mutating
+preview.


### PR DESCRIPTION
Closes #278.

## Summary
- adds the P101 planning note for the MKRF FreshForge materialization overlay
- advances the MKRF submodule pointer to merged MKRF commit `3d82eb9`
- records P101 roadmap and changelog closeout
- follows the TFL6/P100 materialization contract while proving a second instance that installs its editable adapter package

## MKRF PR
- https://github.com/UBC-FRESH/femic-mkrf-instance/pull/49

## Validation
- `python -m pytest tests/test_freshforge_materialization.py` -> 20 passed
- `sphinx-build -b html docs _build/html -W` -> passed
- `sphinx-build -b html external/femic-mkrf-instance/docs external/femic-mkrf-instance/docs/_build/html -W` -> passed
- `freshforge providers --json` -> lists `femic.materialization` and `mkrf`
- `freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json` -> ok
- `freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json` -> ok
- `freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json` -> ok
- `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json` -> all 9 nodes success
- `git -C external/femic-mkrf-instance annex find --not --in arbutus-s3 -- models data/source` -> no payload gaps reported

## Notes
- Runtime report output stayed under ignored `runtime/freshforge/`.
- `external/femic-public-data` has unrelated submodule dirt and is intentionally left out of this PR.
