### PR TITLE
P106: MKRF executable FreshForge model-build acceptance

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19622,3 +19622,14 @@
 - Recorded final closeout status for parent issue `#286`, parent PR `#287`,
   TFL6 issue `UBC-FRESH/femic-tfl6-instance#162`, and TFL6 PR
   `UBC-FRESH/femic-tfl6-instance#163`.
+
+## 2026-07-02 - Launched P106 MKRF executable FreshForge model-build acceptance
+
+- Opened parent issue `#288` and MKRF issue
+  `UBC-FRESH/femic-mkrf-instance#50`.
+- Created parent branch `feature/p106-mkrf-executable-model-build` and MKRF
+  branch `feature/freshforge-executable-model-build`.
+- Added P106 roadmap subtasks and planning notes for refreshing the MKRF
+  FreshForge adapter to released execution APIs, converting the MKRF workflow
+  to parent-checkout execution, validating discovery/planning, and running the
+  MKRF model-build workflow through Matrix Builder.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19633,3 +19633,14 @@
   FreshForge adapter to released execution APIs, converting the MKRF workflow
   to parent-checkout execution, validating discovery/planning, and running the
   MKRF model-build workflow through Matrix Builder.
+
+## 2026-07-02 - Refreshed MKRF FreshForge adapter for released execution APIs
+
+- Updated the instance-owned MKRF FreshForge adapter from the old
+  `execute_node(...)` / `ProviderExecutionResult` execution surface to the
+  released `run_node(...)` / `ProviderRunResult` contract.
+- Kept `execute_node(...)` as a compatibility shim while returning
+  deterministic command metadata, status, outputs, artifacts, and diagnostics
+  through the released provider run result shape.
+- Updated MKRF FreshForge tests to use `freshforge.execution.run_workflow` with
+  mocked command runners; the focused MKRF FreshForge test file passes.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19655,3 +19655,22 @@
 - Updated MKRF README, operator docs, and rebuild runbook to use P104 workflow
   discovery and the released `freshforge run --workdir runtime/freshforge
   --namespace mkrf/model-build --json` command shape.
+
+## 2026-07-02 - Completed P106 MKRF FreshForge executable acceptance run
+
+- Revalidated the MKRF model-build workflow from the parent checkout with
+  FreshForge discovery, rendered commands, validation, inspection, and planning.
+- Ran the executable MKRF FreshForge workflow through seven nodes:
+  `mkrf.build_au_inputs`, `mkrf.select_aus`, `mkrf.build_managed_au_inputs`,
+  `mkrf.build_managed_au_curves`, `mkrf.init_runtime_package`,
+  `femic.patchworks_preflight`, and `femic.matrix_build`.
+- Verified Matrix Builder returned `0` for `mkrf_freshforge_exec`, stderr ended
+  with `Done Matrix Builder.`, the expected ForestModel XML, fragments, and
+  tracks existed, and the compiled track row counts matched the accepted MKRF
+  surface.
+- Fixed the MKRF adapter execution boundary so instance-owned commands run with
+  `cwd` set to `external/femic-mkrf-instance` and receive `--instance-root .`;
+  this keeps tracked generated output metadata instance-relative even when the
+  workflow is launched from the parent checkout.
+- Confirmed the required MKRF `models` and `data/source` paths have no
+  `arbutus-s3` availability gaps.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19644,3 +19644,14 @@
   through the released provider run result shape.
 - Updated MKRF FreshForge tests to use `freshforge.execution.run_workflow` with
   mocked command runners; the focused MKRF FreshForge test file passes.
+
+## 2026-07-02 - Updated MKRF FreshForge workflow for parent-checkout execution
+
+- Updated the MKRF model-build workflow so all provider nodes use
+  `instance_root: external/femic-mkrf-instance` when run from the parent FEMIC
+  checkout.
+- Removed embedded rebuild-spec validation from the `femic.validate_case` node;
+  rebuild-spec validation is now documented as a separate pre-run FEMIC check.
+- Updated MKRF README, operator docs, and rebuild runbook to use P104 workflow
+  discovery and the released `freshforge run --workdir runtime/freshforge
+  --namespace mkrf/model-build --json` command shape.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19674,3 +19674,13 @@
   workflow is launched from the parent checkout.
 - Confirmed the required MKRF `models` and `data/source` paths have no
   `arbutus-s3` availability gaps.
