### PR TITLE
P103: Add TSA29 FreshForge materialization overlay

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19486,3 +19486,13 @@
   `0.1.0a5`.
 - Verified the selected TSA29 audit paths report no payload gaps with
   `git annex find --not --in arbutus-s3`.
+
+## 2026-07-02 - Closed P103 TSA29 FreshForge materialization overlay
+
+- Merged the TSA29 materialization PR and advanced the parent TSA29 submodule
+  pointer to merged TSA29 `main` commit `0570596`.
+- Re-ran parent-checkout `freshforge validate`, `freshforge inspect`, and
+  `freshforge plan` against the merged TSA29 materialization workflow.
+- Re-ran focused materialization provider tests and the selected TSA29
+  `arbutus-s3` payload audit after the pointer update.
+- Marked P103 complete in `ROADMAP.md`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19462,3 +19462,27 @@
 - Re-ran focused materialization provider tests after the pointer update.
 - Marked P102 complete in `ROADMAP.md`; TSA29 remains the next separate
   materialization acceptance case.
+
+## 2026-07-02 - Launched P103 TSA29 FreshForge materialization overlay
+
+- Opened parent issue `#282` and TSA29 issue
+  `UBC-FRESH/femic-tsa29-instance#21` for the fourth real FreshForge
+  model-instance materialization workflow.
+- Added `planning/phase103_tsa29_materialization_overlay.md` to record the
+  TSA29 boundary: annex-enabled materialization for the published model package
+  and editable validated export surface, not a TSR/THLB strict-chain
+  reconstruction workflow.
+- Created parent branch `feature/p103-tsa29-materialization-overlay` and TSA29
+  branch `feature/freshforge-materialization-overlay`.
+- Added TSA29-owned materialization overlay/workflow files that enable
+  `arbutus-s3`, materialize launch-critical model payloads plus
+  `output/patchworks_tsa29_validated`, install the editable TSA29 package, and
+  write ignored runtime reports.
+- Updated TSA29 README, getting-started docs, and rebuild runbook with the
+  released FreshForge `--workdir` / `--namespace` CLI shape.
+- Validated provider discovery, `freshforge validate`, `freshforge inspect`,
+  `freshforge plan`, and a bounded `freshforge run` against the TSA29
+  materialization workflow from the parent checkout using FreshForge
+  `0.1.0a5`.
+- Verified the selected TSA29 audit paths report no payload gaps with
+  `git annex find --not --in arbutus-s3`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3128,9 +3128,44 @@ plain-git storage mode without requiring DataLad/git-annex.
   - [x] Re-run parent validation after the pointer update.
   - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
+## Phase 103: FreshForge Materialization Overlay For TSA29 (`#282`)
+
+Status: in progress
+
+Goal: add TSA29 as the fourth model-instance materialization workflow using the
+generic `femic.materialization` provider, with annex-enabled DataLad/git-annex
+materialization through `arbutus-s3`.
+
+- [x] P103.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#282` and TSA29 issue
+        `UBC-FRESH/femic-tsa29-instance#21`.
+  - [x] Create parent branch `feature/p103-tsa29-materialization-overlay`.
+  - [x] Create TSA29 branch `feature/freshforge-materialization-overlay`.
+  - [x] Add `planning/phase103_tsa29_materialization_overlay.md`.
+- [x] P103.2 Add TSA29-owned overlay and workflow.
+  - [x] Add TSA29 materialization overlay and workflow YAML under
+        `external/femic-tsa29-instance/workflows/freshforge/`.
+  - [x] Use only the generic `femic.materialization.*` provider namespace.
+  - [x] Install the TSA29 editable package during materialization so TSA29-owned
+        FEMIC extension entry points are available after bootstrap.
+- [x] P103.3 Update TSA29 docs and validate surfaces.
+  - [x] Document parent-checkout materialization commands in TSA29 README,
+        getting-started docs, and rebuild runbook.
+  - [x] Run provider discovery, validate, inspect, and plan from the parent
+        checkout.
+  - [x] Run the bounded FreshForge materialization workflow from the parent
+        checkout.
+  - [x] Verify required payload availability and `arbutus-s3` remote coverage.
+- [ ] P103.4 Close out.
+  - [ ] Merge the TSA29 materialization PR first.
+  - [ ] Update the parent TSA29 submodule pointer.
+  - [ ] Re-run parent validation after the pointer update.
+  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
+  - `planning/phase103_tsa29_materialization_overlay.md`
   - `planning/phase102_k3z_materialization_overlay.md`
   - `planning/phase98_materialization_execution_surface.md`
   - `planning/phase98_freshforge_materialization_template.md`
