### PR TITLE
P106 post-merge roadmap hygiene

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19684,3 +19684,13 @@
   warnings as errors, and the MKRF `arbutus-s3` audit all passed.
 - Marked P106 complete in the roadmap and prepared parent PR `#289` for final
   merge after GitHub checks.
+
+## 2026-07-02 - Reconciled P106 post-merge planning state
+
+- Confirmed parent PR `#289` merged to `main` and parent issue `#288` is
+  closed after the MKRF executable FreshForge acceptance lane.
+- Recorded that the live MKRF docs root and parent MKRF sample-model docs page
+  returned HTTP 200 after merge.
+- Preserved the already-posted GitHub caveat that the MKRF Pages deploy job hit
+  a platform-side failure even though the MKRF docs build succeeded; this does
+  not block P106 closure.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3344,11 +3344,15 @@ Parent PR `#289` carried the merged-pointer update after MKRF PR
   - `planning/phase68_tsa29_comparison_docs_notes.md`
   - `planning/roadmap_notes_archive.md`
 - Current edge:
-  - `P106` / `#288` is complete pending final parent PR merge/issue closure:
-    MKRF is the second parent-checkout executable FreshForge model-build
-    acceptance lane after TFL6. The MKRF PR merged, the parent submodule
-    pointer was reconciled to merged MKRF `main`, and post-merge parent
-    validation passed.
+  - `P106` / `#288` is complete and merged: parent PR `#289`, parent issue
+    `#288`, MKRF PR `UBC-FRESH/femic-mkrf-instance#51`, and MKRF issue
+    `UBC-FRESH/femic-mkrf-instance#50` are closed. MKRF is the second
+    parent-checkout executable FreshForge model-build acceptance lane after
+    TFL6. The parent submodule pointer was reconciled to merged MKRF `main`
+    commit `dfcebec`, and post-merge parent validation passed.
+  - Next FreshForge workflow work can start from the completed P104-P106 user
+    entry, materialization, and executable model-build surfaces rather than
+    reopening P106.
   - `P105` / `#286` is complete: TFL6 Phase 19 promoted the TFL6-owned
     model-build graph into the first parent-checkout executable FreshForge
     acceptance lane through Matrix Builder. The workflow remains instance-owned


### PR DESCRIPTION
## Summary

- reconciles the P106 roadmap current-edge note now that PR #289 and issue #288 are merged/closed
- records the final P106 post-merge docs status in CHANGE_LOG.md
- preserves the already-documented MKRF GitHub Pages deploy caveat without reopening P106

## Validation

- `rg -n "P106.*pending|#288|#289|dfcebec|P107|Current edge" ROADMAP.md CHANGE_LOG.md`
- `git diff --check`

Only ROADMAP.md and CHANGE_LOG.md changed, so no package or Sphinx rebuild was needed.