+
+## 2026-07-02 - Closed out P106 MKRF executable FreshForge acceptance
+
+- Merged MKRF PR `UBC-FRESH/femic-mkrf-instance#51` and reconciled the parent
+  MKRF submodule pointer to merged MKRF `main` commit `dfcebec`.
+- Re-ran parent validation after pointer reconciliation: FreshForge
+  validate/inspect/plan, focused FreshForge workflow tests, Ruff, Sphinx with
+  warnings as errors, and the MKRF `arbutus-s3` audit all passed.
+- Marked P106 complete in the roadmap and prepared parent PR `#289` for final
+  merge after GitHub checks.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3196,7 +3196,7 @@ FreshForge workflows without knowing repo internals.
 
 ## Phase 105: TFL6 Executable FreshForge Model-Build Acceptance (`#286`)
 
-Status: active
+Status: complete
 
 Goal: promote the existing TFL6 model-build workflow from validation/planning
 into a parent-checkout `freshforge run` acceptance path through Patchworks
@@ -3246,9 +3246,62 @@ generic `femic.*` provider stages as the execution surface.
   - [x] Re-run parent validation after the pointer update.
   - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
+## Phase 106: MKRF Executable FreshForge Model-Build Acceptance (`#288`)
+
+Status: active
+
+Goal: promote the existing MKRF model-build workflow into the second
+parent-checkout executable FreshForge acceptance lane, proving that generic
+FEMIC provider stages work with the instance-owned `mkrf.*` provider namespace
+and released FreshForge execution APIs.
+
+- [x] P106.1 Create lifecycle and planning surfaces.
+  - [x] Open parent issue `#288`.
+  - [x] Open MKRF issue `UBC-FRESH/femic-mkrf-instance#50`.
+  - [x] Create parent branch `feature/p106-mkrf-executable-model-build`.
+  - [x] Create MKRF branch `feature/freshforge-executable-model-build`.
+  - [x] Add parent and MKRF planning notes.
+- [ ] P106.2 Refresh the MKRF FreshForge adapter for released FreshForge.
+  - [ ] Replace old `execute_node(...)` / `ProviderExecutionResult` usage with
+        `run_node(...)` / `ProviderRunResult`.
+  - [ ] Return deterministic command, return-code, stdout/stderr,
+        diagnostics, outputs, and JSON-safe artifact metadata.
+  - [ ] Update MKRF tests from old execution symbols to
+        `freshforge.execution.run_workflow`.
+- [ ] P106.3 Update the MKRF model-build workflow for parent-checkout
+      execution.
+  - [ ] Change workflow `instance_root` parameters from `.` to
+        `external/femic-mkrf-instance`.
+  - [ ] Keep run config, Patchworks config, source data, model package, bundle,
+        runtime, and artifact paths instance-relative.
+  - [ ] Remove `rebuild_spec` from the `validate_case` node and document
+        rebuild-spec validation as a separate pre-run check.
+- [ ] P106.4 Update MKRF docs/runbooks and discovery path.
+  - [ ] Route operators through `python -m femic freshforge workflows list`.
+  - [ ] Document `python -m femic freshforge workflows commands
+        external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`.
+  - [ ] Document released `freshforge run --workdir runtime/freshforge
+        --namespace mkrf/model-build --json` command shape.
+  - [ ] State that materialization should run first when the MKRF submodule is
+        thin or incomplete.
+- [ ] P106.5 Validate and run MKRF executable acceptance.
+  - [ ] Refresh local FreshForge to PyPI `freshforge==0.1.0a5`.
+  - [ ] Run discovery, rendered commands, validate, inspect, and plan from the
+        parent checkout.
+  - [ ] Run the MKRF FreshForge model-build workflow from the parent checkout.
+  - [ ] Inspect FreshForge records, MKRF runtime manifests, ForestModel XML,
+        fragments, tracks, Matrix Builder manifest, and MKRF Git status.
+  - [ ] Audit required MKRF model/source paths against `arbutus-s3`.
+- [ ] P106.6 Close out.
+  - [ ] Merge the MKRF PR first if workflow/docs/code changed.
+  - [ ] Update the parent MKRF submodule pointer.
+  - [ ] Re-run parent validation after pointer reconciliation.
+  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
 ### Detailed Next Steps Notes
 
 - Active detailed planning now lives in:
