### PR TITLE
P102: Add K3Z FreshForge materialization overlay support

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19432,3 +19432,23 @@
   model or source payload gaps were reported.
 - Marked P101 complete in `ROADMAP.md`; follow-on instance materialization
   overlays for K3Z and TSA29 remain separate phases.
+
+## 2026-07-02 - Launched P102 K3Z FreshForge materialization overlay
+
+- Opened parent issue `#280` and K3Z issue
+  `UBC-FRESH/femic-k3z-instance#35` for the third real FreshForge
+  model-instance materialization workflow.
+- Added `planning/phase102_k3z_materialization_overlay.md` to record that K3Z
+  is currently a plain-git snapshot, not a DataLad/git-annex dataset.
+- Extended the generic `femic.materialization` overlay contract with
+  `annex.enabled`, defaulting to `true` for existing TFL6/MKRF behavior and
+  allowing plain-git instances to skip annex-specific nodes.
+- Added K3Z-owned FreshForge materialization overlay/workflow files that verify
+  tracked K3Z paths, install the editable K3Z package, and write ignored
+  runtime reports without enabling `arbutus-s3` or running `datalad get`.
+- Validated provider discovery, `freshforge validate`, `freshforge inspect`,
+  `freshforge plan`, and a bounded `freshforge run` against the K3Z
+  materialization workflow from the parent checkout using `freshforge`
+  `0.1.0a5` in the repo `.venv`.
+- Verified the run wrote the K3Z materialization report only under ignored
+  parent `runtime/freshforge/` output.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19452,3 +19452,13 @@
   `0.1.0a5` in the repo `.venv`.
 - Verified the run wrote the K3Z materialization report only under ignored
   parent `runtime/freshforge/` output.
+
+## 2026-07-02 - Closed P102 K3Z FreshForge materialization overlay
+
+- Merged the K3Z materialization PR and advanced the parent K3Z submodule
+  pointer to merged K3Z `main` commit `7b8e05d`.
+- Re-ran parent-checkout `freshforge validate`, `freshforge inspect`, and
+  `freshforge plan` against the merged K3Z materialization workflow.
+- Re-ran focused materialization provider tests after the pointer update.
+- Marked P102 complete in `ROADMAP.md`; TSA29 remains the next separate
+  materialization acceptance case.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3088,9 +3088,50 @@ checkout acceptance case after TFL6.
   - [x] Re-run parent validation after the pointer update.
   - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
+## Phase 102: FreshForge Materialization Overlay For K3Z (`#280`)
+
+Status: in progress
+
+Goal: add K3Z as the third model-instance materialization workflow using the
+generic `femic.materialization` provider, while handling K3Z's current
+plain-git storage mode without requiring DataLad/git-annex.
+
+- [x] P102.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#280` and K3Z issue
+        `UBC-FRESH/femic-k3z-instance#35`.
+  - [x] Create parent branch `feature/p102-k3z-materialization-overlay`.
+  - [x] Create K3Z branch `feature/freshforge-materialization-overlay`.
+  - [x] Add `planning/phase102_k3z_materialization_overlay.md`.
+- [x] P102.2 Extend generic materialization for plain-git instances.
+  - [x] Add optional overlay field `annex.enabled`, defaulting to `true`.
+  - [x] Treat annex initialization, special-remote enablement, and annex audit
+        nodes as no-op success nodes when annex is disabled.
+  - [x] Make `materialize_paths` verify working-tree paths instead of running
+        `datalad get` when annex is disabled.
+- [x] P102.3 Add K3Z-owned overlay and workflow.
+  - [x] Add K3Z materialization overlay and workflow YAML under
+        `external/femic-k3z-instance/workflows/freshforge/`.
+  - [x] Use only the generic `femic.materialization.*` provider namespace.
+  - [x] Install the K3Z editable package during materialization so K3Z-owned
+        FEMIC extension entry points are available after bootstrap.
+- [x] P102.4 Update docs and validate surfaces.
+  - [x] Document parent-checkout materialization commands in K3Z README and
+        operator runbook.
+  - [x] Run provider discovery, validate, inspect, and plan from the parent
+        checkout.
+  - [x] Run the bounded FreshForge materialization workflow from the parent
+        checkout.
+  - [x] Verify the workflow writes only ignored `runtime/freshforge/` output.
+- [ ] P102.5 Close out.
+  - [ ] Merge the K3Z materialization PR first.
+  - [ ] Update the parent K3Z submodule pointer.
+  - [ ] Re-run parent validation after the pointer update.
+  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
+  - `planning/phase102_k3z_materialization_overlay.md`
   - `planning/phase98_materialization_execution_surface.md`
   - `planning/phase98_freshforge_materialization_template.md`
   - `planning/phase87_parent_instance_reference_audit.md`