@@ -3143,6 +3178,13 @@ plain-git storage mode without requiring DataLad/git-annex.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P103` / `#282` is active: the fourth real `femic.materialization`
+    FreshForge workflow targets the TSA29 submodule from the parent FEMIC
+    checkout. TSA29 is a DataLad/git-annex dataset, so the first overlay uses
+    `annex.enabled: true` and `arbutus-s3` for the launch-critical model
+    materialization path. Implementation and validation are complete locally;
+    next step is TSA29 PR review/merge, parent submodule pointer update, and
+    final closeout.
   - `P102` / `#280` is complete: the third real `femic.materialization`
     FreshForge workflow targets the K3Z submodule from the parent FEMIC
     checkout. K3Z is a plain-git snapshot, generic `annex.enabled: false`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3130,7 +3130,7 @@ plain-git storage mode without requiring DataLad/git-annex.
 
 ## Phase 103: FreshForge Materialization Overlay For TSA29 (`#282`)
 
-Status: in progress
+Status: complete
 
 Goal: add TSA29 as the fourth model-instance materialization workflow using the
 generic `femic.materialization` provider, with annex-enabled DataLad/git-annex
@@ -3156,11 +3156,11 @@ materialization through `arbutus-s3`.
   - [x] Run the bounded FreshForge materialization workflow from the parent
         checkout.
   - [x] Verify required payload availability and `arbutus-s3` remote coverage.
-- [ ] P103.4 Close out.
-  - [ ] Merge the TSA29 materialization PR first.
-  - [ ] Update the parent TSA29 submodule pointer.
-  - [ ] Re-run parent validation after the pointer update.
-  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+- [x] P103.4 Close out.
+  - [x] Merge the TSA29 materialization PR first.
+  - [x] Update the parent TSA29 submodule pointer.
+  - [x] Re-run parent validation after the pointer update.
+  - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
 ### Detailed Next Steps Notes
 
@@ -3178,13 +3178,12 @@ materialization through `arbutus-s3`.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P103` / `#282` is active: the fourth real `femic.materialization`
+  - `P103` / `#282` is complete: the fourth real `femic.materialization`
     FreshForge workflow targets the TSA29 submodule from the parent FEMIC
     checkout. TSA29 is a DataLad/git-annex dataset, so the first overlay uses
     `annex.enabled: true` and `arbutus-s3` for the launch-critical model
-    materialization path. Implementation and validation are complete locally;
-    next step is TSA29 PR review/merge, parent submodule pointer update, and
-    final closeout.
+    materialization path. The TSA29 PR has merged, the parent submodule pointer
+    has been updated, and merged-pointer validation passed.
   - `P102` / `#280` is complete: the third real `femic.materialization`
     FreshForge workflow targets the K3Z submodule from the parent FEMIC
     checkout. K3Z is a plain-git snapshot, generic `annex.enabled: false`

