### PR TITLE
P104: FreshForge workflow discovery and user entry points

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19496,3 +19496,32 @@
 - Re-ran focused materialization provider tests and the selected TSA29
   `arbutus-s3` payload audit after the pointer update.
 - Marked P103 complete in `ROADMAP.md`.
+
+## 2026-07-02 - Launched P104 FreshForge workflow discovery
+
+- Opened parent issue `#284` and created branch
+  `feature/p104-freshforge-workflow-discovery`.
+- Added `planning/phase104_freshforge_workflow_discovery.md` to record the
+  generic checkout-scanning design.
+- Added `femic.freshforge_workflows` discovery helpers for workflows under
+  `examples/freshforge/` and `external/*/workflows/freshforge/`.
+- Added non-mutating CLI helpers:
+  `python -m femic freshforge workflows list`,
+  `python -m femic freshforge workflows list --json`, and
+  `python -m femic freshforge workflows commands PATH`.
+- Updated the FreshForge provider guide with the workflow discovery path and
+  released FreshForge command shape.
+
+## 2026-07-02 - Validated P104 FreshForge workflow discovery
+
+- Tightened discovery to workflow documents matching `*workflow.yaml`, so
+  overlay/config YAML files in FreshForge directories are not presented as
+  runnable workflows.
+- Verified `python -m femic freshforge workflows list --json` reports current
+  example and instance workflow documents without listing overlays.
+- Verified `python -m femic freshforge workflows commands
+  examples/freshforge/materialization_smoke_workflow.yaml` prints released
+  `freshforge validate`, `inspect`, `plan`, and `run --workdir
+  runtime/freshforge --namespace ... --json` commands.
+- Validation passed for Ruff, targeted mypy, focused discovery/docs/boundary
+  tests, and Sphinx warning-clean docs build.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3162,9 +3162,42 @@ materialization through `arbutus-s3`.
   - [x] Re-run parent validation after the pointer update.
   - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
+## Phase 104: FreshForge Workflow Discovery And User Entry Points (`#284`)
+
+Status: active
+
+Goal: add a small generic discovery layer so users can find existing
+FreshForge workflows without knowing repo internals.
+
+- [x] P104.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#284`.
+  - [x] Create branch `feature/p104-freshforge-workflow-discovery`.
+  - [x] Add `planning/phase104_freshforge_workflow_discovery.md`.
+- [x] P104.2 Add generic workflow discovery.
+  - [x] Scan `examples/freshforge/*workflow.yaml`.
+  - [x] Scan `external/*/workflows/freshforge/*workflow.yaml`.
+  - [x] Report workflow id/name, provider refs, kind, load status, and
+        diagnostics without hardcoding instance names.
+- [x] P104.3 Add user-facing CLI helpers.
+  - [x] Add `python -m femic freshforge workflows list`.
+  - [x] Add `python -m femic freshforge workflows list --json`.
+  - [x] Add `python -m femic freshforge workflows commands PATH`.
+  - [x] Keep the commands non-mutating and FreshForge imports lazy.
+- [x] P104.4 Update docs and validate.
+  - [x] Add a workflow discovery section to the FreshForge guide.
+  - [x] Run focused discovery tests and lint.
+  - [x] Run Sphinx docs with warnings as errors.
+  - [x] Confirm the boundary guard still rejects named-instance references in
+        `src/femic`.
+- [ ] P104.5 Close out.
+  - [ ] Update `CHANGE_LOG.md`.
+  - [ ] Post progress and closeout comments on issue `#284`.
+  - [ ] Open and merge the parent PR after checks pass.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
+  - `planning/phase104_freshforge_workflow_discovery.md`
   - `planning/phase103_tsa29_materialization_overlay.md`
   - `planning/phase102_k3z_materialization_overlay.md`
   - `planning/phase98_materialization_execution_surface.md`