@@ -3102,9 +3143,15 @@ checkout acceptance case after TFL6.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P101` / `#278` is complete locally and ready for parent PR review: the
-    second real `femic.materialization` FreshForge workflow targets the MKRF
-    submodule materialization ritual from the parent FEMIC checkout. The MKRF
+  - `P102` / `#280` is active: the third real `femic.materialization`
+    FreshForge workflow targets the K3Z submodule from the parent FEMIC
+    checkout. K3Z is a plain-git snapshot, generic `annex.enabled: false`
+    support is implemented, and provider discovery plus K3Z validate/inspect/
+    plan/run checks pass from the parent checkout. Next step is K3Z PR merge,
+    parent submodule pointer update, and final closeout.
+  - `P101` / `#278` is complete and merged: the second real
+    `femic.materialization` FreshForge workflow targets the MKRF submodule
+    materialization ritual from the parent FEMIC checkout. The MKRF
     materialization PR has merged, the parent submodule pointer has been
     updated, and merged-pointer validation passed.
   - `P100` / `#276` is complete and merged: the first real

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3090,7 +3090,7 @@ checkout acceptance case after TFL6.
 
 ## Phase 102: FreshForge Materialization Overlay For K3Z (`#280`)
 
-Status: in progress
+Status: complete
 
 Goal: add K3Z as the third model-instance materialization workflow using the
 generic `femic.materialization` provider, while handling K3Z's current
@@ -3122,11 +3122,11 @@ plain-git storage mode without requiring DataLad/git-annex.
   - [x] Run the bounded FreshForge materialization workflow from the parent
         checkout.
   - [x] Verify the workflow writes only ignored `runtime/freshforge/` output.
-- [ ] P102.5 Close out.
-  - [ ] Merge the K3Z materialization PR first.
-  - [ ] Update the parent K3Z submodule pointer.
-  - [ ] Re-run parent validation after the pointer update.
-  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+- [x] P102.5 Close out.
+  - [x] Merge the K3Z materialization PR first.
+  - [x] Update the parent K3Z submodule pointer.
+  - [x] Re-run parent validation after the pointer update.
+  - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
 ### Detailed Next Steps Notes
 
@@ -3143,12 +3143,11 @@ plain-git storage mode without requiring DataLad/git-annex.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P102` / `#280` is active: the third real `femic.materialization`
+  - `P102` / `#280` is complete: the third real `femic.materialization`
     FreshForge workflow targets the K3Z submodule from the parent FEMIC
     checkout. K3Z is a plain-git snapshot, generic `annex.enabled: false`
-    support is implemented, and provider discovery plus K3Z validate/inspect/
-    plan/run checks pass from the parent checkout. Next step is K3Z PR merge,
-    parent submodule pointer update, and final closeout.
+    support is implemented, the K3Z PR has merged, the parent submodule pointer
+    has been updated, and merged-pointer validation passed.
   - `P101` / `#278` is complete and merged: the second real
     `femic.materialization` FreshForge workflow targets the MKRF submodule
     materialization ritual from the parent FEMIC checkout. The MKRF

