### PR TITLE
P105: TFL6 executable FreshForge model-build acceptance

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19609,5 +19609,16 @@
   Patchworks export, Patchworks preflight, and Matrix Builder.
 - Verified the clean run used BTC sub-run id
   `tfl6_freshforge_model_build_tfl6`, rebuilt the Patchworks export and
-  compiled tracks, and left no `tsatfl` matches in the source/test/TFL6
-  workspace search.
+  compiled tracks, and left no invalid combined TSA/TFL matches in the
+  source/test/TFL6 workspace search.
+
+## 2026-07-02 - Closed P105 TFL6 executable FreshForge acceptance
+
+- Merged the TFL6 Phase 19 PR and updated the parent FEMIC TFL6 submodule
+  pointer to the merged TFL6 `main` commit.
+- Revalidated the parent-checkout TFL6 FreshForge model-build workflow after
+  pointer reconciliation with FreshForge validation/planning, focused tests,
+  Ruff, targeted mypy, Sphinx, and the TFL6 annex publication audit.
+- Recorded final closeout status for parent issue `#286`, parent PR `#287`,
+  TFL6 issue `UBC-FRESH/femic-tfl6-instance#162`, and TFL6 PR
+  `UBC-FRESH/femic-tfl6-instance#163`.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19557,3 +19557,12 @@
 - Updated TFL6 docs and runbook text to route operators through P104 workflow
   discovery and the released `freshforge run --workdir ... --namespace ...`
   command shape.
+
+## 2026-07-02 - Fixed SiteProd maple alias exposed by P105 acceptance
+
+- The first P105 executable run reached TFL6 data prep and exposed a generic
+  SiteProd lookup gap for VRI maple species codes.
+- Added `M`, `MB`, and `MV` aliases to the existing SiteProd species lookup so
+  they resolve to the available `AT` SiteProd raster band.
+- Added focused test coverage and re-ran SiteProd plus FreshForge workflow
+  tests.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19543,3 +19543,17 @@
 - Added P105 roadmap subtasks for parent-checkout workflow updates, discovery
   path documentation, executable FreshForge run acceptance, direct output
   inspection, and closeout.
+
+## 2026-07-02 - Updated TFL6 model-build workflow for P105 execution
+
+- Updated the TFL6 model-build workflow to run from the parent FEMIC checkout by
+  using `instance_root: external/femic-tfl6-instance` for generic FEMIC
+  provider stages.
+- Kept workflow-owned run config, Patchworks config, bundle, checkpoint, output,
+  log, and artifact paths instance-relative.
+- Removed rebuild-spec validation from the first FreshForge node so
+  `femic.validate_case` runs the generic case preflight command; rebuild-spec
+  validation remains a separate documented FEMIC pre-run check.
+- Updated TFL6 docs and runbook text to route operators through P104 workflow
+  discovery and the released `freshforge run --workdir ... --namespace ...`
+  command shape.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19566,3 +19566,15 @@
   they resolve to the available `AT` SiteProd raster band.
 - Added focused test coverage and re-ran SiteProd plus FreshForge workflow
   tests.
+
+## 2026-07-02 - Recorded P105 executable model-build blocker
+
+- Re-ran the TFL6 FreshForge model-build workflow from the parent checkout with
+  `FEMIC_EXTERNAL_DATA_ROOT` and Arbutus auth loaded.
+- The run completed the `validate_case` and `geospatial_preflight` FreshForge
+  nodes, then failed in `femic.compile_upstream` during legacy TIPSY parameter
+  generation.
+- The active blocker is a TFL6 runtime/config decision: no TIPSY config rule
+  matched AU `1000` (`leading_species=HW`, `BEC=CWH`, `forest_type=1`).
+- P105 remains active; FreshForge discovery, validation, inspection, planning,
+  docs, focused tests, and the generic SiteProd alias fix are validated.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19578,3 +19578,36 @@
   matched AU `1000` (`leading_species=HW`, `BEC=CWH`, `forest_type=1`).
 - P105 remains active; FreshForge discovery, validation, inspection, planning,
   docs, focused tests, and the generic SiteProd alias fix are validated.
+
+## 2026-07-02 - Added accepted BTC handoff preflight for P105
+
+- Added the generic `femic.accepted_btc_handoff` FreshForge node and matching
+  `femic prep accepted-btc-handoff` command.
+- Rewired the TFL6 executable model-build workflow to consume the accepted
+  `03_input`, `04_output`, and treated-curve artifacts before running
+  `femic.btc_post_tipsy`.
+- Updated P105 planning and TFL6 docs to state that Phase 19 uses the accepted
+  BTC handoff boundary; production TIPSY rule reconstruction is deferred.
+
+## 2026-07-02 - Removed the spreadsheet requirement from the P105 BTC handoff
+
+- Updated the post-TIPSY freshness guard so the accepted BTC handoff path can
+  validate against the canonical BTC input CSV without requiring the legacy
+  TIPSY parameter spreadsheet.
+- Removed the legacy 01b script's spreadsheet lookup from the FreshForge
+  model-build path; `femic.btc_post_tipsy` now uses the declared accepted BTC
+  input CSV and BatchTIPSY output.
+- Added focused tests for CSV-only freshness, matching BTC input fingerprints,
+  and generic fingerprint-mismatch diagnostics.
+
+## 2026-07-02 - Completed the P105 TFL6 FreshForge executable acceptance run
+
+- Fixed remaining non-numeric case artifact naming seams so `tfl6` remains
+  `tfl6`; numeric cases still use the `tsaNN` convention.
+- Re-ran the parent-checkout FreshForge model-build workflow through case
+  preflight, geospatial preflight, accepted BTC handoff, BTC/post-TIPSY,
+  Patchworks export, Patchworks preflight, and Matrix Builder.
+- Verified the clean run used BTC sub-run id
+  `tfl6_freshforge_model_build_tfl6`, rebuilt the Patchworks export and
+  compiled tracks, and left no `tsatfl` matches in the source/test/TFL6
+  workspace search.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19532,3 +19532,14 @@
   `package-release-checks` passed.
 - Marked P104 complete in `ROADMAP.md`.
 - Posted final closeout details on issue `#284`; the issue is closed.
+
+## 2026-07-02 - Launched P105 TFL6 executable FreshForge model-build acceptance
+
+- Opened parent issue `#286` and TFL6 issue
+  `UBC-FRESH/femic-tfl6-instance#162`.
+- Created parent branch `feature/p105-tfl6-executable-model-build` and TFL6
+  branch `feature/p19-freshforge-executable-model-build`.
+- Added `planning/phase105_tfl6_executable_model_build.md`.
+- Added P105 roadmap subtasks for parent-checkout workflow updates, discovery
+  path documentation, executable FreshForge run acceptance, direct output
+  inspection, and closeout.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3194,9 +3194,54 @@ FreshForge workflows without knowing repo internals.
   - [x] Post progress and closeout comments on issue `#284`.
   - [x] Open and merge the parent PR after checks pass.
 
+## Phase 105: TFL6 Executable FreshForge Model-Build Acceptance (`#286`)
+
+Status: active
+
+Goal: promote the existing TFL6 model-build workflow from validation/planning
+into a parent-checkout `freshforge run` acceptance path through Patchworks
+Matrix Builder, using P104 workflow discovery as the user entry point and the
+generic `femic.*` provider stages as the execution surface.
+
+- [x] P105.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#286`.
+  - [x] Open TFL6 issue `UBC-FRESH/femic-tfl6-instance#162`.
+  - [x] Create parent branch `feature/p105-tfl6-executable-model-build`.
+  - [x] Create TFL6 branch `feature/p19-freshforge-executable-model-build`.
+  - [x] Add `planning/phase105_tfl6_executable_model_build.md`.
+- [ ] P105.2 Update the TFL6 model-build workflow for parent-checkout
+      execution.
+  - [ ] Change TFL6 workflow `instance_root` parameters from `.` to
+        `external/femic-tfl6-instance`.
+  - [ ] Keep run config, Patchworks config, bundle, checkpoint, output, log,
+        and artifact paths instance-relative.
+  - [ ] Remove `rebuild_spec` from the `validate_case` node so generic case
+        preflight remains the first workflow stage.
+- [ ] P105.3 Update operator docs and discovery path.
+  - [ ] Document `python -m femic freshforge workflows list`.
+  - [ ] Document `python -m femic freshforge workflows commands
+        external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml`.
+  - [ ] Document separate rebuild-spec validation before execution.
+  - [ ] State that materialization should run first when the TFL6 submodule is
+        thin or incomplete.
+- [ ] P105.4 Validate and run TFL6 executable acceptance.
+  - [ ] Run discovery, rendered commands, validate, inspect, and plan from the
+        parent checkout.
+  - [ ] Run the FreshForge model-build workflow with `--workdir
+        runtime/freshforge --namespace tfl6/model-build --json`.
+  - [ ] Inspect FreshForge run records, FEMIC runtime manifests, exported
+        Patchworks package, Matrix Builder manifest, compiled tracks, and TFL6
+        Git status.
+- [ ] P105.5 Close out.
+  - [ ] Merge the TFL6 PR first if workflow/docs changed.
+  - [ ] Update the parent TFL6 submodule pointer.
+  - [ ] Re-run parent validation after the pointer update.
+  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
+  - `planning/phase105_tfl6_executable_model_build.md`
   - `planning/phase104_freshforge_workflow_discovery.md`
   - `planning/phase103_tsa29_materialization_overlay.md`
   - `planning/phase102_k3z_materialization_overlay.md`