--- a/planning/phase103_tsa29_materialization_overlay.md
+++ b/planning/phase103_tsa29_materialization_overlay.md
@@ -1,0 +1,47 @@
+# Phase 103: TSA29 FreshForge Materialization Overlay
+
+## Purpose
+
+P103 adds TSA29 as the fourth real acceptance case for the reusable
+`femic.materialization` FreshForge provider. Unlike K3Z, TSA29 is a
+DataLad/git-annex dataset with an `arbutus-s3` special remote, so the workflow
+uses the annex-enabled materialization path.
+
+## Scope
+
+The first TSA29 overlay targets the parent FEMIC checkout with TSA29 mounted at
+`external/femic-tsa29-instance`.
+
+It materializes the launch-critical and rebuild-facing published package
+surfaces needed for the current TSA29 alpha snapshot:
+
+- `models/tsa29_patchworks_model/blocks`
+- `models/tsa29_patchworks_model/tracks`
+- `models/tsa29_patchworks_model/analysis`
+- `output/patchworks_tsa29_validated`
+- `config`
+- `workflows`
+
+The overlay installs the parent FEMIC package with `dev` and `freshforge`
+extras, then installs the TSA29 instance package editable so TSA29-owned FEMIC
+extension entry points are available after bootstrap.
+
+## Non-Goals
+
+P103 does not materialize the whole TSR/THLB reconstruction stack, run the
+strict locked-chain pipeline, rerun THLB recipes, regenerate model inputs, or
+change TSA29 scientific/runtime behavior. Those are separate analytical
+workflow phases.
+
+## Acceptance
+
+P103 is accepted when:
+
+- the TSA29 overlay and workflow are tracked under
+  `external/femic-tsa29-instance/workflows/freshforge/`;
+- parent-checkout `freshforge validate`, `inspect`, and `plan` pass;
+- a bounded parent-checkout `freshforge run --workdir runtime/freshforge
+  --namespace tsa29/materialization --json` succeeds;
+- `git annex find --not --in arbutus-s3 -- <audit paths>` reports no required
+  payload gaps; and
+- run reports remain ignored under `runtime/freshforge/`.


### PR DESCRIPTION
﻿## Summary

Adds the parent P103 planning/status lane for TSA29 FreshForge materialization and coordinates the TSA29 instance PR.

TSA29 is the fourth `femic.materialization` acceptance case after TFL6, MKRF, and K3Z. Unlike K3Z, TSA29 is a DataLad/git-annex dataset, so the instance overlay uses `annex.enabled: true` and `arbutus-s3`.

## Changes

- Added `planning/phase103_tsa29_materialization_overlay.md`.
- Added P103 roadmap and changelog entries.
- Recorded validation evidence for the TSA29 workflow.

## Dependent Instance PR

TSA29 workflow/docs live in `UBC-FRESH/femic-tsa29-instance#22`. After that PR merges, this parent branch should update the TSA29 submodule pointer, re-run validation, mark P103 complete, and close out.

## Validation

- `.venv\Scripts\python.exe -m freshforge providers --json`
- `.venv\Scripts\python.exe -m freshforge validate external/femic-tsa29-instance/workflows/freshforge/tsa29_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge inspect external/femic-tsa29-instance/workflows/freshforge/tsa29_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge plan external/femic-tsa29-instance/workflows/freshforge/tsa29_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge run external/femic-tsa29-instance/workflows/freshforge/tsa29_materialization_workflow.yaml --workdir runtime/freshforge --namespace tsa29/materialization --json`
- `git -C external/femic-tsa29-instance annex find --not --in arbutus-s3 -- models/tsa29_patchworks_model/blocks models/tsa29_patchworks_model/tracks models/tsa29_patchworks_model/analysis output/patchworks_tsa29_validated`
- `.venv\Scripts\python.exe -m pytest tests/test_freshforge_materialization.py`
- `sphinx-build -b html docs _build/html -W`
- `sphinx-build -b html docs docs\_build\html -W` from `external/femic-tsa29-instance`

The bounded TSA29 run wrote only ignored parent `runtime/freshforge/` output and the annex audit reported no required payload gaps.

Closes #282 after the TSA29 submodule pointer update lands.