--- a/planning/phase102_k3z_materialization_overlay.md
+++ b/planning/phase102_k3z_materialization_overlay.md
@@ -1,0 +1,62 @@
+# Phase 102: K3Z FreshForge Materialization Overlay
+
+## Purpose
+
+P102 adds K3Z as the third acceptance case for the reusable
+`femic.materialization` FreshForge provider. The goal is to prove that the
+provider can cover both DataLad/git-annex model instances and plain-git
+teaching snapshots without instance-specific code in FEMIC core.
+
+## Storage Mode
+
+K3Z is currently a plain-git snapshot. It does not carry a DataLad dataset
+configuration, an annex special remote, or annex-backed payloads. Its README
+explicitly treats the current payload size as suitable for plain git, with
+future LFS/DataLad migration left as a separate decision.
+
+P102 therefore adds a generic overlay field:
+
+```yaml
+annex:
+  enabled: false
+```
+
+When annex is disabled, the shared materialization provider keeps the workflow
+shape stable but changes behavior:
+
+- `init_annex`, `enable_special_remote`, and `audit_annex_availability` return
+  deterministic no-op success results explaining that annex is disabled.
+- `materialize_paths` verifies that configured paths exist in the working tree
+  instead of running `datalad get`.
+- The behavior remains generic; FEMIC core does not name K3Z or any
+  `external/femic-*-instance` path in provider code.
+
+## K3Z Overlay Scope
+
+The K3Z workflow targets the parent FEMIC checkout with K3Z mounted as
+`external/femic-k3z-instance`.
+
+Initial overlay values:
+
+- `instance.root`: `external/femic-k3z-instance`
+- `instance.submodule_path`: `external/femic-k3z-instance`
+- `environment.venv_path`: `.venv`
+- install extras: `dev`, `freshforge`
+- install editable paths: `external/femic-k3z-instance`
+- `annex.enabled`: `false`
+- materialization paths: `models`, `config`, `data`, `docs`, `workflows`
+- audit paths: same as materialization paths
+- report path: `runtime/freshforge/k3z_materialization_report.json`
+
+## Validation
+
+P102 is accepted when:
+
+- the parent provider tests cover both annex-enabled and annex-disabled
+  overlays;
+- K3Z `freshforge validate`, `inspect`, and `plan` succeed from the parent
+  checkout;
+- K3Z `freshforge run --workdir runtime/freshforge --namespace
+  k3z/materialization --json` succeeds and writes only ignored runtime output;
+- the K3Z docs describe that plain-git materialization does not enable
+  `arbutus-s3` or run `datalad get`.

--- a/src/femic/freshforge_materialization.py
+++ b/src/femic/freshforge_materialization.py
@@ -42,6 +42,7 @@ class MaterializationOverlay:
     audit_paths: tuple[Path, ...]
     report_path: Path
     submodule_path: Path | None = None
+    annex_enabled: bool = True
     install_requirements: tuple[Path, ...] = ()
     install_editable_paths: tuple[Path, ...] = ()
     install_extras: tuple[str, ...] = ()
@@ -51,6 +52,7 @@ class MaterializationOverlay:
         data: dict[str, Any] = {
             "instance_root": str(self.instance_root),
             "venv_path": str(self.venv_path),
+            "annex_enabled": self.annex_enabled,
             "special_remote": self.special_remote,
             "materialization_paths": [str(path) for path in self.materialization_paths],
             "audit_paths": [str(path) for path in self.audit_paths],
@@ -71,7 +73,7 @@ _NODE_CONTRACTS: tuple[_NodeContract, ...] = (
     _NodeContract(
         id="check_toolchain",
         name="Check toolchain",
-        description="Check Git, Python, FEMIC, FreshForge, DataLad, and git-annex.",
+        description="Check Git, Python, FEMIC, FreshForge, and optional annex tools.",
         outputs=("toolchain",),
     ),
     _NodeContract(
@@ -279,6 +281,20 @@ class FemicMaterializationProvider:
                     ),
                 ),
             )