@@ -3211,6 +3256,11 @@ FreshForge workflows without knowing repo internals.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P105` / `#286` is active: TFL6 Phase 19 promotes the existing
+    TFL6-owned model-build graph into the first parent-checkout executable
+    FreshForge acceptance lane through Matrix Builder. The workflow remains
+    instance-owned under `external/femic-tfl6-instance`; FEMIC core keeps only
+    generic `femic.*` provider stages and P104 workflow discovery helpers.
   - `P104` / `#284` is complete: FEMIC now has generic FreshForge workflow
     discovery and user-facing CLI helpers so users can list checked-out
     workflow documents and print copy-paste `freshforge validate`, `inspect`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3224,14 +3224,20 @@ generic `femic.*` provider stages as the execution surface.
   - [x] Document separate rebuild-spec validation before execution.
   - [x] State that materialization should run first when the TFL6 submodule is
         thin or incomplete.
-- [ ] P105.4 Validate and run TFL6 executable acceptance.
+- [x] P105.4 Validate and run TFL6 executable acceptance.
   - [x] Run discovery, rendered commands, validate, inspect, and plan from the
         parent checkout.
   - [x] Resolve the generic SiteProd species alias gap exposed by TFL6
         broadleaf code `MB`.
-  - [ ] Run the FreshForge model-build workflow with `--workdir
+  - [x] Replace the blocked upstream compile node with a generic accepted BTC
+        handoff preflight that consumes the reviewed TFL6 `03_input`,
+        `04_output`, and treated-curve artifacts.
+  - [x] Remove the spreadsheet freshness requirement from the accepted BTC
+        handoff path so post-TIPSY execution only requires the canonical BTC
+        input CSV and recorded BatchTIPSY output.
+  - [x] Run the FreshForge model-build workflow with `--workdir
         runtime/freshforge --namespace tfl6/model-build --json`.
-  - [ ] Inspect FreshForge run records, FEMIC runtime manifests, exported
+  - [x] Inspect FreshForge run records, FEMIC runtime manifests, exported
         Patchworks package, Matrix Builder manifest, compiled tracks, and TFL6
         Git status.
 - [ ] P105.5 Close out.
@@ -3258,18 +3264,22 @@ generic `femic.*` provider stages as the execution surface.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P105` executable acceptance is partially validated but not closeable yet.
+  - `P105` executable acceptance has completed its parent-checkout run through
+    Matrix Builder and is now in closeout.
     The parent-checkout workflow discovery, command rendering, validate,
-    inspect, plan, rebuild-spec validation, focused FreshForge tests, Ruff, and
-    Sphinx checks pass. The explicit `freshforge run` reaches
-    `femic.compile_upstream` after successful case preflight and geospatial
-    preflight, but TFL6 legacy data prep then fails in TIPSY parameter
-    generation because no config rule matches AU `1000`
-    (`leading_species=HW`, `BEC=CWH`, `forest_type=1`). This is a TFL6
-    executable-model-build blocker, not a FreshForge discovery/planning
-    blocker. The first runtime blocker, missing SiteProd aliases for VRI maple
-    species codes, was fixed generically by mapping `M`, `MB`, and `MV` to the
-    available `AT` SiteProd band.
+    plan, rebuild-spec validation, focused FreshForge tests, Ruff, and Sphinx
+    checks pass. The first runtime blocker, missing SiteProd aliases for VRI
+    maple species codes, was fixed generically by mapping `M`, `MB`, and `MV`
+    to the available `AT` SiteProd band. The second blocker, legacy upstream
+    compile trying to regenerate production TIPSY parameters for AU `1000`, is
+    being resolved by switching the TFL6 executable workflow to a generic
+    accepted BTC handoff preflight before `femic.btc_post_tipsy`. This consumes
+    the reviewed TFL6 BTC input CSV, `04_output`, and treated-curve artifacts
+    instead of reopening production TIPSY rule reconstruction or spreadsheet
+    regeneration in P105. The successful run rebuilt the Patchworks export and
+    Matrix Builder tracks with `btc` sub-run id
+    `tfl6_freshforge_model_build_tfl6`; no `tsatfl` source/test/TFL6 matches
+    remain after cleanup.
   - `P105` / `#286` is active: TFL6 Phase 19 promotes the existing
     TFL6-owned model-build graph into the first parent-checkout executable
     FreshForge acceptance lane through Matrix Builder. The workflow remains

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3225,8 +3225,10 @@ generic `femic.*` provider stages as the execution surface.
   - [x] State that materialization should run first when the TFL6 submodule is
         thin or incomplete.
 - [ ] P105.4 Validate and run TFL6 executable acceptance.
-  - [ ] Run discovery, rendered commands, validate, inspect, and plan from the
+  - [x] Run discovery, rendered commands, validate, inspect, and plan from the
         parent checkout.
+  - [x] Resolve the generic SiteProd species alias gap exposed by TFL6
+        broadleaf code `MB`.
   - [ ] Run the FreshForge model-build workflow with `--workdir
         runtime/freshforge --namespace tfl6/model-build --json`.
   - [ ] Inspect FreshForge run records, FEMIC runtime manifests, exported

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3209,20 +3209,20 @@ generic `femic.*` provider stages as the execution surface.
   - [x] Create parent branch `feature/p105-tfl6-executable-model-build`.
   - [x] Create TFL6 branch `feature/p19-freshforge-executable-model-build`.
   - [x] Add `planning/phase105_tfl6_executable_model_build.md`.
-- [ ] P105.2 Update the TFL6 model-build workflow for parent-checkout
+- [x] P105.2 Update the TFL6 model-build workflow for parent-checkout
       execution.
-  - [ ] Change TFL6 workflow `instance_root` parameters from `.` to
+  - [x] Change TFL6 workflow `instance_root` parameters from `.` to
         `external/femic-tfl6-instance`.
-  - [ ] Keep run config, Patchworks config, bundle, checkpoint, output, log,
+  - [x] Keep run config, Patchworks config, bundle, checkpoint, output, log,
         and artifact paths instance-relative.
-  - [ ] Remove `rebuild_spec` from the `validate_case` node so generic case
+  - [x] Remove `rebuild_spec` from the `validate_case` node so generic case
         preflight remains the first workflow stage.
-- [ ] P105.3 Update operator docs and discovery path.
-  - [ ] Document `python -m femic freshforge workflows list`.
-  - [ ] Document `python -m femic freshforge workflows commands
+- [x] P105.3 Update operator docs and discovery path.
+  - [x] Document `python -m femic freshforge workflows list`.
+  - [x] Document `python -m femic freshforge workflows commands
         external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml`.
-  - [ ] Document separate rebuild-spec validation before execution.
-  - [ ] State that materialization should run first when the TFL6 submodule is
+  - [x] Document separate rebuild-spec validation before execution.
+  - [x] State that materialization should run first when the TFL6 submodule is
         thin or incomplete.
 - [ ] P105.4 Validate and run TFL6 executable acceptance.
   - [ ] Run discovery, rendered commands, validate, inspect, and plan from the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3258,6 +3258,18 @@ generic `femic.*` provider stages as the execution surface.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
+  - `P105` executable acceptance is partially validated but not closeable yet.
+    The parent-checkout workflow discovery, command rendering, validate,
+    inspect, plan, rebuild-spec validation, focused FreshForge tests, Ruff, and
+    Sphinx checks pass. The explicit `freshforge run` reaches
+    `femic.compile_upstream` after successful case preflight and geospatial
+    preflight, but TFL6 legacy data prep then fails in TIPSY parameter
+    generation because no config rule matches AU `1000`
+    (`leading_species=HW`, `BEC=CWH`, `forest_type=1`). This is a TFL6
+    executable-model-build blocker, not a FreshForge discovery/planning
+    blocker. The first runtime blocker, missing SiteProd aliases for VRI maple
+    species codes, was fixed generically by mapping `M`, `MB`, and `MV` to the
+    available `AT` SiteProd band.
   - `P105` / `#286` is active: TFL6 Phase 19 promotes the existing
     TFL6-owned model-build graph into the first parent-checkout executable
     FreshForge acceptance lane through Matrix Builder. The workflow remains

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3240,11 +3240,11 @@ generic `femic.*` provider stages as the execution surface.
   - [x] Inspect FreshForge run records, FEMIC runtime manifests, exported
         Patchworks package, Matrix Builder manifest, compiled tracks, and TFL6
         Git status.
-- [ ] P105.5 Close out.
-  - [ ] Merge the TFL6 PR first if workflow/docs changed.
-  - [ ] Update the parent TFL6 submodule pointer.
-  - [ ] Re-run parent validation after the pointer update.
-  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+- [x] P105.5 Close out.
+  - [x] Merge the TFL6 PR first if workflow/docs changed.
+  - [x] Update the parent TFL6 submodule pointer.
+  - [x] Re-run parent validation after the pointer update.
+  - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
 ### Detailed Next Steps Notes
 