+  - `planning/phase106_mkrf_executable_model_build.md`
   - `planning/phase105_tfl6_executable_model_build.md`
   - `planning/phase104_freshforge_workflow_discovery.md`
   - `planning/phase103_tsa29_materialization_overlay.md`
@@ -3264,29 +3317,17 @@ generic `femic.*` provider stages as the execution surface.
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P105` executable acceptance has completed its parent-checkout run through
-    Matrix Builder and the TFL6 instance PR has been merged.
-    Parent FEMIC now points at the merged TFL6 `main` commit and is in final
-    PR/issue closeout.
-    The parent-checkout workflow discovery, command rendering, validate,
-    plan, rebuild-spec validation, focused FreshForge tests, Ruff, and Sphinx
-    checks pass. The first runtime blocker, missing SiteProd aliases for VRI
-    maple species codes, was fixed generically by mapping `M`, `MB`, and `MV`
-    to the available `AT` SiteProd band. The second blocker, legacy upstream
-    compile trying to regenerate production TIPSY parameters for AU `1000`, is
-    being resolved by switching the TFL6 executable workflow to a generic
-    accepted BTC handoff preflight before `femic.btc_post_tipsy`. This consumes
-    the reviewed TFL6 BTC input CSV, `04_output`, and treated-curve artifacts
-    instead of reopening production TIPSY rule reconstruction or spreadsheet
-    regeneration in P105. The successful run rebuilt the Patchworks export and
-    Matrix Builder tracks with `btc` sub-run id
-    `tfl6_freshforge_model_build_tfl6`; no invalid combined TSA/TFL
-    source/test/TFL6 matches remain after cleanup.
-  - `P105` / `#286` is active: TFL6 Phase 19 promotes the existing
-    TFL6-owned model-build graph into the first parent-checkout executable
-    FreshForge acceptance lane through Matrix Builder. The workflow remains
-    instance-owned under `external/femic-tfl6-instance`; FEMIC core keeps only
-    generic `femic.*` provider stages and P104 workflow discovery helpers.
+  - `P106` / `#288` is active: MKRF is the second parent-checkout executable
+    FreshForge model-build acceptance lane after TFL6. The first required
+    implementation move is refreshing the instance-owned `mkrf.*` provider
+    from the older branch-era `execute_node(...)` / `ProviderExecutionResult`
+    API to the released FreshForge `run_node(...)` / `ProviderRunResult`
+    contract before running the real MKRF model-build workflow.
+  - `P105` / `#286` is complete: TFL6 Phase 19 promoted the TFL6-owned
+    model-build graph into the first parent-checkout executable FreshForge
+    acceptance lane through Matrix Builder. The workflow remains instance-owned
+    under `external/femic-tfl6-instance`; FEMIC core keeps only generic
+    `femic.*` provider stages and P104 workflow discovery helpers.
   - `P104` / `#284` is complete: FEMIC now has generic FreshForge workflow
     discovery and user-facing CLI helpers so users can list checked-out
     workflow documents and print copy-paste `freshforge validate`, `inspect`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3274,8 +3274,12 @@ and released FreshForge execution APIs.
         `external/femic-mkrf-instance`.
   - [x] Keep run config, Patchworks config, source data, model package, bundle,
         runtime, and artifact paths instance-relative.
-  - [x] Remove `rebuild_spec` from the `validate_case` node and document
+  - [x] Remove embedded rebuild-spec validation from the workflow and document
         rebuild-spec validation as a separate pre-run check.
+  - [x] Start the executable graph at the MKRF-owned `mkrf.*` regeneration
+        nodes because older TSA-style case/geospatial preflight surfaces still
+        require legacy checkpoint files outside the accepted MKRF source
+        contract.
 - [x] P106.4 Update MKRF docs/runbooks and discovery path.
   - [x] Route operators through `python -m femic freshforge workflows list`.
   - [x] Document `python -m femic freshforge workflows commands
@@ -3284,19 +3288,35 @@ and released FreshForge execution APIs.
         --namespace mkrf/model-build --json` command shape.
   - [x] State that materialization should run first when the MKRF submodule is
         thin or incomplete.
-- [ ] P106.5 Validate and run MKRF executable acceptance.
-  - [ ] Refresh local FreshForge to PyPI `freshforge==0.1.0a5`.
-  - [ ] Run discovery, rendered commands, validate, inspect, and plan from the
+- [x] P106.5 Validate and run MKRF executable acceptance.
+  - [x] Refresh local FreshForge to PyPI `freshforge==0.1.0a5`.
+  - [x] Run discovery, rendered commands, validate, inspect, and plan from the
         parent checkout.