@@ -3178,6 +3211,13 @@ materialization through `arbutus-s3`.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P104` / `#284` is active: add a generic FreshForge workflow discovery
+    layer and user-facing CLI helpers so users can list checked-out workflow
+    documents and print copy-paste `freshforge validate`, `inspect`, `plan`,
+    and `run --workdir runtime/freshforge --namespace ... --json` command
+    blocks without knowing the repo path layout. The helper, CLI, docs, focused
+    tests, Ruff, targeted mypy, boundary guard, and Sphinx validation now pass;
+    remaining work is branch/PR closeout.
   - `P103` / `#282` is complete: the fourth real `femic.materialization`
     FreshForge workflow targets the TSA29 submodule from the parent FEMIC
     checkout. TSA29 is a DataLad/git-annex dataset, so the first overlay uses

--- a/docs/guides/freshforge-provider-integration.rst
+++ b/docs/guides/freshforge-provider-integration.rst
@@ -34,6 +34,43 @@ For local development, install the editable checkout with:
 
 The extra currently pins ``freshforge==0.1.0a5``.
 
+Finding Available Workflows
+---------------------------
+
+FEMIC can list FreshForge workflow documents that are present in the current
+checkout. This is a discovery helper only; it does not validate, plan, or run
+the workflows:
+
+.. code-block:: bash
+
+   python -m femic freshforge workflows list
+   python -m femic freshforge workflows list --json
+
+The helper scans public-safe example workflow documents under
+``examples/freshforge`` and checked-out instance workflow documents under
+``external/*/workflows/freshforge``. Overlay/config YAML files are not listed
+as workflows. The helper reports the workflow path, parsed workflow id/name,
+provider references, and a broad workflow kind such as ``materialization`` or
+``model-build``.
+
+To print copy-paste FreshForge commands for a workflow, use:
+
+.. code-block:: bash
+
+   python -m femic freshforge workflows commands external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml
+
+The command helper prints the released FreshForge CLI shape:
+
+.. code-block:: bash
+
+   freshforge validate PATH
+   freshforge inspect PATH
+   freshforge plan PATH
+   freshforge run PATH --workdir runtime/freshforge --namespace NAME --json
+
+Use ``freshforge plan`` as the non-mutating preview. Use ``freshforge run``
+only when you are ready for the provider-owned workflow steps to run.
+
 Provider Discovery
 ------------------
 
@@ -81,9 +118,8 @@ The public-safe smoke workflow writes only a report and does not run
    freshforge plan examples/freshforge/materialization_smoke_workflow.yaml
    freshforge run examples/freshforge/materialization_smoke_workflow.yaml --workdir runtime/freshforge --namespace smoke --json
 
-Real MKRF, TFL6, K3Z, and TSA29 materialization overlays are later instance
-phases. They should use the same provider and overlay contract rather than
-adding instance names to FEMIC core.
+Real instance materialization overlays should use the same provider and
+overlay contract rather than adding instance names to FEMIC core.
 
 Generic Workflow Example
 ------------------------

--- a/planning/phase104_freshforge_workflow_discovery.md
+++ b/planning/phase104_freshforge_workflow_discovery.md
@@ -1,0 +1,43 @@
+# Phase 104: FreshForge Workflow Discovery
+
+P104 adds a small generic discovery layer for FreshForge workflow documents
+that already live in the FEMIC checkout or checked-out instance submodules.
+The goal is user entry, not new execution semantics.
+
+The discovery helper scans workflow documents:
+
+- `examples/freshforge/*workflow.yaml`
+- `external/*/workflows/freshforge/*workflow.yaml`
+
+Overlay/config YAML files in the same directories are intentionally not listed
+as workflows.
+
+The implementation must stay generic. It must not hardcode example instance
+names or require MKRF, TFL6, K3Z, TSA29, or any future instance to exist.
+Instance-specific workflow documents remain owned by instance repositories.
+
+The CLI entry point is:
+
+```powershell
+python -m femic freshforge workflows list
+python -m femic freshforge workflows list --json
+python -m femic freshforge workflows commands PATH
+```
+
+The `commands` helper prints released FreshForge CLI commands:
+
+```powershell
+freshforge validate PATH
+freshforge inspect PATH
+freshforge plan PATH
+freshforge run PATH --workdir runtime/freshforge --namespace NAME --json
+```
+
+The suggested namespace is derived from the workflow file name. For example,
+`foo_model_build_workflow.yaml` becomes `foo/model-build`, and
+`foo_materialization_workflow.yaml` becomes `foo/materialization`.
+
+P104 does not add new providers, change workflow YAML schemas, run workflows,
+or route command outputs differently. P105 should use this discovery surface as
+the user entry point before promoting the TFL6 model-build workflow into a full
+executable acceptance lane.

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -381,6 +381,16 @@ pipelines_app = typer.Typer(
     no_args_is_help=True,
     help="Resolve and run narrow proof-oriented named pipelines from runbooks.",
 )
+freshforge_app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    help="Inspect optional FreshForge workflow documents.",
+)
+freshforge_workflows_app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    help="Discover FreshForge workflows and print user commands.",
+)
 tsr_app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
@@ -10208,6 +10218,86 @@ def fansier_run_and_parse(
     )
 
 
+@freshforge_workflows_app.command("list")
+def freshforge_workflows_list(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit deterministic JSON instead of a text summary.",
+    ),
+) -> None:
+    """List FreshForge workflow documents discoverable from this checkout."""
+
+    from femic.freshforge_workflows import (
+        FreshForgeWorkflowDiscoveryError,
+        discover_freshforge_workflows,
+    )
+
+    try:
+        records = discover_freshforge_workflows(Path.cwd())
+    except FreshForgeWorkflowDiscoveryError as exc:
+        console.print(f"[red]FreshForge workflow discovery failed:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if json_output:
+        typer.echo(json.dumps([record.to_dict() for record in records], indent=2))
+        return
+
+    if not records:
+        console.print("No FreshForge workflow documents found.")
+        return
+
+    for record in records:
+        label = record.workflow_id or "(unreadable)"
+        console.print(f"{record.path.as_posix()} [{record.kind}] {label}")
+        if record.name:
+            console.print(f"  name: {record.name}")
+        if record.provider_refs:
+            console.print(f"  providers: {', '.join(record.provider_refs)}")
+        if record.diagnostics:
+            console.print(f"  diagnostics: {'; '.join(record.diagnostics)}")
+
+
+@freshforge_workflows_app.command("commands")
+def freshforge_workflows_commands(
+    workflow_path: Path = typer.Argument(
+        ...,
+        help="FreshForge workflow YAML path.",
+    ),
+    namespace: str | None = typer.Option(
+        None,
+        "--namespace",
+        help="Override the suggested FreshForge run namespace.",
+    ),
+    workdir: Path = typer.Option(
+        Path("runtime/freshforge"),
+        "--workdir",
+        help="FreshForge run work directory.",
+    ),
+) -> None:
+    """Print copy-paste FreshForge commands for a workflow document."""
+
+    from femic.freshforge_workflows import (
+        FreshForgeWorkflowDiscoveryError,
+        build_freshforge_command_block,
+    )
+
+    try:
+        commands = build_freshforge_command_block(
+            workflow_path,
+            namespace=namespace,
+            workdir=workdir,
+        )
+    except FreshForgeWorkflowDiscoveryError as exc:
+        console.print(
+            f"[red]FreshForge workflow command generation failed:[/red] {exc}"
+        )
+        raise typer.Exit(code=1) from exc
+
+    for command in commands:
+        typer.echo(command)
+
+
 app.add_typer(prep_app, name="prep")
 app.add_typer(vdyp_app, name="vdyp")
 app.add_typer(tsa_app, name="tsa")
@@ -10217,6 +10307,8 @@ app.add_typer(data_app, name="data")
 doc_app.add_typer(doc_figures_app, name="figures")
 app.add_typer(doc_app, name="doc")
 app.add_typer(pipelines_app, name="pipelines")
+freshforge_app.add_typer(freshforge_workflows_app, name="workflows")
+app.add_typer(freshforge_app, name="freshforge")
 app.add_typer(tsr_app, name="tsr")
 app.add_typer(export_app, name="export")
 patchworks_app.add_typer(patchworks_instances_app, name="instances")

--- a/src/femic/freshforge_workflows.py
+++ b/src/femic/freshforge_workflows.py
@@ -1,0 +1,193 @@
+"""Discovery helpers for FEMIC-adjacent FreshForge workflow documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class FreshForgeWorkflowDiscoveryError(RuntimeError):
+    """Raised when FreshForge workflow discovery cannot proceed."""
+
+
+@dataclass(frozen=True)
+class FreshForgeWorkflowRecord:
+    """Summary of a discovered FreshForge workflow document."""
+
+    path: Path
+    workflow_id: str | None
+    name: str | None
+    description: str | None
+    provider_refs: tuple[str, ...]
+    kind: str
+    load_status: str
+    diagnostics: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a deterministic JSON-serializable representation."""
+
+        return {
+            "path": self.path.as_posix(),
+            "workflow_id": self.workflow_id,
+            "name": self.name,
+            "description": self.description,
+            "provider_refs": list(self.provider_refs),
+            "kind": self.kind,
+            "load_status": self.load_status,
+            "diagnostics": list(self.diagnostics),
+        }
+
+
+def discover_freshforge_workflows(
+    root: str | Path = ".",
+) -> tuple[FreshForgeWorkflowRecord, ...]:
+    """Discover FreshForge workflow YAML files under a FEMIC checkout."""
+
+    checkout_root = Path(root)
+    records = [
+        _record_for_workflow(path=path, root=checkout_root)
+        for path in _iter_workflow_candidates(checkout_root)
+    ]
+    return tuple(sorted(records, key=lambda record: record.path.as_posix()))
+
+
+def build_freshforge_command_block(
+    workflow_path: str | Path,
+    *,
+    namespace: str | None = None,
+    workdir: str | Path = "runtime/freshforge",
+) -> tuple[str, ...]:
+    """Build copy-paste FreshForge commands for a workflow document."""
+
+    path = Path(workflow_path)
+    if not path.exists():
+        raise FreshForgeWorkflowDiscoveryError(f"FreshForge workflow not found: {path}")
+
+    path_text = path.as_posix()
+    namespace_text = namespace or suggest_freshforge_namespace(path)
+    workdir_text = Path(workdir).as_posix()
+    return (
+        f"freshforge validate {path_text}",
+        f"freshforge inspect {path_text}",
+        f"freshforge plan {path_text}",
+        (
+            f"freshforge run {path_text} --workdir {workdir_text} "
+            f"--namespace {namespace_text} --json"
+        ),
+    )
+
+
+def suggest_freshforge_namespace(workflow_path: str | Path) -> str:
+    """Suggest a generic namespace from a workflow filename."""
+
+    stem = Path(workflow_path).stem
+    tokens = [token for token in stem.replace("-", "_").split("_") if token]
+    if tokens and tokens[-1] == "workflow":
+        tokens = tokens[:-1]
+    if not tokens:
+        return "workflow"
+
+    if len(tokens) >= 2 and tokens[-2:] == ["model", "build"]:
+        prefix = tokens[:-2]
+        suffix = "model-build"
+    else:
+        prefix = tokens[:-1]
+        suffix = tokens[-1]
+
+    prefix_text = "-".join(prefix)
+    if prefix_text:
+        return f"{prefix_text}/{suffix}"
+    return suffix
+
+
+def _iter_workflow_candidates(root: Path) -> tuple[Path, ...]:
+    patterns = (
+        root / "examples" / "freshforge",
+        root / "external",
+    )
+    candidates: list[Path] = []
+    examples_root = patterns[0]
+    if examples_root.exists():
+        candidates.extend(examples_root.glob("*workflow.yaml"))
+
+    external_root = patterns[1]
+    if external_root.exists():
+        candidates.extend(external_root.glob("*/workflows/freshforge/*workflow.yaml"))
+
+    return tuple(
+        path.relative_to(root) if path.is_absolute() else path
+        for path in sorted(candidates, key=lambda value: value.as_posix())
+    )
+
+
+def _record_for_workflow(*, path: Path, root: Path) -> FreshForgeWorkflowRecord:
+    load_workflow = _freshforge_loader()
+    load_path = root / path
+    try:
+        spec, diagnostics = load_workflow(load_path)
+    except Exception as exc:  # pragma: no cover - defensive against parser changes.
+        return FreshForgeWorkflowRecord(
+            path=path,
+            workflow_id=None,
+            name=None,
+            description=None,
+            provider_refs=(),
+            kind="unknown",
+            load_status="error",
+            diagnostics=(str(exc),),
+        )
+
+    diagnostic_messages = tuple(_diagnostic_message(item) for item in diagnostics)
+    if spec is None:
+        return FreshForgeWorkflowRecord(
+            path=path,
+            workflow_id=None,
+            name=None,
+            description=None,
+            provider_refs=(),
+            kind="unknown",
+            load_status="error",
+            diagnostics=diagnostic_messages,
+        )
+
+    provider_refs = tuple(sorted({node.provider for node in spec.nodes}))
+    return FreshForgeWorkflowRecord(
+        path=path,
+        workflow_id=spec.id,
+        name=spec.name,
+        description=spec.description,
+        provider_refs=provider_refs,
+        kind=_classify_workflow(provider_refs),
+        load_status="ok" if not diagnostic_messages else "warning",
+        diagnostics=diagnostic_messages,
+    )
+
+
+def _freshforge_loader() -> Any:
+    try:
+        from freshforge.loading import load_workflow  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise FreshForgeWorkflowDiscoveryError(
+            "FreshForge workflow discovery requires the optional "
+            "`femic[freshforge]` dependency."
+        ) from exc
+    return load_workflow
+
+
+def _classify_workflow(provider_refs: tuple[str, ...]) -> str:
+    if any(ref.startswith("femic.materialization.") for ref in provider_refs):
+        return "materialization"
+    if any(ref.startswith("femic.") for ref in provider_refs):
+        return "model-build"
+    return "unknown"
+
+
+def _diagnostic_message(value: Any) -> str:
+    message = getattr(value, "message", None)
+    code = getattr(value, "code", None)
+    if code and message:
+        return f"{code}: {message}"
+    if message:
+        return str(message)
+    return str(value)

--- a/tests/test_freshforge_workflows.py
+++ b/tests/test_freshforge_workflows.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from femic.cli.main import app
+from femic.freshforge_workflows import (
+    FreshForgeWorkflowDiscoveryError,
+    build_freshforge_command_block,
+    discover_freshforge_workflows,
+    suggest_freshforge_namespace,
+)
+
+
+runner = CliRunner()
+
+
+def _write_workflow(path: Path, *, provider: str = "femic.validate_case") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "workflow:",
+                "  id: fixture_workflow",
+                "  name: Fixture workflow",
+                "nodes:",
+                "  - id: validate_case",
+                f"    provider: {provider}",
+                "    parameters:",
+                "      instance_root: .",
+                "      run_config: config/run_profile.fixture.yaml",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_discovery_finds_example_workflows() -> None:
+    records = discover_freshforge_workflows(Path("."))
+    paths = {record.path.as_posix() for record in records}
+
+    assert "examples/freshforge/model_build_workflow.yaml" in paths
+    assert "examples/freshforge/materialization_smoke_workflow.yaml" in paths
+    assert all(record.to_dict()["path"] == record.path.as_posix() for record in records)
+
+
+def test_discovery_finds_synthetic_external_workflow(tmp_path: Path) -> None:
+    workflow_path = (
+        tmp_path
+        / "external"
+        / "fixture-instance"
+        / "workflows"
+        / "freshforge"
+        / "fixture_model_build_workflow.yaml"
+    )
+    _write_workflow(workflow_path)
+
+    records = discover_freshforge_workflows(tmp_path)
+
+    assert [record.path.as_posix() for record in records] == [
+        "external/fixture-instance/workflows/freshforge/fixture_model_build_workflow.yaml"
+    ]
+    assert records[0].workflow_id == "fixture_workflow"
+    assert records[0].kind == "model-build"
+    assert records[0].provider_refs == ("femic.validate_case",)
+
+
+def test_discovery_classifies_materialization_workflow(tmp_path: Path) -> None:
+    workflow_path = (
+        tmp_path
+        / "external"
+        / "fixture-instance"
+        / "workflows"
+        / "freshforge"
+        / "fixture_materialization_workflow.yaml"
+    )
+    _write_workflow(
+        workflow_path,
+        provider="femic.materialization.check_toolchain",
+    )
+
+    records = discover_freshforge_workflows(tmp_path)
+
+    assert records[0].kind == "materialization"
+
+
+def test_discovery_reports_missing_freshforge(monkeypatch) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "freshforge.loading":
+            raise ImportError("missing freshforge")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    try:
+        discover_freshforge_workflows(Path("."))
+    except FreshForgeWorkflowDiscoveryError as exc:
+        assert "femic[freshforge]" in str(exc)
+    else:  # pragma: no cover - guards against a false-positive test.
+        raise AssertionError("expected FreshForgeWorkflowDiscoveryError")
+
+
+def test_namespace_suggestion_is_filename_driven() -> None:
+    assert (
+        suggest_freshforge_namespace(
+            "external/example/workflows/freshforge/foo_model_build_workflow.yaml"
+        )
+        == "foo/model-build"
+    )
+    assert (
+        suggest_freshforge_namespace(
+            "external/example/workflows/freshforge/foo_materialization_workflow.yaml"
+        )
+        == "foo/materialization"
+    )
+
+
+def test_command_block_uses_released_freshforge_cli_shape() -> None:
+    commands = build_freshforge_command_block(
+        Path("examples/freshforge/materialization_smoke_workflow.yaml")
+    )
+
+    assert commands == (
+        "freshforge validate examples/freshforge/materialization_smoke_workflow.yaml",
+        "freshforge inspect examples/freshforge/materialization_smoke_workflow.yaml",
+        "freshforge plan examples/freshforge/materialization_smoke_workflow.yaml",
+        (
+            "freshforge run examples/freshforge/materialization_smoke_workflow.yaml "
+            "--workdir runtime/freshforge --namespace materialization/smoke --json"
+        ),
+    )
+
+
+def test_command_block_rejects_missing_workflow() -> None:
+    try:
+        build_freshforge_command_block(Path("missing.yaml"))
+    except FreshForgeWorkflowDiscoveryError as exc:
+        assert "not found" in str(exc)
+    else:  # pragma: no cover - guards against a false-positive test.
+        raise AssertionError("expected FreshForgeWorkflowDiscoveryError")
+
+
+def test_cli_workflow_list_json() -> None:
+    result = runner.invoke(app, ["freshforge", "workflows", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    paths = {item["path"] for item in payload}
+    assert "examples/freshforge/model_build_workflow.yaml" in paths
+
+
+def test_cli_workflow_commands() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "freshforge",
+            "workflows",
+            "commands",
+            "examples/freshforge/materialization_smoke_workflow.yaml",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "freshforge validate examples/freshforge/materialization_smoke_workflow.yaml"
+        in result.output
+    )
+    assert "--workdir runtime/freshforge" in result.output
+    assert "--namespace materialization/smoke" in result.output
+    assert "--json" in result.output
+
+
+def test_cli_workflow_commands_rejects_missing_path() -> None:
+    result = runner.invoke(
+        app,
+        ["freshforge", "workflows", "commands", "missing.yaml"],
+    )
+
+    assert result.exit_code == 1
+    assert "not found" in result.output


### PR DESCRIPTION
## Summary

- adds generic FreshForge workflow discovery for `*workflow.yaml` documents under `examples/freshforge/` and checked-out instance workflow directories
- adds non-mutating `python -m femic freshforge workflows list`, `list --json`, and `commands PATH` helpers
- documents the workflow discovery path and records P104 planning/changelog updates

## Validation

- `python -m ruff format src tests`
- `python -m ruff check src tests`
- `python -m mypy src/femic/freshforge_workflows.py src/femic/cli/main.py`
- `python -m pytest tests/test_freshforge_workflows.py tests/test_docs_contract.py::test_guides_pages_are_in_docs_tree tests/test_instance_extension_boundaries.py`
- `sphinx-build -b html docs _build/html -W`

Closes #284 after merge.