@@ -3265,7 +3265,9 @@ generic `femic.*` provider stages as the execution surface.
   - `planning/roadmap_notes_archive.md`
 - Current edge:
   - `P105` executable acceptance has completed its parent-checkout run through
-    Matrix Builder and is now in closeout.
+    Matrix Builder and the TFL6 instance PR has been merged.
+    Parent FEMIC now points at the merged TFL6 `main` commit and is in final
+    PR/issue closeout.
     The parent-checkout workflow discovery, command rendering, validate,
     plan, rebuild-spec validation, focused FreshForge tests, Ruff, and Sphinx
     checks pass. The first runtime blocker, missing SiteProd aliases for VRI
@@ -3278,8 +3280,8 @@ generic `femic.*` provider stages as the execution surface.
     instead of reopening production TIPSY rule reconstruction or spreadsheet
     regeneration in P105. The successful run rebuilt the Patchworks export and
     Matrix Builder tracks with `btc` sub-run id
-    `tfl6_freshforge_model_build_tfl6`; no `tsatfl` source/test/TFL6 matches
-    remain after cleanup.
+    `tfl6_freshforge_model_build_tfl6`; no invalid combined TSA/TFL
+    source/test/TFL6 matches remain after cleanup.
   - `P105` / `#286` is active: TFL6 Phase 19 promotes the existing
     TFL6-owned model-build graph into the first parent-checkout executable
     FreshForge acceptance lane through Matrix Builder. The workflow remains

--- a/planning/phase105_tfl6_executable_model_build.md
+++ b/planning/phase105_tfl6_executable_model_build.md
@@ -1,0 +1,77 @@
+# Phase 105: TFL6 Executable FreshForge Model-Build Acceptance
+
+## Purpose
+
+P105 promotes the existing TFL6 FreshForge model-build workflow from a
+validate/inspect/plan contract into the first executable parent-checkout model
+build acceptance lane. The acceptance target is a full `freshforge run` through
+the generic FEMIC provider stages and Patchworks Matrix Builder.
+
+## Boundary
+
+- The workflow document remains owned by the TFL6 instance repository.
+- FEMIC core keeps only generic `femic.*` FreshForge provider stages.
+- No `tfl6.*` provider is added in this phase.
+- FreshForge schema and execution semantics are unchanged.
+- Materialization remains a prerequisite workflow family; P105 assumes the TFL6
+  submodule has already been materialized enough to run model-build commands.
+
+## Execution Shape
+
+The workflow should be run from the parent FEMIC checkout:
+
+```powershell
+freshforge run external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml --workdir runtime/freshforge --namespace tfl6/model-build --json
+```
+
+The workflow nodes continue to use generic provider references:
+
+- `femic.validate_case`
+- `femic.geospatial_preflight`
+- `femic.compile_upstream`
+- `femic.btc_post_tipsy`
+- `femic.export_patchworks`
+- `femic.patchworks_preflight`
+- `femic.matrix_build`
+
+The TFL6 workflow must use `instance_root: external/femic-tfl6-instance` so the
+same document works from the parent checkout. Run config, Patchworks config,
+bundle, checkpoint, output, log, and artifact paths stay instance-relative
+because the FEMIC CLI resolves them against `instance_root`.
+
+## Pre-Run Checks
+
+Before the executable run, operators should use P104 workflow discovery and
+non-mutating FreshForge checks:
+
+```powershell
+python -m femic freshforge workflows list
+python -m femic freshforge workflows commands external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml
+freshforge validate external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml
+freshforge inspect external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml
+freshforge plan external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml
+```
+
+Rebuild-spec validation remains a separate pre-run FEMIC check:
+
+```powershell
+python -m femic instance validate-spec --instance-root external/femic-tfl6-instance --spec config/rebuild.spec.yaml
+```
+
+## Acceptance Evidence
+
+P105 is complete only after the executable run finishes and the rebuilt output
+surface is inspected directly:
+
+- FreshForge run record under parent `runtime/freshforge/`.
+- FEMIC runtime manifests under
+  `external/femic-tfl6-instance/runtime/logs/`.
+- Exported Patchworks package under
+  `external/femic-tfl6-instance/output/patchworks_tfl6_mp11_harvest_system_candidate/`.
+- Matrix Builder manifest.
+- Compiled tracks under
+  `external/femic-tfl6-instance/models/tfl6_patchworks_model_mp11_harvest_system_candidate/tracks`.
+- TFL6 Git status after execution.
+
+Tracked model-output changes are reviewable rebuild output. They should be
+committed only when expected and validated.

--- a/planning/phase105_tfl6_executable_model_build.md
+++ b/planning/phase105_tfl6_executable_model_build.md
@@ -28,7 +28,7 @@ The workflow nodes continue to use generic provider references:
 
 - `femic.validate_case`
 - `femic.geospatial_preflight`
-- `femic.compile_upstream`
+- `femic.accepted_btc_handoff`
 - `femic.btc_post_tipsy`
 - `femic.export_patchworks`
 - `femic.patchworks_preflight`
@@ -38,6 +38,12 @@ The TFL6 workflow must use `instance_root: external/femic-tfl6-instance` so the
 same document works from the parent checkout. Run config, Patchworks config,
 bundle, checkpoint, output, log, and artifact paths stay instance-relative
 because the FEMIC CLI resolves them against `instance_root`.
+
+P105 uses the accepted TFL6 BTC handoff artifacts recorded in the instance
+run profile and planning surfaces. It does not regenerate production TIPSY
+parameter rules from raw upstream inputs. The accepted-handoff node checks the
+declared BTC input/output and treated-curve artifacts before the workflow
+continues to `femic.btc_post_tipsy`.
 
 ## Pre-Run Checks
 
@@ -75,3 +81,23 @@ surface is inspected directly:
 
 Tracked model-output changes are reviewable rebuild output. They should be
 committed only when expected and validated.
+
+## Acceptance Result
+
+The parent-checkout acceptance run completed on 2026-07-02 with:
+
+- `freshforge run ... --workdir runtime/freshforge --namespace tfl6/model-build --json`
+  returning `ok: true`;
+- all seven workflow nodes succeeding;
+- BTC sub-run id `tfl6_freshforge_model_build_tfl6`;
+- Matrix Builder manifest `returncode: 0`;
+- `accounts_sync.status: synced`;
+- Patchworks export rebuilt under
+  `external/femic-tfl6-instance/output/patchworks_tfl6_mp11_harvest_system_candidate/`;
+- compiled tracks rebuilt under
+  `external/femic-tfl6-instance/models/tfl6_patchworks_model_mp11_harvest_system_candidate/tracks`;
+- no `tsatfl` matches remaining in the source/test/TFL6 workspace search.
+
+The run intentionally uses the accepted BTC input CSV and accepted BatchTIPSY
+output. It does not require or regenerate the legacy TIPSY parameter
+spreadsheet.

--- a/planning/phase105_tfl6_executable_model_build.md
+++ b/planning/phase105_tfl6_executable_model_build.md
@@ -96,7 +96,8 @@ The parent-checkout acceptance run completed on 2026-07-02 with:
   `external/femic-tfl6-instance/output/patchworks_tfl6_mp11_harvest_system_candidate/`;
 - compiled tracks rebuilt under
   `external/femic-tfl6-instance/models/tfl6_patchworks_model_mp11_harvest_system_candidate/tracks`;
-- no `tsatfl` matches remaining in the source/test/TFL6 workspace search.
+- no invalid combined TSA/TFL matches remaining in the source/test/TFL6
+  workspace search.
 
 The run intentionally uses the accepted BTC input CSV and accepted BatchTIPSY
 output. It does not require or regenerate the legacy TIPSY parameter

--- a/src/femic/cli/main.py
+++ b/src/femic/cli/main.py
@@ -1108,6 +1108,45 @@ CASE_STRICT_WARNINGS_OPTION = typer.Option(
     "--strict-warnings",
     help="Fail preflight when warnings are present.",
 )