-  - [ ] Run the MKRF FreshForge model-build workflow from the parent checkout.
-  - [ ] Inspect FreshForge records, MKRF runtime manifests, ForestModel XML,
+  - [x] Run the MKRF FreshForge model-build workflow from the parent checkout.
+  - [x] Inspect FreshForge records, MKRF runtime manifests, ForestModel XML,
         fragments, tracks, Matrix Builder manifest, and MKRF Git status.
-  - [ ] Audit required MKRF model/source paths against `arbutus-s3`.
+  - [x] Audit required MKRF model/source paths against `arbutus-s3`.
 - [ ] P106.6 Close out.
   - [ ] Merge the MKRF PR first if workflow/docs/code changed.
   - [ ] Update the parent MKRF submodule pointer.
   - [ ] Re-run parent validation after pointer reconciliation.
   - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+
+P106.5 executable acceptance passed from the parent FEMIC checkout. FreshForge
+discovery, rendered commands, validation, inspection, and planning all resolved
+the MKRF workflow. The executable run completed seven nodes in order:
+`mkrf.build_au_inputs`, `mkrf.select_aus`, `mkrf.build_managed_au_inputs`,
+`mkrf.build_managed_au_curves`, `mkrf.init_runtime_package`,
+`femic.patchworks_preflight`, and `femic.matrix_build`. The Matrix Builder
+manifest for `mkrf_freshforge_exec` reported `returncode=0`, stderr ended with
+`Done Matrix Builder.`, `forestmodel.xml` and `fragments.dbf` were present, and
+compiled tracks contained 98,413 `features.csv` rows, 62 `protoaccounts.csv`
+rows, 62 `accounts.csv` rows, 2,684,869 `curves.csv` rows, and 140,196
+`products.csv` rows. The `arbutus-s3` audit over required `models` and
+`data/source` paths returned no gaps. A first parent-checkout run exposed that
+MKRF tracked output metadata must remain instance-relative; the MKRF adapter now
+runs instance-owned commands with `cwd` set to the instance root and
+`--instance-root .`, keeping tracked generated outputs stable.
 
 ### Detailed Next Steps Notes
 
@@ -3318,11 +3338,11 @@ and released FreshForge execution APIs.
   - `planning/roadmap_notes_archive.md`
 - Current edge:
   - `P106` / `#288` is active: MKRF is the second parent-checkout executable
-    FreshForge model-build acceptance lane after TFL6. The first required
-    implementation move is refreshing the instance-owned `mkrf.*` provider
-    from the older branch-era `execute_node(...)` / `ProviderExecutionResult`
-    API to the released FreshForge `run_node(...)` / `ProviderRunResult`
-    contract before running the real MKRF model-build workflow.
+    FreshForge model-build acceptance lane after TFL6. P106.5 executable
+    acceptance has passed through Patchworks Matrix Builder; the remaining
+    tranche is P106.6 closeout: push/open the MKRF PR, update the parent
+    submodule pointer, rerun parent validation, and synchronize issue/PR
+    comments before merge.
   - `P105` / `#286` is complete: TFL6 Phase 19 promoted the TFL6-owned
     model-build graph into the first parent-checkout executable FreshForge
     acceptance lane through Matrix Builder. The workflow remains instance-owned

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3248,7 +3248,7 @@ generic `femic.*` provider stages as the execution surface.
 
 ## Phase 106: MKRF Executable FreshForge Model-Build Acceptance (`#288`)
 
-Status: active
+Status: complete
 
 Goal: promote the existing MKRF model-build workflow into the second
 parent-checkout executable FreshForge acceptance lane, proving that generic
@@ -3296,11 +3296,11 @@ and released FreshForge execution APIs.
   - [x] Inspect FreshForge records, MKRF runtime manifests, ForestModel XML,
         fragments, tracks, Matrix Builder manifest, and MKRF Git status.
   - [x] Audit required MKRF model/source paths against `arbutus-s3`.