+        if _is_annex_disabled_noop(str(node_type.id), overlay):
+            return result_type(
+                status=run_status.SUCCESS,
+                outputs=node.outputs if isinstance(node.outputs, dict) else {},
+                artifacts=_resolved_artifacts(node, context),
+                data={
+                    "annex_enabled": False,
+                    "commands": [],
+                    "skipped": (
+                        "Annex operation skipped because annex.enabled is false "
+                        "in the materialization overlay."
+                    ),
+                },
+            )
         completed = [self._command_runner(command) for command in commands]
         diagnostics = _command_diagnostics(
             completed=completed,
@@ -337,8 +353,13 @@ def load_materialization_overlay(
     venv_path = _required_path(
         environment, "venv_path", "environment.venv_path", errors
     )
-    special_remote = _required_str(
-        annex, "special_remote", "annex.special_remote", errors
+    annex_enabled = _optional_bool(
+        annex, "enabled", "annex.enabled", errors, default=True
+    )
+    special_remote = (
+        _required_str(annex, "special_remote", "annex.special_remote", errors)
+        if annex_enabled
+        else _optional_str(annex.get("special_remote"))
     )
     report_path = _required_path(report, "path", "report.path", errors)
     materialization_paths = _path_list(
@@ -364,6 +385,7 @@ def load_materialization_overlay(
             instance_root=instance_root,
             submodule_path=_optional_path(instance.get("submodule_path")),
             venv_path=venv_path,
+            annex_enabled=annex_enabled,
             special_remote=special_remote,
             materialization_paths=tuple(materialization_paths),
             audit_paths=tuple(audit_paths),
@@ -398,16 +420,22 @@ def _commands_for_node(
 
 
 def _check_toolchain_commands(
-    _overlay: MaterializationOverlay,
+    overlay: MaterializationOverlay,
 ) -> tuple[tuple[str, ...], ...]:
-    return (
+    commands = [
         ("git", "--version"),
         (sys.executable, "--version"),
         (sys.executable, "-m", "femic", "--help"),
         (sys.executable, "-m", "freshforge", "--version"),
-        ("datalad", "--version"),
-        ("git", "annex", "version"),
-    )
+    ]
+    if overlay.annex_enabled:
+        commands.extend(
+            [
+                ("datalad", "--version"),
+                ("git", "annex", "version"),
+            ]
+        )
+    return tuple(commands)
 
 
 def _python_environment_commands(
@@ -456,12 +484,16 @@ def _init_submodule_commands(
 def _init_annex_commands(
     overlay: MaterializationOverlay,
 ) -> tuple[tuple[str, ...], ...]:
+    if not overlay.annex_enabled:
+        return ()
     return (("git", "-C", str(overlay.instance_root), "annex", "init"),)
 
 
 def _enable_remote_commands(
     overlay: MaterializationOverlay,
 ) -> tuple[tuple[str, ...], ...]:
+    if not overlay.annex_enabled:
+        return ()
     return (
         (
             "git",
@@ -477,6 +509,11 @@ def _enable_remote_commands(
 def _materialize_path_commands(
     overlay: MaterializationOverlay,
 ) -> tuple[tuple[str, ...], ...]:
+    if not overlay.annex_enabled:
+        return tuple(
+            _path_exists_command(_instance_path(overlay, path))
+            for path in overlay.materialization_paths
+        )
     return tuple(
         ("datalad", "get", "-r", str(_instance_path(overlay, path)))
         for path in overlay.materialization_paths
@@ -486,6 +523,8 @@ def _materialize_path_commands(
 def _audit_annex_commands(
     overlay: MaterializationOverlay,
 ) -> tuple[tuple[str, ...], ...]:
+    if not overlay.annex_enabled:
+        return ()
     return tuple(
         (
             "git",
@@ -501,6 +540,26 @@ def _audit_annex_commands(
         )
         for path in overlay.audit_paths
     )
+
+
+def _path_exists_command(path: Path) -> tuple[str, ...]:
+    return (
+        sys.executable,
+        "-c",
+        "from pathlib import Path; import sys; sys.exit(0 if Path(sys.argv[1]).exists() else 1)",
+        str(path),
+    )
+
+
+def _is_annex_disabled_noop(
+    node_type_id: str,
+    overlay: MaterializationOverlay,
+) -> bool:
+    return not overlay.annex_enabled and node_type_id in {
+        "init_annex",
+        "enable_special_remote",
+        "audit_annex_availability",
+    }
 
 
 def _write_report_result(
@@ -609,6 +668,27 @@ def _optional_path(value: object) -> Path | None:
     if isinstance(value, str) and value.strip():
         return Path(value)
     return None
+
+
+def _optional_str(value: object) -> str:
+    if isinstance(value, str) and value.strip():
+        return value
+    return ""
+
+
+def _optional_bool(
+    payload: Mapping[str, object],
+    key: str,
+    label: str,
+    errors: list[str],
+    *,
+    default: bool,
+) -> bool:
+    value = payload.get(key, default)
+    if isinstance(value, bool):
+        return value
+    errors.append(f"Materialization overlay field '{label}' must be a boolean.")
+    return default
 
 
 def _path_list(

--- a/tests/test_freshforge_materialization.py
+++ b/tests/test_freshforge_materialization.py
@@ -133,10 +133,86 @@ def test_overlay_parser_accepts_public_safe_fixture() -> None:
 
     assert diagnostics == ()
     assert overlay is not None
+    assert overlay.annex_enabled is True
     assert overlay.instance_root == Path("examples/freshforge/fixture-instance")
     assert overlay.special_remote == "arbutus-s3"
     assert overlay.materialization_paths == (Path("data"), Path("models"))
     assert overlay.audit_paths == (Path("data"), Path("models"))
+
+
+def test_overlay_parser_accepts_plain_git_overlay_without_special_remote(
+    tmp_path: Path,
+) -> None:
+    overlay_path = tmp_path / "plain_git_overlay.yaml"
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "instance:",
+                "  root: instance",
+                "environment:",
+                "  venv_path: .venv",
+                "install:",
+                "  requirements: []",
+                "  editable_paths: []",
+                "  extras: []",
+                "  packages: []",
+                "annex:",
+                "  enabled: false",
+                "materialization:",
+                "  required_paths: [models, config]",
+                "audit:",
+                "  required_paths: [models, config]",
+                "report:",
+                "  path: runtime/freshforge/report.json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    overlay, diagnostics = load_materialization_overlay(overlay_path)
+
+    assert diagnostics == ()
+    assert overlay is not None
+    assert overlay.annex_enabled is False
+    assert overlay.special_remote == ""
+    assert overlay.materialization_paths == (Path("models"), Path("config"))
+
+
+def test_overlay_parser_requires_special_remote_when_annex_enabled(
+    tmp_path: Path,
+) -> None:
+    overlay_path = tmp_path / "annex_overlay.yaml"
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "instance:",
+                "  root: instance",
+                "environment:",
+                "  venv_path: .venv",
+                "install:",
+                "  requirements: []",
+                "  editable_paths: []",
+                "  extras: []",
+                "  packages: []",
+                "annex:",
+                "  enabled: true",
+                "materialization:",
+                "  required_paths: [models]",
+                "audit:",
+                "  required_paths: [models]",
+                "report:",
+                "  path: runtime/freshforge/report.json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    overlay, diagnostics = load_materialization_overlay(overlay_path)
+
+    assert overlay is None
+    assert any("annex.special_remote" in message for message in diagnostics)
 
 
 def test_overlay_parser_reports_missing_required_fields(tmp_path: Path) -> None:
@@ -292,6 +368,156 @@ def test_annex_audit_stdout_is_failure_even_with_zero_returncode(
     assert {diagnostic.code for diagnostic in result.diagnostics} == {
         "femic.materialization.audit.missing_remote_content"
     }
+
+
+@pytest.mark.parametrize(
+    "node_type_id",
+    ("init_annex", "enable_special_remote", "audit_annex_availability"),
+)
+def test_annex_disabled_nodes_are_noop_success(
+    node_type_id: str,
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    overlay_path = tmp_path / "plain_git_overlay.yaml"
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "instance:",
+                "  root: instance",
+                "environment:",
+                "  venv_path: .venv",
+                "install:",
+                "  requirements: []",
+                "  editable_paths: []",
+                "  extras: []",
+                "  packages: []",
+                "annex:",
+                "  enabled: false",
+                "materialization:",
+                "  required_paths: [models]",
+                "audit:",
+                "  required_paths: [models]",
+                "report:",
+                "  path: runtime/freshforge/report.json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    commands: list[tuple[str, ...]] = []
+    provider = FemicMaterializationProvider(command_runner=_successful_runner(commands))
+    node = _workflow_node(node_type_id, overlay=str(overlay_path))
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, node_type_id),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert commands == []
+    assert result.data["annex_enabled"] is False
+    assert result.data["commands"] == []
+
+
+def test_plain_git_materialize_paths_checks_working_tree_paths(
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    instance_root = tmp_path / "instance"
+    (instance_root / "models").mkdir(parents=True)
+    overlay_path = tmp_path / "plain_git_overlay.yaml"
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "instance:",
+                f"  root: {instance_root}",
+                "environment:",
+                "  venv_path: .venv",
+                "install:",
+                "  requirements: []",
+                "  editable_paths: []",
+                "  extras: []",
+                "  packages: []",
+                "annex:",
+                "  enabled: false",
+                "materialization:",
+                "  required_paths: [models]",
+                "audit:",
+                "  required_paths: [models]",
+                "report:",
+                "  path: runtime/freshforge/report.json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    commands: list[tuple[str, ...]] = []
+    provider = FemicMaterializationProvider(command_runner=_successful_runner(commands))
+    node = _workflow_node("materialize_paths", overlay=str(overlay_path))
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, "materialize_paths"),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert len(commands) == 1
+    assert commands[0][0:3] == (sys.executable, "-c", commands[0][2])
+    assert commands[0][-1] == str(instance_root / "models")
+
+
+def test_plain_git_toolchain_check_skips_datalad_and_git_annex(
+    tmp_path: Path,
+) -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus
+
+    overlay_path = tmp_path / "plain_git_overlay.yaml"
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "instance:",
+                "  root: instance",
+                "environment:",
+                "  venv_path: .venv",
+                "install:",
+                "  requirements: []",
+                "  editable_paths: []",
+                "  extras: []",
+                "  packages: []",
+                "annex:",
+                "  enabled: false",
+                "materialization:",
+                "  required_paths: [models]",
+                "audit:",
+                "  required_paths: [models]",
+                "report:",
+                "  path: runtime/freshforge/report.json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    commands: list[tuple[str, ...]] = []
+    provider = FemicMaterializationProvider(command_runner=_successful_runner(commands))
+    node = _workflow_node("check_toolchain", overlay=str(overlay_path))
+
+    result = provider.run_node(
+        node,
+        _node_type(provider, "check_toolchain"),
+        context=RunContext(workflow_id="wf", workdir=tmp_path),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert ("datalad", "--version") not in commands
+    assert ("git", "annex", "version") not in commands
 
 
 def test_write_report_node_resolves_namespace_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary

Adds generic plain-git support to the FEMIC FreshForge materialization provider and records P102 planning for the K3Z materialization overlay.

K3Z is currently a plain-git teaching snapshot, so this adds `annex.enabled: false` to the generic materialization overlay contract. Existing TFL6/MKRF annex-enabled overlays remain behavior-compatible.

## Changes

- `femic.materialization` overlay parser now supports optional `annex.enabled`, defaulting to `true`.
- When annex is disabled:
  - `check_toolchain` skips DataLad/git-annex checks;
  - `init_annex`, `enable_special_remote`, and `audit_annex_availability` return deterministic no-op success results;
  - `materialize_paths` checks configured paths exist instead of running `datalad get`.
- Added tests for annex-enabled compatibility and annex-disabled plain-git behavior.
- Added P102 roadmap, changelog, and planning surfaces.

## Dependent Instance PR

K3Z workflow/docs live in `UBC-FRESH/femic-k3z-instance#36`. After that PR merges, this parent branch should update the K3Z submodule pointer and then complete P102 closeout.

## Validation

- `python -m pytest tests/test_freshforge_materialization.py`
- `python -m ruff check src tests`
- `python -m mypy src/femic/freshforge_materialization.py`
- `.venv\Scripts\python.exe -m freshforge providers --json`
- `.venv\Scripts\python.exe -m freshforge validate external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge inspect external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge plan external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --json`
- `python -m freshforge run external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --workdir runtime/freshforge --namespace k3z/materialization --json`
- `sphinx-build -b html docs _build/html -W`
- `sphinx-build -b html docs docs\_build\html -W` from `external/femic-k3z-instance`

The bounded K3Z run wrote only ignored parent `runtime/freshforge/` output and did not enable `arbutus-s3` or run `datalad get`.

Closes #280 after the K3Z submodule pointer update lands.