+ACCEPTED_BTC_INPUT_OPTION = typer.Option(
+    ...,
+    "--btc-input",
+    help="Accepted BatchTIPSY input CSV path, resolved under the instance root.",
+)
+ACCEPTED_BTC_OUTPUT_OPTION = typer.Option(
+    ...,
+    "--btc-output",
+    help="Accepted BatchTIPSY output CSV path, resolved under the instance root.",
+)
+ACCEPTED_BTC_TREATED_CURVES_OPTION = typer.Option(
+    ...,
+    "--treated-curves",
+    help="Accepted treated-curve table path, resolved under the instance root.",
+)
+ACCEPTED_BTC_ERROR_OPTION = typer.Option(
+    None,
+    "--btc-error",
+    help="Optional accepted BatchTIPSY error CSV path, resolved under the instance root.",
+    show_default=False,
+)
+ACCEPTED_BTC_TREATED_CURVE_DIAGNOSTICS_OPTION = typer.Option(
+    None,
+    "--treated-curve-diagnostics",
+    help="Optional treated-curve diagnostics path, resolved under the instance root.",
+    show_default=False,
+)
+ACCEPTED_BTC_PARAMETER_CROSSWALK_OPTION = typer.Option(
+    None,
+    "--tipsy-parameter-crosswalk",
+    help="Optional TIPSY parameter crosswalk path, resolved under the instance root.",
+    show_default=False,
+)
+ACCEPTED_BTC_CURVE_ID_MAP_OPTION = typer.Option(
+    None,
+    "--curve-id-map",
+    help="Optional accepted BTC curve-id map path, resolved under the instance root.",
+    show_default=False,
+)
 ARCGIS_REVIEW_OUTPUT_DIR_OPTION = typer.Option(
     None,
     "--output-dir",
@@ -6783,6 +6822,95 @@ def prep_validate_case(
         f"[green]Case preflight passed[/green] run_config={resolved_run_config} "
         f"targets=[{targets}] tipsy_config_dir={resolved_tipsy_config_dir}"
     )
+
+
+def _validate_required_nonempty_file(
+    *,
+    label: str,
+    path: Path,
+    errors: list[str],
+) -> None:
+    if not path.exists():
+        errors.append(f"Missing {label}: {path}")
+        return
+    if not path.is_file():
+        errors.append(f"{label} is not a file: {path}")
+        return
+    if path.stat().st_size <= 0:
+        errors.append(f"{label} is empty: {path}")
+
+
+def _validate_optional_existing_file(
+    *,
+    label: str,
+    path: Path | None,
+    errors: list[str],
+) -> None:
+    if path is None:
+        return
+    if not path.exists():
+        errors.append(f"Missing optional {label}: {path}")
+        return
+    if not path.is_file():
+        errors.append(f"Optional {label} is not a file: {path}")
+
+
+@prep_app.command("accepted-btc-handoff")
+def prep_accepted_btc_handoff(
+    btc_input: Path = ACCEPTED_BTC_INPUT_OPTION,
+    btc_output: Path = ACCEPTED_BTC_OUTPUT_OPTION,
+    treated_curves: Path = ACCEPTED_BTC_TREATED_CURVES_OPTION,
+    btc_error: Path | None = ACCEPTED_BTC_ERROR_OPTION,
+    treated_curve_diagnostics: Path | None = (
+        ACCEPTED_BTC_TREATED_CURVE_DIAGNOSTICS_OPTION
+    ),
+    tipsy_parameter_crosswalk: Path | None = ACCEPTED_BTC_PARAMETER_CROSSWALK_OPTION,
+    curve_id_map: Path | None = ACCEPTED_BTC_CURVE_ID_MAP_OPTION,
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Validate accepted BTC handoff artifacts before post-TIPSY assembly."""
+    instance_context = _resolve_cli_instance_context(instance_root=instance_root)
+    required_paths = {
+        "BTC input": instance_context.resolve_path(btc_input),
+        "BTC output": instance_context.resolve_path(btc_output),
+        "treated curves": instance_context.resolve_path(treated_curves),
+    }
+    optional_paths: dict[str, Path | None] = {
+        "BTC error": instance_context.resolve_path(btc_error)
+        if btc_error is not None
+        else None,
+        "treated-curve diagnostics": instance_context.resolve_path(
+            treated_curve_diagnostics
+        )
+        if treated_curve_diagnostics is not None
+        else None,
+        "TIPSY parameter crosswalk": instance_context.resolve_path(
+            tipsy_parameter_crosswalk
+        )
+        if tipsy_parameter_crosswalk is not None
+        else None,
+        "curve-id map": instance_context.resolve_path(curve_id_map)
+        if curve_id_map is not None
+        else None,
+    }
+
+    errors: list[str] = []
+    for label, path in required_paths.items():
+        _validate_required_nonempty_file(label=label, path=path, errors=errors)
+    for label, optional_path in optional_paths.items():
+        _validate_optional_existing_file(label=label, path=optional_path, errors=errors)
+
+    if errors:
+        for message in errors:
+            console.print(f"[red]Error:[/red] {message}")
+        raise typer.Exit(code=1)
+
+    console.print("[green]Accepted BTC handoff preflight passed[/green]")
+    for label, path in required_paths.items():
+        console.print(f"{label}: {path}")
+    for label, optional_path in optional_paths.items():
+        if optional_path is not None:
+            console.print(f"{label}: {optional_path}")
 
 
 @prep_app.command("geospatial-preflight")

--- a/src/femic/freshforge.py
+++ b/src/femic/freshforge.py
@@ -58,6 +58,15 @@ _NODE_CONTRACTS: tuple[_NodeContract, ...] = (
         artifacts=("run_manifest",),
     ),
     _NodeContract(
+        id="accepted_btc_handoff",
+        name="Accepted BTC handoff",
+        description="Declare an accepted BTC input/output handoff preflight.",
+        inputs=("geospatial_runtime",),
+        outputs=("btc_handoff",),
+        parameters=("instance_root", "btc_input", "btc_output", "treated_curves"),
+        artifacts=("btc_input", "btc_output", "treated_curves"),
+    ),
+    _NodeContract(
         id="btc_post_tipsy",
         name="BTC and post-TIPSY bundle",
         description="Declare the unattended BTC and Stage 01b bundle seam.",
@@ -413,6 +422,7 @@ def _generic_command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...
         "validate_case": _build_validate_case_command,
         "geospatial_preflight": _build_geospatial_preflight_command,
         "compile_upstream": _build_compile_upstream_command,
+        "accepted_btc_handoff": _build_accepted_btc_handoff_command,
         "btc_post_tipsy": _build_btc_post_tipsy_command,
         "export_patchworks": _build_export_patchworks_command,
         "patchworks_preflight": _build_patchworks_preflight_command,
@@ -463,6 +473,32 @@ def _build_compile_upstream_command(node: Any, _context: Any) -> tuple[str, ...]
         )
     )
     _append_option(command, node, "log_dir", "--log-dir")
+    return tuple(command)
+
+
+def _build_accepted_btc_handoff_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "prep",
+            "accepted-btc-handoff",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--btc-input",
+            _parameter(node, "btc_input"),
+            "--btc-output",
+            _parameter(node, "btc_output"),
+            "--treated-curves",
+            _parameter(node, "treated_curves"),
+        )
+    )
+    _append_option(command, node, "btc_error", "--btc-error")
+    _append_option(
+        command, node, "treated_curve_diagnostics", "--treated-curve-diagnostics"
+    )
+    _append_option(
+        command, node, "tipsy_parameter_crosswalk", "--tipsy-parameter-crosswalk"
+    )
+    _append_option(command, node, "curve_id_map", "--curve-id-map")
     return tuple(command)
 
 

--- a/src/femic/pipeline/legacy_runtime.py
+++ b/src/femic/pipeline/legacy_runtime.py
@@ -41,6 +41,7 @@ class Legacy01BRuntimeConfig:
 
     tipsy_params_path_prefix: str | Path
     tipsy_output_root: str | Path
+    tipsy_input_filename_template: str = "03_input-tsa{tsa}.csv"
     tipsy_output_filename_template: str = "04_output-tsa{tsa}.csv"
 
 
@@ -103,11 +104,13 @@ def build_legacy_01b_runtime_config(
     *,
     tipsy_params_path_prefix: str | Path,
     tipsy_output_root: str | Path = "data",
+    tipsy_input_filename_template: str = "03_input-tsa{tsa}.csv",
     tipsy_output_filename_template: str = "04_output-tsa{tsa}.csv",
 ) -> Legacy01BRuntimeConfig:
     """Build typed runtime config payload for a single 01b TSA run."""
     return Legacy01BRuntimeConfig(
         tipsy_params_path_prefix=tipsy_params_path_prefix,
         tipsy_output_root=tipsy_output_root,
+        tipsy_input_filename_template=tipsy_input_filename_template,
         tipsy_output_filename_template=tipsy_output_filename_template,
     )

--- a/src/femic/pipeline/siteprod.py
+++ b/src/femic/pipeline/siteprod.py
@@ -74,6 +74,9 @@ def _export_siteprod_layers_arcgis_batch(
 
 DEFAULT_SITEPROD_SPECIES_LOOKUP: dict[str, str] = {
     "AC": "AT",
+    "M": "AT",
+    "MB": "AT",
+    "MV": "AT",
     "PLI": "PL",
     "FDI": "FD",
     "S": "SW",

--- a/src/femic/pipeline/tipsy.py
+++ b/src/femic/pipeline/tipsy.py
@@ -3306,6 +3306,13 @@ def btc_msyt_input_csv_path(
     return Path(input_root) / filename_template.format(tsa=tsa)
 
 
+def _legacy_case_artifact_code(value: str) -> str:
+    raw = str(value).strip().lower()
+    if raw.isdigit():
+        return f"tsa{raw.zfill(2)}"
+    return raw
+
+
 def tipsy_stage_output_paths(
     *,
     tsa: str,
@@ -3313,15 +3320,16 @@ def tipsy_stage_output_paths(
 ) -> tuple[Path, Path]:
     """Build legacy 01b per-TSA output CSV paths."""
     root = Path(output_root)
+    artifact_code = _legacy_case_artifact_code(tsa)
     return (
-        root / f"tipsy_curves_tsa{tsa}.csv",
-        root / f"tipsy_sppcomp_tsa{tsa}.csv",
+        root / f"tipsy_curves_{artifact_code}.csv",
+        root / f"tipsy_sppcomp_{artifact_code}.csv",
     )
 
 
 def validate_tipsy_output_is_fresh(
     *,
-    tipsy_input_excel_path: str | Path,
+    tipsy_input_excel_path: str | Path | None = None,
     btc_input_csv_path: str | Path | None = None,
     tipsy_output_path: str | Path,
     allow_stale: bool = False,
@@ -3330,7 +3338,7 @@ def validate_tipsy_output_is_fresh(
     """Fail fast when BatchTIPSY output is stale against canonical BTC CSV input."""
     if allow_stale:
         return
-    excel_path = Path(tipsy_input_excel_path)
+    excel_path = Path(tipsy_input_excel_path) if tipsy_input_excel_path else None
     input_csv_path = Path(btc_input_csv_path) if btc_input_csv_path else None
     output_path = Path(tipsy_output_path)
     if not output_path.is_file():
@@ -3338,7 +3346,7 @@ def validate_tipsy_output_is_fresh(
     if input_csv_path is not None and not input_csv_path.is_file():
         raise RuntimeError(
             "Missing canonical BatchTIPSY input CSV file: "
-            f"{input_csv_path}. Generate 03_input-tsaXX.csv in Stage 01a before "
+            f"{input_csv_path}. Provide the accepted BTC input CSV before "
             "running Stage 01b/post-TIPSY."
         )
 
@@ -3357,53 +3365,68 @@ def validate_tipsy_output_is_fresh(
                 raise RuntimeError(
                     "Stale BatchTIPSY output detected: "
                     f"{output_path} was recorded against a different "
-                    f"03_input-tsaXX.csv fingerprint ({known_sha} != {input_sha256}). "
-                    "Regenerate 04_output-tsaXX.csv from the current "
-                    "03_input-tsaXX.csv handoff, then rerun FEMIC stage "
+                    "canonical BTC input CSV fingerprint "
+                    f"({known_sha} != {input_sha256}). "
+                    "Regenerate the BatchTIPSY output from the current "
+                    "accepted BTC input CSV handoff, then rerun FEMIC stage "
                     "01b/post-TIPSY."
                 )
             return
         input_mtime = input_csv_path.stat().st_mtime
-    elif excel_path.is_file():
+    elif excel_path is not None and excel_path.is_file():
         input_mtime = excel_path.stat().st_mtime
     else:
         return
 
     output_mtime = output_path.stat().st_mtime
     if output_mtime < input_mtime:
-        coherence = assess_tipsy_input_output_coherence(
-            tipsy_input_excel_path=excel_path,
-            tipsy_output_path=output_path,
-        )
-        if coherence.coherent:
-            detail = (
-                "Timestamp mismatch detected but TIPSY input/output appear coherent: "
-                f"{coherence.summary}"
+        if input_csv_path is not None and excel_path is None:
+            raise RuntimeError(
+                "Stale BatchTIPSY output detected: "
+                f"{output_path} is older than {input_csv_path}. "
+                "Regenerate the BatchTIPSY output from the current accepted BTC "
+                "input CSV handoff, then rerun FEMIC stage 01b/post-TIPSY. "
+                "Future reruns can avoid repeated timestamp prompts when CSV "
+                "content is unchanged once a fingerprint is recorded."
             )
-            if strict_timestamp_mismatch:
-                raise RuntimeError(
-                    "Strict BatchTIPSY freshness is enabled and "
-                    f"{output_path} is older than {input_csv_path or excel_path}. "
-                    f"{detail} Regenerate 04_output-tsaXX.csv from current "
-                    "03_input-tsaXX.csv before rerunning."
+
+        if excel_path is not None:
+            coherence = assess_tipsy_input_output_coherence(
+                tipsy_input_excel_path=excel_path,
+                tipsy_output_path=output_path,
+            )
+            if coherence.coherent:
+                detail = (
+                    "Timestamp mismatch detected but TIPSY input/output appear coherent: "
+                    f"{coherence.summary}"
                 )
-            warnings.warn(
-                detail
-                + " Continuing with existing 04_output-tsaXX.csv (default behavior). "
-                "Set FEMIC_STRICT_TIPSY_TIMESTAMP_MISMATCH=1 to escalate this to an error.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            return
+                if strict_timestamp_mismatch:
+                    raise RuntimeError(
+                        "Strict BatchTIPSY freshness is enabled and "
+                        f"{output_path} is older than {input_csv_path or excel_path}. "
+                        f"{detail} Regenerate the BatchTIPSY output from current "
+                        "accepted BTC inputs before rerunning."
+                    )
+                warnings.warn(
+                    detail
+                    + " Continuing with existing BatchTIPSY output (default behavior). "
+                    "Set FEMIC_STRICT_TIPSY_TIMESTAMP_MISMATCH=1 to escalate "
+                    "this to an error.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return
+            coherence_summary = coherence.summary
+        else:
+            coherence_summary = "no workbook coherence check was requested"
         raise RuntimeError(
             "Stale BatchTIPSY output detected: "
             f"{output_path} is older than {input_csv_path or excel_path}. "
-            f"Coherence check did not pass ({coherence.summary}). "
-            "Regenerate 04_output-tsaXX.csv from the current "
-            "03_input-tsaXX.csv handoff (and matching workbook), then rerun "
-            "FEMIC stage 01b/post-TIPSY. Future reruns can avoid repeated "
-            "manual prompts when CSV content is unchanged once a fingerprint "
-            "is recorded."
+            f"Coherence check did not pass ({coherence_summary}). "
+            "Regenerate the BatchTIPSY output from the current accepted BTC "
+            "input CSV handoff, then rerun FEMIC stage 01b/post-TIPSY. Future "
+            "reruns can avoid repeated manual prompts when CSV content is "
+            "unchanged once a fingerprint is recorded."
         )
 
 

--- a/src/femic/resources/legacy/01b_run-tsa.py
+++ b/src/femic/resources/legacy/01b_run-tsa.py
@@ -54,8 +54,6 @@ def run_tsa(
     from femic.pipeline.plots import tipsy_vdyp_ylim_for_tsa
     from femic.pipeline.tipsy import (
         parse_btc_tsr_transposed_output,
-        btc_msyt_input_csv_path,
-        tipsy_params_excel_path,
         tipsy_stage_output_paths,
         validate_tipsy_output_is_fresh,
         write_tipsy_output_input_fingerprint,
@@ -68,18 +66,24 @@ def run_tsa(
         )
 
     #############no need to change the code below
-    tipsy_excel = str(
-        tipsy_params_excel_path(
-            tsa=tsa,
-            tipsy_params_path_prefix=runtime_config.tipsy_params_path_prefix,
-        )
-    )
     tipsy_output_root = Path(runtime_config.tipsy_output_root)
+    artifact_code = (
+        f"tsa{str(tsa).zfill(2)}" if str(tsa).isdigit() else str(tsa).lower()
+    )
     tipsyout = str(
         tipsy_output_root
-        / runtime_config.tipsy_output_filename_template.format(tsa=tsa)
+        / runtime_config.tipsy_output_filename_template.format(
+            tsa=tsa,
+            artifact_code=artifact_code,
+        )
     )
-    tipsy_input_csv = str(btc_msyt_input_csv_path(tsa=tsa))
+    tipsy_input_csv = str(
+        tipsy_output_root
+        / runtime_config.tipsy_input_filename_template.format(
+            tsa=tsa,
+            artifact_code=artifact_code,
+        )
+    )
     outYield_path, outSPP_path = tipsy_stage_output_paths(
         tsa=tsa, output_root=runtime_config.tipsy_output_root
     )
@@ -91,7 +95,7 @@ def run_tsa(
         if not csv_path.is_file():
             raise FileNotFoundError(
                 "Missing canonical BatchTIPSY input CSV: "
-                f"{csv_path}. Regenerate 03_input-tsaXX.csv in Stage 01a before "
+                f"{csv_path}. Provide the accepted BTC input CSV before "
                 "running legacy 01b/post-TIPSY."
             )
 
@@ -152,7 +156,9 @@ def run_tsa(
                     record.get(f"planted_density{idx}"), errors="coerce"
                 )
                 row[f"SPP_{idx}"] = (
-                    str(spp).strip().upper() if pd.notna(spp) and str(spp).strip() else ""
+                    str(spp).strip().upper()
+                    if pd.notna(spp) and str(spp).strip()
+                    else ""
                 )
                 if planted_total > 0 and pd.notna(density) and float(density) > 0.0:
                     row[f"PCT_{idx}"] = (float(density) / planted_total) * 100.0
@@ -193,7 +199,7 @@ def run_tsa(
     requires_batch_tipsy = managed_curve_mode == "tipsy"
     if requires_batch_tipsy:
         validate_tipsy_output_is_fresh(
-            tipsy_input_excel_path=tipsy_excel,
+            tipsy_input_excel_path=None,
             btc_input_csv_path=tipsy_input_csv,
             tipsy_output_path=tipsyout,
             allow_stale=allow_stale_tipsy_output,

--- a/src/femic/workflows/legacy.py
+++ b/src/femic/workflows/legacy.py
@@ -619,7 +619,8 @@ def _vdyp_species_proportions_from_vdyp_layer_fallback(
     tsa: str,
     bundle_au_table: pd.DataFrame,
 ) -> dict[tuple[str, str], dict[str, float]]:
-    layer_path = data_root / f"vdyp_lyr-tsa{tsa}.feather"
+    artifact_code = _legacy_case_artifact_code(tsa)
+    layer_path = data_root / f"vdyp_lyr-{artifact_code}.feather"
     if not layer_path.exists():
         return {}
 
@@ -661,6 +662,13 @@ def _vdyp_species_proportions_from_vdyp_layer_fallback(
     return out
 
 
+def _legacy_case_artifact_code(value: str) -> str:
+    raw = str(value).strip().lower()
+    if raw.isdigit():
+        return f"tsa{raw.zfill(2)}"
+    return raw
+
+
 def run_post_tipsy_bundle(
     *,
     tsa_list: list[str],
@@ -676,6 +684,7 @@ def run_post_tipsy_bundle(
     managed_curve_truncate_at_culm: bool | None = None,
     managed_curve_max_age: int | None = None,
     yield_assumptions_path: Path | None = None,
+    tipsy_input_filename_template: str = "03_input-{artifact_code}.csv",
     tipsy_output_filename_template: str = "04_output-tsa{tsa}.csv",
 ) -> PostTipsyBundleResult:
     """Run downstream 01b + bundle assembly from cached TSA artifacts only."""
@@ -727,8 +736,9 @@ def run_post_tipsy_bundle(
     )
     with _temporary_env(managed_env_overrides):
         for tsa in normalized_tsa_list:
-            prep_path = data_root / f"vdyp_prep-tsa{tsa}.pkl"
-            smooth_path = data_root / f"vdyp_curves_smooth-tsa{tsa}.feather"
+            artifact_code = _legacy_case_artifact_code(tsa)
+            prep_path = data_root / f"vdyp_prep-{artifact_code}.pkl"
+            smooth_path = data_root / f"vdyp_curves_smooth-{artifact_code}.feather"
             if not smooth_path.exists():
                 raise FileNotFoundError(f"Missing smoothed VDYP curves: {smooth_path}")
 
@@ -784,6 +794,7 @@ def run_post_tipsy_bundle(
             runtime_config = build_legacy_01b_runtime_config(
                 tipsy_params_path_prefix=data_root / "tipsy_params_tsa",
                 tipsy_output_root=data_root,
+                tipsy_input_filename_template=tipsy_input_filename_template,
                 tipsy_output_filename_template=tipsy_output_filename_template,
             )
             message_fn(f"running 01b for tsa {tsa}")
@@ -796,8 +807,8 @@ def run_post_tipsy_bundle(
                     vdyp_curves_smooth=vdyp_curves_smooth,
                     runtime_config=runtime_config,
                 )
-            tipsy_curves_paths.append(data_root / f"tipsy_curves_tsa{tsa}.csv")
-            tipsy_sppcomp_paths.append(data_root / f"tipsy_sppcomp_tsa{tsa}.csv")
+            tipsy_curves_paths.append(data_root / f"tipsy_curves_{artifact_code}.csv")
+            tipsy_sppcomp_paths.append(data_root / f"tipsy_sppcomp_{artifact_code}.csv")
             tipsy_spp_path = tipsy_sppcomp_paths[-1]
             if tipsy_spp_path.exists():
                 tipsy_sppcomp[tsa] = pd.read_csv(tipsy_spp_path)
@@ -955,6 +966,7 @@ def run_post_tipsy_bundle_with_manifest(
     managed_curve_truncate_at_culm: bool | None = None,
     managed_curve_max_age: int | None = None,
     yield_assumptions_path: Path | None = None,
+    tipsy_input_filename_template: str = "03_input-{artifact_code}.csv",
     tipsy_output_filename_template: str = "04_output-tsa{tsa}.csv",
 ) -> PostTipsyBundleRunResult:
     """Run post-TIPSY downstream assembly and emit run-manifest metadata."""
@@ -999,6 +1011,7 @@ def run_post_tipsy_bundle_with_manifest(
             managed_curve_truncate_at_culm=managed_curve_truncate_at_culm,
             managed_curve_max_age=managed_curve_max_age,
             yield_assumptions_path=yield_assumptions_path,
+            tipsy_input_filename_template=tipsy_input_filename_template,
             tipsy_output_filename_template=tipsy_output_filename_template,
         )
     except Exception as exc:
@@ -1042,6 +1055,37 @@ def run_post_tipsy_bundle_with_manifest(
     return PostTipsyBundleRunResult(manifest_path=manifest_path, result=bundle_result)
 
 
+def _resolve_btc_handoff_paths(
+    *,
+    data_root: Path,
+    tsa: str,
+) -> tuple[Path, Path, Path, str, str]:
+    artifact_code = _legacy_case_artifact_code(tsa)
+    legacy_input = data_root / f"03_input-{artifact_code}.csv"
+    if legacy_input.exists():
+        return (
+            legacy_input,
+            data_root / f"04_output-{artifact_code}.csv",
+            data_root / f"04_error-{artifact_code}.csv",
+            "03_input-{artifact_code}.csv",
+            "04_output-{artifact_code}.csv",
+        )
+
+    case_input = data_root / f"03_input-{tsa}.csv"
+    if case_input.exists():
+        return (
+            case_input,
+            data_root / f"04_output-{tsa}.csv",
+            data_root / f"04_error-{tsa}.csv",
+            "03_input-{tsa}.csv",
+            "04_output-{tsa}.csv",
+        )
+
+    raise FileNotFoundError(
+        f"Missing BTC Stage 01a input CSV: {legacy_input} or {case_input}"
+    )
+
+
 def run_btc_and_post_tipsy_bundle_with_manifest(
     *,
     tsa_list: list[str],
@@ -1073,13 +1117,23 @@ def run_btc_and_post_tipsy_bundle_with_manifest(
     resolved_log_dir = Path(log_dir)
     resolved_data_root = Path(data_root)
     btc_results: list[BTCRunResult] = []
+    tipsy_input_template = "03_input-{artifact_code}.csv"
+    tipsy_output_template = "04_output-{artifact_code}.csv"
     for tsa in normalized_tsa_list:
-        input_csv = resolved_data_root / f"03_input-tsa{tsa}.csv"
-        if not input_csv.exists():
-            raise FileNotFoundError(f"Missing BTC Stage 01a input CSV: {input_csv}")
-        output_csv = resolved_data_root / f"04_output-tsa{tsa}.csv"
-        error_csv = resolved_data_root / f"04_error-tsa{tsa}.csv"
-        tsa_run_id = f"{effective_run_id}_tsa{tsa}"
+        artifact_code = _legacy_case_artifact_code(tsa)
+        (
+            input_csv,
+            output_csv,
+            error_csv,
+            input_template,
+            output_template,
+        ) = _resolve_btc_handoff_paths(
+            data_root=resolved_data_root,
+            tsa=tsa,
+        )
+        tipsy_input_template = input_template
+        tipsy_output_template = output_template
+        tsa_run_id = f"{effective_run_id}_{artifact_code}"
         result = run_btc_cli(
             input_csv=input_csv,
             mode=btc_mode,
@@ -1091,7 +1145,7 @@ def run_btc_and_post_tipsy_bundle_with_manifest(
             indicator_bank_names=indicator_bank_names,
             copy_install=True,
             scratch_root=(
-                (scratch_root / f"tsa{tsa}") if scratch_root is not None else None
+                (scratch_root / artifact_code) if scratch_root is not None else None
             ),
             log_dir=resolved_log_dir,
             run_id=tsa_run_id,
@@ -1121,7 +1175,8 @@ def run_btc_and_post_tipsy_bundle_with_manifest(
         managed_curve_truncate_at_culm=managed_curve_truncate_at_culm,
         managed_curve_max_age=managed_curve_max_age,
         yield_assumptions_path=yield_assumptions_path,
-        tipsy_output_filename_template="04_output-tsa{tsa}.csv",
+        tipsy_input_filename_template=tipsy_input_template,
+        tipsy_output_filename_template=tipsy_output_template,
     )
     return BTCPostTipsyRunResult(
         btc_results=btc_results,

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -673,6 +673,76 @@ def test_prep_glb_build_wires_stash_flags(
     assert captured["force_update_public_data_glb"] is True
 
 
+def test_prep_accepted_btc_handoff_passes_for_declared_files(tmp_path: Path) -> None:
+    instance_root = tmp_path / "instance"
+    for relative_path in (
+        "data/03_input-example.csv",
+        "data/04_output-example.csv",
+        "planning/example_treated_curves.csv",
+        "data/04_error-example.csv",
+        "planning/example_curve_diagnostics.csv",
+    ):
+        path = instance_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("ok\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli_main.app,
+        [
+            "prep",
+            "accepted-btc-handoff",
+            "--instance-root",
+            str(instance_root),
+            "--btc-input",
+            "data/03_input-example.csv",
+            "--btc-output",
+            "data/04_output-example.csv",
+            "--treated-curves",
+            "planning/example_treated_curves.csv",
+            "--btc-error",
+            "data/04_error-example.csv",
+            "--treated-curve-diagnostics",
+            "planning/example_curve_diagnostics.csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Accepted BTC handoff preflight passed" in result.stdout
+    assert "03_input-example.csv" in result.stdout
+
+
+def test_prep_accepted_btc_handoff_fails_for_missing_required_file(
+    tmp_path: Path,
+) -> None:
+    instance_root = tmp_path / "instance"
+    (instance_root / "data").mkdir(parents=True)
+    (instance_root / "data" / "04_output-example.csv").write_text(
+        "ok\n", encoding="utf-8"
+    )
+    treated_curves = instance_root / "planning" / "example_treated_curves.csv"
+    treated_curves.parent.mkdir(parents=True)
+    treated_curves.write_text("ok\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli_main.app,
+        [
+            "prep",
+            "accepted-btc-handoff",
+            "--instance-root",
+            str(instance_root),
+            "--btc-input",
+            "data/03_input-example.csv",
+            "--btc-output",
+            "data/04_output-example.csv",
+            "--treated-curves",
+            "planning/example_treated_curves.csv",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Missing BTC input" in result.stdout
+
+
 def test_preflight_checks_windows_requires_git_annex(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_freshforge_integration.py
+++ b/tests/test_freshforge_integration.py
@@ -95,6 +95,20 @@ def test_provider_metadata_serializes_deterministically() -> None:
                 ),
             },
             {
+                "id": "accepted_btc_handoff",
+                "inputs": ["geospatial_runtime"],
+                "outputs": ["btc_handoff"],
+                "parameters": [
+                    "instance_root",
+                    "btc_input",
+                    "btc_output",
+                    "treated_curves",
+                ],
+                "artifacts": ["btc_input", "btc_output", "treated_curves"],
+                "name": "Accepted BTC handoff",
+                "description": "Declare an accepted BTC input/output handoff preflight.",
+            },
+            {
                 "id": "btc_post_tipsy",
                 "inputs": ["btc_handoff"],
                 "outputs": ["model_input_bundle"],
@@ -469,6 +483,66 @@ def test_legacy_execute_node_shim_delegates_to_run_node() -> None:
 
     assert result.status is RunStatus.SUCCESS
     assert commands == [(sys.executable, "-m", "femic", "prep", "geospatial-preflight")]
+
+
+def test_accepted_btc_handoff_execution_constructs_preflight_command() -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus, WorkflowNode
+
+    commands: list[tuple[str, ...]] = []
+    provider = FemicFreshForgeProvider(command_runner=_successful_runner(commands))
+    node_type = next(
+        item
+        for item in provider.metadata().node_types
+        if item.id == "accepted_btc_handoff"
+    )
+    node = WorkflowNode(
+        id="accepted_btc_handoff",
+        provider="femic.accepted_btc_handoff",
+        parameters={
+            "instance_root": "external/femic-example-instance",
+            "btc_input": "data/03_input-example.csv",
+            "btc_output": "data/04_output-example.csv",
+            "treated_curves": "planning/example_treated_curves.csv",
+            "btc_error": "data/04_error-example.csv",
+            "treated_curve_diagnostics": "planning/example_curve_diagnostics.csv",
+            "tipsy_parameter_crosswalk": "planning/example_parameter_crosswalk.csv",
+            "curve_id_map": "planning/example_curve_id_map.csv",
+        },
+    )
+
+    result = provider.run_node(
+        node,
+        node_type,
+        context=RunContext(workflow_id="wf", workdir=Path(".")),
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert commands == [
+        (
+            sys.executable,
+            "-m",
+            "femic",
+            "prep",
+            "accepted-btc-handoff",
+            "--instance-root",
+            "external/femic-example-instance",
+            "--btc-input",
+            "data/03_input-example.csv",
+            "--btc-output",
+            "data/04_output-example.csv",
+            "--treated-curves",
+            "planning/example_treated_curves.csv",
+            "--btc-error",
+            "data/04_error-example.csv",
+            "--treated-curve-diagnostics",
+            "planning/example_curve_diagnostics.csv",
+            "--tipsy-parameter-crosswalk",
+            "planning/example_parameter_crosswalk.csv",
+            "--curve-id-map",
+            "planning/example_curve_id_map.csv",
+        )
+    ]
 
 
 def test_provider_execution_failure_returns_freshforge_diagnostic() -> None:

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -280,4 +280,5 @@ def test_build_legacy_01b_runtime_config_builds_output_paths() -> None:
     )
     assert runtime_cfg.tipsy_params_path_prefix == "./data/tipsy_params_tsa"
     assert runtime_cfg.tipsy_output_root == "./data"
+    assert runtime_cfg.tipsy_input_filename_template == "03_input-tsa{tsa}.csv"
     assert runtime_cfg.tipsy_output_filename_template == "04_output-tsa{tsa}.csv"

--- a/tests/test_siteprod.py
+++ b/tests/test_siteprod.py
@@ -33,6 +33,8 @@ def test_parse_arc_raster_rescue_layer_mappings() -> None:
 def test_siteprod_species_lookup_prefers_full_code_then_initial() -> None:
     assert siteprod_species_lookup("FDI") == "FD"
     assert siteprod_species_lookup("FAKE") == "FD"
+    assert siteprod_species_lookup("MB") == "AT"
+    assert siteprod_species_lookup("MV") == "AT"
     assert DEFAULT_SITEPROD_SPECIES_LOOKUP["FDI"] == "FD"
 
 

--- a/tests/test_tipsy.py
+++ b/tests/test_tipsy.py
@@ -2377,18 +2377,16 @@ def test_prepare_btc_runtime_tsr_preset_applies_industrial_logs_indicator_bank(
 
 
 def test_validate_tipsy_output_is_fresh_raises_on_stale_output(tmp_path: Path) -> None:
-    tipsy_input = tmp_path / "tipsy_params_tsa29.xlsx"
     input_csv = tmp_path / "03_input-tsa29.csv"
     tipsy_output = tmp_path / "04_output-tsa29.csv"
     tipsy_output.write_text("old\n", encoding="utf-8")
     input_csv.write_text("newer-csv\n", encoding="utf-8")
-    tipsy_input.write_text("new\n", encoding="utf-8")
-    older = min(tipsy_input.stat().st_mtime, input_csv.stat().st_mtime) - 10
+    older = input_csv.stat().st_mtime - 10
     os.utime(tipsy_output, (older, older))
 
     with pytest.raises(RuntimeError, match="Stale BatchTIPSY output detected"):
         validate_tipsy_output_is_fresh(
-            tipsy_input_excel_path=tipsy_input,
+            tipsy_input_excel_path=None,
             btc_input_csv_path=input_csv,
             tipsy_output_path=tipsy_output,
         )
@@ -2508,10 +2506,8 @@ def test_validate_tipsy_output_is_fresh_requires_csv_when_provided(
 def test_validate_tipsy_output_is_fresh_accepts_known_csv_fingerprint(
     tmp_path: Path,
 ) -> None:
-    tipsy_input = tmp_path / "tipsy_params_tsa29.xlsx"
     input_csv = tmp_path / "03_input-tsa29.csv"
     tipsy_output = tmp_path / "04_output-tsa29.csv"
-    tipsy_input.write_text("human-readable\n", encoding="utf-8")
     input_csv.write_text("same-csv-content\n", encoding="utf-8")
     tipsy_output.write_text("old-output\n", encoding="utf-8")
     older = input_csv.stat().st_mtime - 10
@@ -2521,7 +2517,7 @@ def test_validate_tipsy_output_is_fresh_accepts_known_csv_fingerprint(
     fingerprint.write_text(f"{compute_file_sha256(input_csv)}\n", encoding="utf-8")
 
     validate_tipsy_output_is_fresh(
-        tipsy_input_excel_path=tipsy_input,
+        tipsy_input_excel_path=None,
         btc_input_csv_path=input_csv,
         tipsy_output_path=tipsy_output,
     )
@@ -2530,19 +2526,20 @@ def test_validate_tipsy_output_is_fresh_accepts_known_csv_fingerprint(
 def test_validate_tipsy_output_is_fresh_raises_on_csv_fingerprint_mismatch(
     tmp_path: Path,
 ) -> None:
-    tipsy_input = tmp_path / "tipsy_params_tsa29.xlsx"
     input_csv = tmp_path / "03_input-tsa29.csv"
     tipsy_output = tmp_path / "04_output-tsa29.csv"
-    tipsy_input.write_text("human-readable\n", encoding="utf-8")
     input_csv.write_text("new-csv-content\n", encoding="utf-8")
     tipsy_output.write_text("some-output\n", encoding="utf-8")
 
     fingerprint = tipsy_output_input_fingerprint_path(tipsy_output_path=tipsy_output)
     fingerprint.write_text("badfingerprint\n", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="different 03_input-tsaXX.csv fingerprint"):
+    with pytest.raises(
+        RuntimeError,
+        match="different canonical BTC input CSV fingerprint",
+    ):
         validate_tipsy_output_is_fresh(
-            tipsy_input_excel_path=tipsy_input,
+            tipsy_input_excel_path=None,
             btc_input_csv_path=input_csv,
             tipsy_output_path=tipsy_output,
         )
@@ -2566,6 +2563,16 @@ def test_tipsy_stage_output_paths_uses_expected_naming(tmp_path: Path) -> None:
     curves_path, sppcomp_path = tipsy_stage_output_paths(tsa="08", output_root=tmp_path)
     assert curves_path == tmp_path / "tipsy_curves_tsa08.csv"
     assert sppcomp_path == tmp_path / "tipsy_sppcomp_tsa08.csv"
+
+
+def test_tipsy_stage_output_paths_preserves_non_numeric_case_code(
+    tmp_path: Path,
+) -> None:
+    curves_path, sppcomp_path = tipsy_stage_output_paths(
+        tsa="tfl6", output_root=tmp_path
+    )
+    assert curves_path == tmp_path / "tipsy_curves_tfl6.csv"
+    assert sppcomp_path == tmp_path / "tipsy_sppcomp_tfl6.csv"
 
 
 def test_tipsy_params_excel_path_uses_expected_naming(tmp_path: Path) -> None:

--- a/tests/test_workflows_post_tipsy.py
+++ b/tests/test_workflows_post_tipsy.py
@@ -1134,14 +1134,19 @@ def test_run_btc_and_post_tipsy_bundle_with_manifest_orchestrates_paths(
     assert Path(btc_calls[0]["input_csv"]) == data_root / "03_input-tsa29.csv"
     assert Path(btc_calls[0]["output_csv"]) == data_root / "04_output-tsa29.csv"
     assert Path(btc_calls[0]["error_csv"]) == data_root / "04_error-tsa29.csv"
+    assert btc_calls[0]["run_id"] == "btc_post_tipsy_test_tsa29"
     assert btc_calls[0]["report_preset_name"] == "tsr-unattended-default"
     assert btc_calls[0]["indicator_bank_names"] == ()
     assert btc_calls[0]["copy_install"] is True
     assert Path(btc_calls[0]["scratch_root"]) == tmp_path / "scratch" / "tsa29"
     assert len(post_tipsy_calls) == 1
     assert (
+        post_tipsy_calls[0]["tipsy_input_filename_template"]
+        == "03_input-{artifact_code}.csv"
+    )
+    assert (
         post_tipsy_calls[0]["tipsy_output_filename_template"]
-        == "04_output-tsa{tsa}.csv"
+        == "04_output-{artifact_code}.csv"
     )
     fingerprint_path = tipsy_output_input_fingerprint_path(
         tipsy_output_path=data_root / "04_output-tsa29.csv"
@@ -1149,6 +1154,99 @@ def test_run_btc_and_post_tipsy_bundle_with_manifest_orchestrates_paths(
     assert fingerprint_path.is_file()
     assert fingerprint_path.read_text(encoding="utf-8").strip() == compute_file_sha256(
         data_root / "03_input-tsa29.csv"
+    )
+
+
+def test_run_btc_and_post_tipsy_bundle_with_manifest_accepts_case_code_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    data_root = tmp_path / "data"
+    data_root.mkdir(parents=True, exist_ok=True)
+    (data_root / "03_input-tfl6.csv").write_text("feature_id\n1000\n", encoding="utf-8")
+
+    btc_calls: list[dict[str, object]] = []
+    post_tipsy_calls: list[dict[str, object]] = []
+
+    def _fake_run_btc_cli(**kwargs: object) -> BTCRunResult:
+        btc_calls.append(kwargs)
+        output_csv = Path(kwargs["output_csv"])
+        error_csv = Path(kwargs["error_csv"])
+        output_csv.write_text("feature_id,MVcon_0\n1000,0\n", encoding="utf-8")
+        error_csv.write_text("warnings,errors\n0,0\n", encoding="utf-8")
+        return BTCRunResult(
+            run_id=str(kwargs["run_id"]),
+            mode="TSR",
+            manifest_path=tmp_path / "logs" / "btc_manifest.json",
+            stdout_log_path=tmp_path / "logs" / "btc_stdout.log",
+            stderr_log_path=tmp_path / "logs" / "btc_stderr.log",
+            output_csv_path=output_csv,
+            error_csv_path=error_csv,
+            executable_path=tmp_path / "btc" / "TIPSYbtc.exe",
+            install_root=tmp_path / "btc",
+            working_dir=tmp_path / "scratch" / "work",
+            command=("btc.exe", "/TSR", "MSYT.csv"),
+            copied_install=True,
+            exit_code=0,
+            duration_sec=1.0,
+            report_template_path=tmp_path / "btc" / "TimberSupply.rpt",
+        )
+
+    def _fake_post_tipsy(**kwargs: object) -> PostTipsyBundleRunResult:
+        post_tipsy_calls.append(kwargs)
+        result = PostTipsyBundleResult(
+            tsa_list=["tfl6"],
+            au_rows=1,
+            curve_rows=2,
+            curve_points_rows=4,
+            tipsy_curves_paths=[data_root / "tipsy_curves_tfl6.csv"],
+            tipsy_sppcomp_paths=[data_root / "tipsy_sppcomp_tfl6.csv"],
+            au_table_path=data_root / "model_input_bundle" / "au_table.csv",
+            curve_table_path=data_root / "model_input_bundle" / "curve_table.csv",
+            curve_points_table_path=data_root
+            / "model_input_bundle"
+            / "curve_points_table.csv",
+        )
+        return PostTipsyBundleRunResult(
+            manifest_path=tmp_path / "logs" / "run_manifest.json",
+            result=result,
+        )
+
+    monkeypatch.setattr("femic.workflows.legacy.run_btc_cli", _fake_run_btc_cli)
+    monkeypatch.setattr(
+        "femic.workflows.legacy.run_post_tipsy_bundle_with_manifest",
+        _fake_post_tipsy,
+    )
+
+    run_btc_and_post_tipsy_bundle_with_manifest(
+        tsa_list=["tfl6"],
+        run_id="btc_post_tipsy_test",
+        log_dir=tmp_path / "logs",
+        repo_root=tmp_path,
+        data_root=data_root,
+        scratch_root=tmp_path / "scratch",
+        message_fn=lambda _msg: None,
+    )
+
+    assert Path(btc_calls[0]["input_csv"]) == data_root / "03_input-tfl6.csv"
+    assert Path(btc_calls[0]["output_csv"]) == data_root / "04_output-tfl6.csv"
+    assert Path(btc_calls[0]["error_csv"]) == data_root / "04_error-tfl6.csv"
+    assert btc_calls[0]["run_id"] == "btc_post_tipsy_test_tfl6"
+    assert Path(btc_calls[0]["scratch_root"]) == tmp_path / "scratch" / "tfl6"
+    assert (
+        post_tipsy_calls[0]["tipsy_input_filename_template"]
+        == "03_input-{artifact_code}.csv"
+    )
+    assert (
+        post_tipsy_calls[0]["tipsy_output_filename_template"]
+        == "04_output-{artifact_code}.csv"
+    )
+    fingerprint_path = tipsy_output_input_fingerprint_path(
+        tipsy_output_path=data_root / "04_output-tfl6.csv"
+    )
+    assert fingerprint_path.is_file()
+    assert fingerprint_path.read_text(encoding="utf-8").strip() == compute_file_sha256(
+        data_root / "03_input-tfl6.csv"
     )
 
 


### PR DESCRIPTION
﻿## Summary

Implements the parent FEMIC side of P105 for TFL6 executable FreshForge model-build acceptance.

## Changes

- Adds P105 planning and roadmap surfaces.
- Updates the parent TFL6 submodule pointer to the TFL6 Phase 19 branch commits.
- Records the P105 execution evidence and current blocker.
- Fixes the generic SiteProd species lookup exposed by TFL6 by mapping VRI maple species codes `M`, `MB`, and `MV` to the available `AT` SiteProd raster band, with focused test coverage.

## Validation

Passed:

- `python -m femic freshforge workflows list --json`
- `python -m femic freshforge workflows commands external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml`
- `freshforge validate external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml --json`
- `freshforge inspect external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml --json`
- `freshforge plan external/femic-tfl6-instance/workflows/freshforge/tfl6_model_build_workflow.yaml --json`
- `python -m femic instance validate-spec --instance-root external/femic-tfl6-instance --spec config/rebuild.spec.yaml`
- `python -m pytest tests/test_siteprod.py tests/test_freshforge_integration.py tests/test_freshforge_workflows.py`
- `python -m ruff check src/femic/pipeline/siteprod.py tests/test_siteprod.py`
- `python -m ruff check src tests`
- parent `sphinx-build -b html docs _build/html -W`
- TFL6 `sphinx-build -b html docs _build/html -W`

Blocked:

- Full `freshforge run` gets through `validate_case` and `geospatial_preflight`, then fails in `femic.compile_upstream` during legacy TIPSY parameter generation because no TFL6 config rule matches AU `1000` (`leading_species=HW`, `BEC=CWH`, `forest_type=1`).

This PR is draft because P105 executable acceptance is not complete until the TFL6 runtime/config blocker is resolved and the TFL6 PR is mergeable.

Refs #286 and UBC-FRESH/femic-tfl6-instance#162.