-- [ ] P106.6 Close out.
-  - [ ] Merge the MKRF PR first if workflow/docs/code changed.
-  - [ ] Update the parent MKRF submodule pointer.
-  - [ ] Re-run parent validation after pointer reconciliation.
-  - [ ] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
+- [x] P106.6 Close out.
+  - [x] Merge the MKRF PR first if workflow/docs/code changed.
+  - [x] Update the parent MKRF submodule pointer.
+  - [x] Re-run parent validation after pointer reconciliation.
+  - [x] Update `CHANGE_LOG.md`, issue comments, and PR closeout records.
 
 P106.5 executable acceptance passed from the parent FEMIC checkout. FreshForge
 discovery, rendered commands, validation, inspection, and planning all resolved
@@ -3317,6 +3317,13 @@ rows, 62 `accounts.csv` rows, 2,684,869 `curves.csv` rows, and 140,196
 MKRF tracked output metadata must remain instance-relative; the MKRF adapter now
 runs instance-owned commands with `cwd` set to the instance root and
 `--instance-root .`, keeping tracked generated outputs stable.
+
+P106.6 closeout reconciled the parent MKRF submodule pointer to merged MKRF
+`main` commit `dfcebec`. Parent post-merge validation passed with FreshForge
+validate/inspect/plan, focused FreshForge workflow tests, Ruff, Sphinx with
+warnings as errors, and the MKRF `arbutus-s3` model/source availability audit.
+Parent PR `#289` carried the merged-pointer update after MKRF PR
+`UBC-FRESH/femic-mkrf-instance#51` merged.
 
 ### Detailed Next Steps Notes
 
@@ -3337,12 +3344,11 @@ runs instance-owned commands with `cwd` set to the instance root and
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P106` / `#288` is active: MKRF is the second parent-checkout executable
-    FreshForge model-build acceptance lane after TFL6. P106.5 executable
-    acceptance has passed through Patchworks Matrix Builder; the remaining
-    tranche is P106.6 closeout: push/open the MKRF PR, update the parent
-    submodule pointer, rerun parent validation, and synchronize issue/PR
-    comments before merge.
+  - `P106` / `#288` is complete pending final parent PR merge/issue closure:
+    MKRF is the second parent-checkout executable FreshForge model-build
+    acceptance lane after TFL6. The MKRF PR merged, the parent submodule
+    pointer was reconciled to merged MKRF `main`, and post-merge parent
+    validation passed.
   - `P105` / `#286` is complete: TFL6 Phase 19 promoted the TFL6-owned
     model-build graph into the first parent-checkout executable FreshForge
     acceptance lane through Matrix Builder. The workflow remains instance-owned

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3261,12 +3261,12 @@ and released FreshForge execution APIs.
   - [x] Create parent branch `feature/p106-mkrf-executable-model-build`.
   - [x] Create MKRF branch `feature/freshforge-executable-model-build`.
   - [x] Add parent and MKRF planning notes.
-- [ ] P106.2 Refresh the MKRF FreshForge adapter for released FreshForge.
-  - [ ] Replace old `execute_node(...)` / `ProviderExecutionResult` usage with
+- [x] P106.2 Refresh the MKRF FreshForge adapter for released FreshForge.
+  - [x] Replace old `execute_node(...)` / `ProviderExecutionResult` usage with
         `run_node(...)` / `ProviderRunResult`.
-  - [ ] Return deterministic command, return-code, stdout/stderr,
+  - [x] Return deterministic command, return-code, stdout/stderr,
         diagnostics, outputs, and JSON-safe artifact metadata.
-  - [ ] Update MKRF tests from old execution symbols to
+  - [x] Update MKRF tests from old execution symbols to
         `freshforge.execution.run_workflow`.
 - [ ] P106.3 Update the MKRF model-build workflow for parent-checkout
       execution.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3268,21 +3268,21 @@ and released FreshForge execution APIs.
         diagnostics, outputs, and JSON-safe artifact metadata.
   - [x] Update MKRF tests from old execution symbols to
         `freshforge.execution.run_workflow`.
-- [ ] P106.3 Update the MKRF model-build workflow for parent-checkout
+- [x] P106.3 Update the MKRF model-build workflow for parent-checkout
       execution.
-  - [ ] Change workflow `instance_root` parameters from `.` to
+  - [x] Change workflow `instance_root` parameters from `.` to
         `external/femic-mkrf-instance`.
-  - [ ] Keep run config, Patchworks config, source data, model package, bundle,
+  - [x] Keep run config, Patchworks config, source data, model package, bundle,
         runtime, and artifact paths instance-relative.
-  - [ ] Remove `rebuild_spec` from the `validate_case` node and document
+  - [x] Remove `rebuild_spec` from the `validate_case` node and document
         rebuild-spec validation as a separate pre-run check.
-- [ ] P106.4 Update MKRF docs/runbooks and discovery path.
-  - [ ] Route operators through `python -m femic freshforge workflows list`.
-  - [ ] Document `python -m femic freshforge workflows commands
+- [x] P106.4 Update MKRF docs/runbooks and discovery path.
+  - [x] Route operators through `python -m femic freshforge workflows list`.
+  - [x] Document `python -m femic freshforge workflows commands
         external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`.
-  - [ ] Document released `freshforge run --workdir runtime/freshforge
+  - [x] Document released `freshforge run --workdir runtime/freshforge
         --namespace mkrf/model-build --json` command shape.
-  - [ ] State that materialization should run first when the MKRF submodule is
+  - [x] State that materialization should run first when the MKRF submodule is
         thin or incomplete.
 - [ ] P106.5 Validate and run MKRF executable acceptance.
   - [ ] Refresh local FreshForge to PyPI `freshforge==0.1.0a5`.

--- a/planning/phase106_mkrf_executable_model_build.md
+++ b/planning/phase106_mkrf_executable_model_build.md
@@ -1,0 +1,38 @@
+# P106 MKRF Executable FreshForge Model-Build Acceptance
+
+P106 promotes the MKRF model-build workflow into the second executable
+FreshForge acceptance lane after TFL6. The workflow runs from the parent FEMIC
+checkout and uses generic `femic.*` provider stages plus the instance-owned
+`mkrf.*` provider namespace.
+
+The first implementation requirement is compatibility with released FreshForge.
+The MKRF adapter still carries the older branch-era execution surface
+(`execute_node`, `ProviderExecutionResult`, and tests importing
+`ExecutionContext` / `execute_workflow`). P106 refreshes that adapter to
+`run_node`, `ProviderRunResult`, `RunStatus`, and
+`freshforge.execution.run_workflow`.
+
+The MKRF workflow remains owned by the instance repository:
+`external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`.
+All `instance_root` parameters should be parent-checkout paths:
+`external/femic-mkrf-instance`. Workflow-owned run config, source data,
+Patchworks config, model package, runtime, and artifact paths remain
+instance-relative.
+
+`rebuild_spec` validation is not embedded in the first FreshForge node.
+Operators should run the separate pre-run check:
+
+```powershell
+python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml
+```
+
+Acceptance requires validation, planning, and a real `freshforge run` from the
+parent checkout:
+
+```powershell
+freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json
+```
+
+Before closeout, inspect the FreshForge record, MKRF runtime manifests,
+ForestModel XML, fragments, tracks, Matrix Builder manifest, MKRF Git status,
+and the `arbutus-s3` availability audit for required model/source paths.


### PR DESCRIPTION
## Summary

Promotes MKRF into the second executable FreshForge model-build acceptance lane after TFL6.

This parent PR:

- records P106 roadmap and changelog status;
- points the MKRF submodule at the executable FreshForge model-build branch;
- records the accepted parent-checkout run through Matrix Builder;
- keeps FEMIC core unchanged except for planning/status surfaces already committed in this branch.

Depends on MKRF PR UBC-FRESH/femic-mkrf-instance#51.

Closes #288 after the MKRF PR is merged and the parent submodule pointer is reconciled to the merged MKRF `main` commit.

## Validation

Parent validation completed:

- `python -m femic freshforge workflows list --json`
- `python -m femic freshforge workflows commands external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`
- `python -m freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `python -m freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `python -m freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `python -m pytest tests/test_freshforge_integration.py tests/test_freshforge_workflows.py -q`
- `python -m ruff check src tests`

Runtime acceptance completed from the parent checkout:

- `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json`
- Matrix Builder manifest for `mkrf_freshforge_exec` reported `returncode=0`;
- Matrix Builder stderr ended with `Done Matrix Builder.`;
- `forestmodel.xml`, `fragments.dbf`, and compiled tracks exist;
- compiled tracks contain 98,413 `features.csv` rows, 62 `protoaccounts.csv` rows, 62 `accounts.csv` rows, 2,684,869 `curves.csv` rows, and 140,196 `products.csv` rows;
- `git -C external/femic-mkrf-instance annex find --not --in arbutus-s3 -- models data/source` returned no gaps.

Known unrelated local state:

- `external/femic-public-data` is dirty in this workspace and intentionally untouched.
